### PR TITLE
feat(desktop): add slash suggestions in chat input for commands and skills

### DIFF
--- a/desktop/app/components/MessageComposer.tsx
+++ b/desktop/app/components/MessageComposer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { Send, RotateCcw, Crown, Moon, CheckCircle2, XCircle } from "lucide-react";
@@ -8,6 +8,11 @@ import type { MainAgentId } from "@/lib/useAgentChatLog";
 const MAX_MESSAGE_LENGTH = 4000;
 
 type SendStatus = "idle" | "sending" | "sent" | "failed";
+type SlashSuggestion = {
+  label: string;
+  value: string;
+  source: "command" | "skill";
+};
 
 interface MessageComposerProps {
   activeAgent: MainAgentId;
@@ -34,6 +39,10 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   const [lastContent, setLastContent] = useState("");
   const [lastAgent, setLastAgent] = useState<MainAgentId>(activeAgent);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [allSlashSuggestions, setAllSlashSuggestions] = useState<SlashSuggestion[]>([]);
+  const [showSlashSuggestions, setShowSlashSuggestions] = useState(false);
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { label, Icon, placeholder } = AGENT_CONFIG[activeAgent];
   const charCount = content.length;
@@ -79,12 +88,118 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   const handleRetry = () => doSend(lastAgent, lastContent);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (showSlashSuggestions) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedSuggestionIndex((prev) =>
+          filteredSlashSuggestions.length === 0
+            ? 0
+            : (prev + 1) % filteredSlashSuggestions.length
+        );
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedSuggestionIndex((prev) =>
+          filteredSlashSuggestions.length === 0
+            ? 0
+            : (prev - 1 + filteredSlashSuggestions.length) % filteredSlashSuggestions.length
+        );
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        const selected = filteredSlashSuggestions[selectedSuggestionIndex];
+        if (selected) {
+          e.preventDefault();
+          applySlashSuggestion(selected.value);
+          return;
+        }
+      }
+      if (e.key === "Escape") {
+        setShowSlashSuggestions(false);
+      }
+    }
+
     // Ctrl+Enter or Cmd+Enter to send
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && canSend) {
       e.preventDefault();
       handleSend();
     }
   };
+
+  const activeSlashToken = useMemo(() => {
+    const cursor = textareaRef.current?.selectionStart ?? content.length;
+    const left = content.slice(0, cursor);
+    const slashMatch = left.match(/(?:^|\s)\/(\S*)$/);
+    return slashMatch?.[1] ?? null;
+  }, [content]);
+
+  const filteredSlashSuggestions = useMemo(() => {
+    if (activeSlashToken === null) {
+      return [];
+    }
+
+    const keyword = activeSlashToken.toLowerCase();
+    return allSlashSuggestions.filter(
+      (item) => item.label.toLowerCase().includes(keyword) || item.value.toLowerCase().includes(keyword)
+    );
+  }, [activeSlashToken, allSlashSuggestions]);
+
+  const applySlashSuggestion = (nextValue: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      setContent((prev) => `${prev} ${nextValue}`.trimStart());
+      setShowSlashSuggestions(false);
+      return;
+    }
+
+    const cursor = textarea.selectionStart;
+    const left = content.slice(0, cursor);
+    const right = content.slice(cursor);
+    const replacedLeft = left.replace(/(?:^|\s)\/\S*$/, (match) => {
+      const leadingSpace = match.startsWith(" ") ? " " : "";
+      return `${leadingSpace}${nextValue}`;
+    });
+
+    const nextContent = `${replacedLeft}${right}${right.startsWith(" ") || right.length === 0 ? "" : " "}`;
+    setContent(nextContent);
+    setShowSlashSuggestions(false);
+
+    requestAnimationFrame(() => {
+      const nextCursor = replacedLeft.length;
+      textarea.focus();
+      textarea.setSelectionRange(nextCursor, nextCursor);
+    });
+  };
+
+  useEffect(() => {
+    let mounted = true;
+    const loadSlashSuggestions = async () => {
+      try {
+        const res = await fetch("/api/slash-suggestions");
+        if (!res.ok) {
+          return;
+        }
+        const data = await res.json();
+        if (mounted && Array.isArray(data?.suggestions)) {
+          setAllSlashSuggestions(data.suggestions);
+        }
+      } catch {
+        // Non-blocking helper endpoint
+      }
+    };
+
+    loadSlashSuggestions();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const shouldShow = activeSlashToken !== null && filteredSlashSuggestions.length > 0;
+    setShowSlashSuggestions(shouldShow);
+    setSelectedSuggestionIndex(0);
+  }, [activeSlashToken, filteredSlashSuggestions.length]);
 
   return (
     <div className="border-t border-border/40 pt-3 space-y-2">
@@ -128,6 +243,7 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
       <div className="flex gap-2">
         <div className="relative flex-1">
           <textarea
+            ref={textareaRef}
             value={content}
             onChange={(e) => setContent(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -140,6 +256,27 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
               isOverLimit ? "border-red-500/60" : "border-border/50"
             )}
           />
+          {showSlashSuggestions && (
+            <div className="absolute left-0 right-0 bottom-[calc(100%+8px)] max-h-40 overflow-y-auto rounded-md border border-border/60 bg-background/95 shadow-lg backdrop-blur-sm z-20">
+              {filteredSlashSuggestions.map((item, idx) => (
+                <button
+                  key={`${item.source}-${item.value}`}
+                  type="button"
+                  className={cn(
+                    "w-full px-3 py-2 text-left text-xs hover:bg-accent/70",
+                    idx === selectedSuggestionIndex && "bg-accent"
+                  )}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    applySlashSuggestion(item.value);
+                  }}
+                >
+                  <span className="font-medium text-foreground">{item.value}</span>
+                  <span className="ml-2 text-muted-foreground">({item.label})</span>
+                </button>
+              ))}
+            </div>
+          )}
           {/* Character count */}
           <span
             className={cn(

--- a/desktop/app/routes.ts
+++ b/desktop/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   route("api/health", "routes/api.health.ts"),
   route("api/projects", "routes/api.projects.ts"),
   route("api/projects/active", "routes/api.projects.active.ts"),
+  route("api/slash-suggestions", "routes/api.slash-suggestions.ts"),
   // UI routes
   layout("routes/_layout.tsx", [
     index("routes/index.tsx"),

--- a/desktop/app/routes/api.slash-suggestions.ts
+++ b/desktop/app/routes/api.slash-suggestions.ts
@@ -1,0 +1,57 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+interface SlashSuggestion {
+  label: string;
+  value: string;
+  source: "command" | "skill";
+}
+
+function collectDirectoryEntries(root: string, relativeDir: string): string[] {
+  const targetDir = join(root, relativeDir);
+  if (!existsSync(targetDir)) {
+    return [];
+  }
+
+  return readdirSync(targetDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() || entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => !name.startsWith("."))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * GET /api/slash-suggestions
+ * Returns candidates from .opencode/command(.s) and .opencode/opencode skills folders.
+ */
+export async function loader() {
+  try {
+    const root = getProjectRoot();
+
+    const commandEntries = [".opencode/command", ".opencode/commands", "opencode/command", "opencode/commands"]
+      .flatMap((path) => collectDirectoryEntries(root, path));
+
+    const skillEntries = [".opencode/skills", "opencode/skills"]
+      .flatMap((path) => collectDirectoryEntries(root, path));
+
+    const commandSuggestions: SlashSuggestion[] = Array.from(new Set(commandEntries)).map((entry) => ({
+      label: `command: ${entry}`,
+      value: `/command ${entry}`,
+      source: "command",
+    }));
+
+    const skillSuggestions: SlashSuggestion[] = Array.from(new Set(skillEntries)).map((entry) => ({
+      label: `skill: ${entry}`,
+      value: `/skill ${entry}`,
+      source: "skill",
+    }));
+
+    return Response.json({
+      suggestions: [...commandSuggestions, ...skillSuggestions],
+    });
+  } catch (e) {
+    return Response.json({ error: String(e) }, { status: 500 });
+  }
+}
+

--- a/desktop/app/routes/api.slash-suggestions.ts
+++ b/desktop/app/routes/api.slash-suggestions.ts
@@ -35,15 +35,18 @@ export async function loader() {
     const skillEntries = [".opencode/skills", "opencode/skills"]
       .flatMap((path) => collectDirectoryEntries(root, path));
 
-    const commandSuggestions: SlashSuggestion[] = Array.from(new Set(commandEntries)).map((entry) => ({
-      label: `command: ${entry}`,
-      value: `/command ${entry}`,
-      source: "command",
-    }));
+    const commandSuggestions: SlashSuggestion[] = Array.from(new Set(commandEntries)).map((entry) => {
+      const name = entry.replace(/\.md$/, "");
+      return {
+        label: `command: ${name}`,
+        value: `/${name}`,
+        source: "command",
+      };
+    });
 
     const skillSuggestions: SlashSuggestion[] = Array.from(new Set(skillEntries)).map((entry) => ({
       label: `skill: ${entry}`,
-      value: `/skill ${entry}`,
+      value: `/${entry}`,
       source: "skill",
     }));
 


### PR DESCRIPTION
### Motivation
- Provide a quick-access UX in the chat input so typing `/` surfaces available `.opencode/command(s)` and `.opencode/skills` entries as selectable suggestions. 

### Description
- Add a new helper API `GET /api/slash-suggestions` that collects non-dot entries from `.opencode/command`, `.opencode/commands`, `.opencode/skills` and fallback `opencode/*` paths and returns candidates in `/command <name>` and `/skill <name>` form (`desktop/app/routes/api.slash-suggestions.ts`).
- Wire the endpoint into the app router by registering `api/slash-suggestions` in `desktop/app/routes.ts`.
- Enhance the chat `MessageComposer` to fetch suggestions, detect the active `/...` token, show a dropdown, support keyboard navigation (`ArrowUp`/`ArrowDown`/`Enter`/`Escape`) and mouse selection, and replace/insert the selected suggestion into the textarea while preserving cursor focus (`desktop/app/components/MessageComposer.tsx`).

### Testing
- Ran `npm run -C desktop typecheck` which executed `react-router typegen && tsc` and completed successfully. 
- Attempted `cd desktop && npx tsc --noEmit` which failed due to missing/generated ambient route types in the local dev environment. 
- Started the dev server (`npm run -C desktop dev`) and executed a Playwright script that navigated to `/chat`, typed `/`, and captured a screenshot showing the suggestions UI, which produced an artifact confirming the feature visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac4ec7ed0832db38b8d7b4e3b9a14)