### PR TITLE
Refactor model switch to label-only config values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ dashboard.md
 agent-chat-monitor.md
 config/*
 !config/models.yaml
+!config/model_switch_keywords.yaml
 logs/
 
 # Project details (contains client/confidential info)

--- a/.opencode/skills/switch-model/SKILL.md
+++ b/.opencode/skills/switch-model/SKILL.md
@@ -44,6 +44,8 @@ Dynamically switch an FF15 agent's LLM model using `scripts/switch.sh`.
 
 Check all available models: `opencode models`
 
+Desktop/Web UI model list source: `config/model_switch_keywords.yaml`
+
 ## Prerequisites
 
 - **Agent must be idle** — switching during active work may cause context loss

--- a/config/model_switch_keywords.yaml
+++ b/config/model_switch_keywords.yaml
@@ -1,0 +1,10 @@
+# Model options for temporary runtime switching via .opencode/skills/switch-model/scripts/switch.sh
+# `label`: display value for UI and /models search input
+models:
+  - label: GPT-5-mini
+  - label: Claude Sonnet 4.5
+  - label: Claude Opus 4.6
+  - label: Claude Haiku 4.5
+  - label: Gemini models
+  - label: GPT-5.2-codex
+  - label: Grok Code Fast 1

--- a/desktop/app/components/MessageComposer.tsx
+++ b/desktop/app/components/MessageComposer.tsx
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Send, RotateCcw, Crown, Moon, CheckCircle2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,8 @@ import type { MainAgentId } from "@/lib/useAgentChatLog";
 const MAX_MESSAGE_LENGTH = 4000;
 
 type SendStatus = "idle" | "sending" | "sent" | "failed";
+type ModelSwitchAgent = "noctis" | "lunafreya" | "ignis" | "gladiolus" | "prompto";
+
 
 interface MessageComposerProps {
   activeAgent: MainAgentId;
@@ -28,6 +31,14 @@ const AGENT_CONFIG: Record<MainAgentId, { label: string; Icon: React.ElementType
   },
 };
 
+const MODEL_SWITCH_AGENTS: Array<{ value: ModelSwitchAgent; label: string }> = [
+  { value: "noctis", label: "Noctis" },
+  { value: "lunafreya", label: "Lunafreya" },
+  { value: "ignis", label: "Ignis" },
+  { value: "gladiolus", label: "Gladiolus" },
+  { value: "prompto", label: "Prompto" },
+];
+
 export default function MessageComposer({ activeAgent, isTauri, onSent }: MessageComposerProps) {
   const [content, setContent] = useState("");
   const [status, setStatus] = useState<SendStatus>("idle");
@@ -35,11 +46,64 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   const [lastAgent, setLastAgent] = useState<MainAgentId>(activeAgent);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [modelSwitchAgent, setModelSwitchAgent] = useState<ModelSwitchAgent>("noctis");
+  const [modelLabel, setModelLabel] = useState("");
+
   const { label, Icon, placeholder } = AGENT_CONFIG[activeAgent];
   const charCount = content.length;
   const isOverLimit = charCount > MAX_MESSAGE_LENGTH;
   const canSend =
     content.trim().length > 0 && !isOverLimit && status !== "sending";
+
+  const selectedModelLabel = useMemo(
+    () => (modelOptions.includes(modelLabel) ? modelLabel : ""),
+    [modelLabel, modelOptions]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadModelOptions = async () => {
+      try {
+        if (isTauri) {
+          const options = await invoke<string[]>("read_model_options");
+          if (!cancelled) {
+            setModelOptions(options);
+            if (!modelLabel && options.length > 0) {
+              setModelLabel(options[0]);
+            }
+          }
+          return;
+        }
+
+        const res = await fetch("/api/model-options");
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const data = (await res.json()) as { modelOptions?: string[] };
+        const options = Array.isArray(data.modelOptions) ? data.modelOptions : [];
+        if (!cancelled) {
+          setModelOptions(options);
+          if (!modelLabel && options.length > 0) {
+            setModelLabel(options[0]);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setModelOptions([]);
+          setModelLabel("");
+          toast.error(`Failed to load model options: ${String(e)}`);
+        }
+      }
+    };
+
+    void loadModelOptions();
+    return () => {
+      cancelled = true;
+    };
+  }, [isTauri]);
 
   const doSend = useCallback(
     async (target: MainAgentId, message: string) => {
@@ -71,8 +135,36 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
         setLastAgent(target);
       }
     },
-    [isTauri]
+    [isTauri, onSent]
   );
+
+  const switchModel = useCallback(async () => {
+    if (!modelLabel) {
+      toast.error("Model is required");
+      return;
+    }
+
+    try {
+      if (isTauri) {
+        await invoke("switch_agent_model", { agent: modelSwitchAgent, label: modelLabel });
+      } else {
+        const res = await fetch("/api/model-switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: modelSwitchAgent, label: modelLabel }),
+        });
+
+        if (!res.ok) {
+          const data = (await res.json()) as { error?: string };
+          throw new Error(data.error || `HTTP ${res.status}`);
+        }
+      }
+
+      toast.success(`Switched ${modelSwitchAgent} to ${selectedModelLabel || modelLabel}`);
+    } catch (e) {
+      toast.error(`Model switch failed: ${String(e)}`);
+    }
+  }, [isTauri, modelLabel, modelSwitchAgent, selectedModelLabel]);
 
   const handleSend = () => doSend(activeAgent, content);
 
@@ -87,13 +179,57 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   };
 
   return (
-    <div className="border-t border-border/40 pt-3 space-y-2">
+    <div className="border-t border-border/40 pt-3 space-y-3">
+      <div className="rounded-md border border-border/40 px-3 py-2 space-y-2">
+        <div className="text-xs text-muted-foreground">Temporary model switch</div>
+        <div className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end">
+          <label className="text-[11px] text-muted-foreground">
+            Agent
+            <select
+              value={modelSwitchAgent}
+              onChange={(e) => setModelSwitchAgent(e.target.value as ModelSwitchAgent)}
+              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
+            >
+              {MODEL_SWITCH_AGENTS.map((agent) => (
+                <option key={agent.value} value={agent.value}>
+                  {agent.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-[11px] text-muted-foreground">
+            Model
+            <select
+              value={modelLabel}
+              onChange={(e) => setModelLabel(e.target.value)}
+              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
+            >
+              {modelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={switchModel}
+            disabled={!modelLabel || modelOptions.length === 0}
+            className="h-8 text-xs"
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+
       {/* To: indicator (task 4.4 – always visible) */}
       <div className="flex items-center gap-2 text-xs text-muted-foreground px-1">
         <Icon className="h-3.5 w-3.5 shrink-0" />
         <span>
-          To:{" "}
-          <span className="font-semibold text-foreground">{label}</span>
+          To: <span className="font-semibold text-foreground">{label}</span>
         </span>
 
         {/* Send status (task 4.7) */}

--- a/desktop/app/routes.ts
+++ b/desktop/app/routes.ts
@@ -9,6 +9,8 @@ export default [
   route("api/health", "routes/api.health.ts"),
   route("api/projects", "routes/api.projects.ts"),
   route("api/projects/active", "routes/api.projects.active.ts"),
+  route("api/model-options", "routes/api.model-options.ts"),
+  route("api/model-switch", "routes/api.model-switch.ts"),
   // UI routes
   layout("routes/_layout.tsx", [
     index("routes/index.tsx"),

--- a/desktop/app/routes/api.model-options.ts
+++ b/desktop/app/routes/api.model-options.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+/**
+ * GET /api/model-options
+ * Returns whitelisted model labels for temporary runtime switch.
+ */
+export async function loader() {
+  try {
+    const root = getProjectRoot();
+    const configPath = join(root, "config/model_switch_keywords.yaml");
+
+    if (!existsSync(configPath)) {
+      return Response.json({ modelOptions: [] satisfies string[] });
+    }
+
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = parseYaml(raw) as { models?: unknown };
+
+    const modelOptions: string[] = Array.isArray(parsed?.models)
+      ? parsed.models
+          .map((item) => {
+            if (
+              item &&
+              typeof item === "object" &&
+              typeof (item as Record<string, unknown>).label === "string"
+            ) {
+              return (item as Record<string, string>).label;
+            }
+            return null;
+          })
+          .filter((item): item is string => item !== null)
+      : [];
+
+    return Response.json({ modelOptions });
+  } catch (e) {
+    return Response.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/desktop/app/routes/api.model-switch.ts
+++ b/desktop/app/routes/api.model-switch.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+const ALLOWED_AGENTS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto"] as const;
+
+type AllowedAgent = (typeof ALLOWED_AGENTS)[number];
+
+function readModelOptions(root: string): string[] {
+  const configPath = join(root, "config/model_switch_keywords.yaml");
+  if (!existsSync(configPath)) return [];
+
+  const raw = readFileSync(configPath, "utf-8");
+  const parsed = parseYaml(raw) as { models?: unknown };
+
+  if (!Array.isArray(parsed?.models)) return [];
+
+  return parsed.models
+    .map((item) => {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as Record<string, unknown>).label === "string"
+      ) {
+        return (item as Record<string, string>).label;
+      }
+      return null;
+    })
+    .filter((item): item is string => item !== null);
+}
+
+/**
+ * POST /api/model-switch
+ * Body: { agent: AllowedAgent, label: string }
+ */
+export async function action({ request }: { request: Request }) {
+  try {
+    const body = (await request.json()) as { agent?: string; label?: string };
+    const agent = body.agent?.trim() ?? "";
+    const label = body.label?.trim() ?? "";
+
+    if (!ALLOWED_AGENTS.includes(agent as AllowedAgent)) {
+      return Response.json({ error: `Invalid agent: ${agent}` }, { status: 400 });
+    }
+    if (!label) {
+      return Response.json({ error: "label is required" }, { status: 400 });
+    }
+
+    const root = getProjectRoot();
+    const modelOptions = readModelOptions(root);
+    if (!modelOptions.includes(label)) {
+      return Response.json({ error: `Invalid model label: ${label}` }, { status: 400 });
+    }
+
+    const script = join(root, ".opencode/skills/switch-model/scripts/switch.sh");
+    const result = spawnSync("bash", [script, agent, label], {
+      cwd: root,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    if (result.status === 0) {
+      return Response.json({ ok: true });
+    }
+
+    const errorMessage = (result.stderr || result.stdout || "switch-model failed").trim();
+    return Response.json({ error: errorMessage }, { status: 500 });
+  } catch (e) {
+    return Response.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ struct ScriptStatus {
 // ---------------------------------------------------------------------------
 
 const ALLOWED_TARGETS: &[&str] = &["noctis", "lunafreya"];
+const MODEL_SWITCH_TARGETS: &[&str] = &["noctis", "lunafreya", "ignis", "gladiolus", "prompto"];
 const ALLOWED_SENDERS: &[&str] = &[
     "crystal", "user", "noctis", "lunafreya", "ignis", "gladiolus", "prompto", "iris",
 ];
@@ -88,6 +89,16 @@ const ALLOWED_SENDERS: &[&str] = &[
 const MAX_MESSAGE_LENGTH: usize = 4000;
 const CHAT_LOG_PATH: &str = "runtime/logs/agent-chat-monitor.jsonl";
 const INBOX_LOG_PATH: &str = "runtime/logs/inbox-log.jsonl";
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ModelOption {
+    label: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ModelSwitchConfig {
+    models: Vec<ModelOption>,
+}
 
 // ---------------------------------------------------------------------------
 // Chat log types
@@ -478,6 +489,58 @@ fn health_check() -> Result<HealthResult, String> {
     })
 }
 
+/// Returns whitelisted model options from config/model_switch_keywords.yaml.
+#[tauri::command]
+fn read_model_options() -> Result<Vec<String>, String> {
+    let root = get_project_root()?;
+    let path = root.join("config/model_switch_keywords.yaml");
+
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read model switch config: {}", e))?;
+    let parsed: ModelSwitchConfig =
+        serde_yaml::from_str(&raw).map_err(|e| format!("Invalid model switch config: {}", e))?;
+
+    Ok(parsed.models.into_iter().map(|m| m.label).collect())
+}
+
+/// Switch agent model via .opencode/skills/switch-model/scripts/switch.sh.
+#[tauri::command]
+fn switch_agent_model(agent: String, label: String) -> Result<String, String> {
+    if !MODEL_SWITCH_TARGETS.contains(&agent.as_str()) {
+        return Err(format!("Invalid agent: {}", agent));
+    }
+
+    let root = get_project_root()?;
+    let model_options = read_model_options()?;
+    if !model_options.contains(&label) {
+        return Err(format!("Invalid model label: {}", label));
+    }
+
+    let script = root.join(".opencode/skills/switch-model/scripts/switch.sh");
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg(&agent)
+        .arg(&label)
+        .current_dir(&root)
+        .output()
+        .map_err(|e| format!("Failed to execute switch.sh: {}", e))?;
+
+    if output.status.success() {
+        Ok(format!("Switched {} to {}", agent, label))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(if stderr.is_empty() {
+            "switch.sh failed".to_string()
+        } else {
+            format!("switch.sh failed: {}", stderr)
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -530,6 +593,8 @@ pub fn run() {
             send_crystal_message,
             read_inbox_log,
             health_check,
+            read_model_options,
+            switch_agent_model,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
### Motivation
- Simplify the model whitelist so the same display/search value is used everywhere by keeping a single `label` field and removing the redundant `keyword` field. 
- Ensure the desktop UI, web API, and Tauri backend validate and execute model switches from the same canonical, committed config file.

### Description
- Replace `config/model_switch_keywords.yaml` with a label-only schema (`models: [{ label }]`) and allow the file to be committed so frontends can read stable options (`config/model_switch_keywords.yaml`).
- Update web API to expose and consume label strings: `GET /api/model-options` now returns `string[]` labels (`desktop/app/routes/api.model-options.ts`) and `POST /api/model-switch` accepts `{ agent, label }`, validates the label against the whitelist, and calls the `switch.sh` script (`desktop/app/routes/api.model-switch.ts`).
- Update desktop UI `MessageComposer` to load labels, present a label-only selector, and send `{ agent, label }` payloads to the backend or Tauri command (`desktop/app/components/MessageComposer.tsx`).
- Update Tauri commands to a label-only API: `read_model_options` returns `Vec<String>` and `switch_agent_model` accepts a `label`, validates it, and invokes `.opencode/skills/switch-model/scripts/switch.sh` (`desktop/src-tauri/src/lib.rs`).
- Update docs and meta: annotate the skill doc to point to the new config source and allow the config file in `.gitignore` rules.

### Testing
- Ran a YAML sanity check (`ruby -e

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac2306f28832db26ea96fff5791cb)