### PR TITLE
refactor(desktop): move model switch to compact inline bar in chat columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ dashboard.md
 agent-chat-monitor.md
 config/*
 !config/models.yaml
+!config/model_switch_keywords.yaml
 logs/
 
 # Project details (contains client/confidential info)

--- a/.opencode/skills/switch-model/SKILL.md
+++ b/.opencode/skills/switch-model/SKILL.md
@@ -44,6 +44,8 @@ Dynamically switch an FF15 agent's LLM model using `scripts/switch.sh`.
 
 Check all available models: `opencode models`
 
+Desktop/Web UI model list source: `config/model_switch_keywords.yaml`
+
 ## Prerequisites
 
 - **Agent must be idle** — switching during active work may cause context loss

--- a/.opencode/skills/switch-model/SKILL.md
+++ b/.opencode/skills/switch-model/SKILL.md
@@ -9,42 +9,32 @@ metadata:
 
 # switch-model
 
-Dynamically switch an FF15 agent's LLM model using `scripts/switch.sh`.
+Dynamically switch an FF15 agent's LLM model using `scripts/switch-model.sh`.
 
 ## Usage
 
 ```bash
-.opencode/skills/switch-model/scripts/switch.sh <agent_name> <model_keyword>
+scripts/switch-model.sh <agent_name> <model_keyword>
 ```
 
 ### Examples
 
 ```bash
 # Upgrade Prompto to Opus for a complex task
-.opencode/skills/switch-model/scripts/switch.sh prompto opus
+scripts/switch-model.sh prompto opus
 
 # Downgrade Ignis to Haiku for a simple task
-.opencode/skills/switch-model/scripts/switch.sh ignis haiku
+scripts/switch-model.sh ignis haiku
 
 # Switch Gladiolus to GPT-5-mini
-.opencode/skills/switch-model/scripts/switch.sh gladiolus gpt-5-mini
+scripts/switch-model.sh gladiolus gpt-5-mini
 ```
 
 ## Model Keywords
 
-| Keyword | Model |
-|---------|-------|
-| `gpt-5-mini` | GPT-5-mini |
-| `sonnet` | Claude Sonnet 4.5 |
-| `opus` | Claude Opus 4.6 |
-| `haiku` | Claude Haiku 4.5 |
-| `gemini` | Gemini models |
-| `gpt-5.2-codex` | GPT-5.2-codex |
-| `grok-code-fast-1` | Grok Code Fast 1 |
-
-Check all available models: `opencode models`
-
-Desktop/Web UI model list source: `config/model_switch_keywords.yaml`
+The available model keywords are managed dynamically. See the following sources:
+- Desktop/Web UI and valid arguments: `config/model_switch_keywords.yaml`
+- Check all available models via OpenCode CLI: `opencode models`
 
 ## Prerequisites
 

--- a/config/model_switch_keywords.yaml
+++ b/config/model_switch_keywords.yaml
@@ -2,9 +2,12 @@
 # `label`: display value for UI and /models search input
 models:
   - label: GPT-5-mini
-  - label: Claude Sonnet 4.5
-  - label: Claude Opus 4.6
-  - label: Claude Haiku 4.5
-  - label: Gemini models
   - label: GPT-5.2-codex
+  - label: Claude Haiku 4.5
+  - label: Claude Sonnet 4.6
+  - label: Claude Opus 4.6
+  - label: Gemini 3 Flash
+  - label: Gemini 3.1 Pro Preview
   - label: Grok Code Fast 1
+  - label: MiniMax M2.5 Free OpenCode Zen
+  - label: GLM-5 Free

--- a/config/model_switch_keywords.yaml
+++ b/config/model_switch_keywords.yaml
@@ -1,0 +1,10 @@
+# Model options for temporary runtime switching via .opencode/skills/switch-model/scripts/switch.sh
+# `label`: display value for UI and /models search input
+models:
+  - label: GPT-5-mini
+  - label: Claude Sonnet 4.5
+  - label: Claude Opus 4.6
+  - label: Claude Haiku 4.5
+  - label: Gemini models
+  - label: GPT-5.2-codex
+  - label: Grok Code Fast 1

--- a/config/model_switch_keywords.yaml
+++ b/config/model_switch_keywords.yaml
@@ -9,5 +9,5 @@ models:
   - label: Gemini 3 Flash
   - label: Gemini 3.1 Pro Preview
   - label: Grok Code Fast 1
-  - label: MiniMax M2.5 Free OpenCode Zen
+  - label: MiniMax M2.5 Free
   - label: GLM-5 Free

--- a/desktop/app/components/AgentChatColumn.tsx
+++ b/desktop/app/components/AgentChatColumn.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { Crown, Moon } from "lucide-react";
+import { Crown, Moon, Zap } from "lucide-react";
 import MessageCard from "@/components/MessageCard";
 import type { ChatLogRecord, AgentId } from "@/lib/useAgentChatLog";
 import type { InboxLogRecord } from "@/lib/useInboxLog";
@@ -8,6 +10,8 @@ import { COMRADES, COMRADE_CONFIG, type ComradeId } from "@/lib/useComradeStatus
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+type ModelSwitchAgent = "noctis" | "lunafreya" | "ignis" | "gladiolus" | "prompto";
 
 interface AgentChatColumnProps {
   agent: "noctis" | "lunafreya";
@@ -22,6 +26,8 @@ interface AgentChatColumnProps {
   partyRecords?: Partial<Record<ComradeId, ChatLogRecord[]>>;
   partyInboxMessages?: Partial<Record<ComradeId, InboxLogRecord[]>>;
   busyMap?: Record<ComradeId, boolean>;
+  modelOptions?: string[];
+  isTauri?: boolean;
 }
 
 const AGENT_CONFIG = {
@@ -163,7 +169,76 @@ function TypingIndicator({ agentLabel }: { agentLabel: string }) {
   );
 }
 
-/** Mini comrade tab shown in the Noctis column party header. */
+function ModelSwitchBar({
+  targetAgent,
+  modelOptions,
+  isTauri,
+}: {
+  targetAgent: ModelSwitchAgent;
+  modelOptions: string[];
+  isTauri: boolean;
+}) {
+  const [modelLabel, setModelLabel] = useState(modelOptions[0] ?? "");
+
+  useEffect(() => {
+    if (modelOptions.length > 0 && !modelOptions.includes(modelLabel)) {
+      setModelLabel(modelOptions[0]);
+    }
+  }, [modelOptions, modelLabel]);
+
+  const applySwitch = useCallback(async () => {
+    if (!modelLabel) {
+      toast.error("Model is required");
+      return;
+    }
+    try {
+      if (isTauri) {
+        await invoke("switch_agent_model", { agent: targetAgent, label: modelLabel });
+      } else {
+        const res = await fetch("/api/model-switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: targetAgent, label: modelLabel }),
+        });
+        if (!res.ok) {
+          const data = (await res.json()) as { error?: string };
+          throw new Error(data.error ?? `HTTP ${res.status}`);
+        }
+      }
+      toast.success(`Switched ${targetAgent} to ${modelLabel}`);
+    } catch (e) {
+      toast.error(`Model switch failed: ${String(e)}`);
+    }
+  }, [isTauri, modelLabel, targetAgent]);
+
+  if (modelOptions.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 px-3 py-1 border-b border-border/20 bg-background/30">
+      <select
+        value={modelLabel}
+        onChange={(e) => setModelLabel(e.target.value)}
+        className="flex-1 rounded border border-border/40 bg-background/60 px-2 py-0.5 text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      >
+        {modelOptions.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={applySwitch}
+        disabled={!modelLabel}
+        title={`Switch ${targetAgent} model to ${modelLabel}`}
+        className="flex items-center justify-center h-5 w-5 rounded hover:bg-white/10 disabled:opacity-40 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+      >
+        <Zap className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
 function ComradeTab({
   comrade,
   cfg,
@@ -232,6 +307,8 @@ export default function AgentChatColumn({
   partyRecords,
   partyInboxMessages,
   busyMap,
+  modelOptions = [],
+  isTauri = false,
 }: AgentChatColumnProps) {
   const { label, Icon, imageSrc } = AGENT_CONFIG[agent];
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -386,6 +463,18 @@ export default function AgentChatColumn({
           </span>
         </button>
       )}
+
+      <ModelSwitchBar
+        targetAgent={
+          agent === "noctis"
+            ? ((partyView === "ignis" || partyView === "gladiolus" || partyView === "prompto"
+                ? partyView
+                : "noctis") as ModelSwitchAgent)
+            : "lunafreya"
+        }
+        modelOptions={modelOptions}
+        isTauri={isTauri}
+      />
 
       {/* Scrollable message list */}
       <div

--- a/desktop/app/components/AgentChatColumn.tsx
+++ b/desktop/app/components/AgentChatColumn.tsx
@@ -46,8 +46,8 @@ const AGENT_CONFIG = {
 } as const;
 
 type MergedItem =
-  | { type: "agent"; record: ChatLogRecord; ts: string }
-  | { type: "inbox"; msg: InboxLogRecord; ts: string };
+  | { type: "agent"; record: ChatLogRecord; ts: string; }
+  | { type: "inbox"; msg: InboxLogRecord; ts: string; };
 
 /** Merge agent records and inbox messages by UTC timestamp (pure sort). */
 function mergeTimeline(
@@ -61,7 +61,7 @@ function mergeTimeline(
 }
 
 /** Code block with wrap/scroll toggle button (appears on hover). */
-function CodeBlock({ children }: { children: React.ReactNode }) {
+function CodeBlock({ children }: { children: React.ReactNode; }) {
   const [wrap, setWrap] = useState(false);
   return (
     <div className="relative group my-1">
@@ -86,7 +86,7 @@ function CodeBlock({ children }: { children: React.ReactNode }) {
 }
 
 /** Inbox message bubble — Crystal (right-aligned purple) or agent (left-aligned amber). */
-function InboxBubble({ msg }: { msg: InboxLogRecord }) {
+function InboxBubble({ msg }: { msg: InboxLogRecord; }) {
   const ts = new Date(msg.ts);
   const timeStr = ts.toLocaleTimeString("en-US", {
     hour: "2-digit",
@@ -152,7 +152,7 @@ function InboxBubble({ msg }: { msg: InboxLogRecord }) {
 }
 
 /** Typing indicator — three bouncing dots. */
-function TypingIndicator({ agentLabel }: { agentLabel: string }) {
+function TypingIndicator({ agentLabel }: { agentLabel: string; }) {
   return (
     <div className="flex flex-col items-start gap-0.5">
       <span className="text-[10px] text-muted-foreground/50">{agentLabel}</span>
@@ -178,38 +178,81 @@ function ModelSwitchBar({
   modelOptions: string[];
   isTauri: boolean;
 }) {
-  const [modelLabel, setModelLabel] = useState(modelOptions[0] ?? "");
+  const [modelLabel, setModelLabel] = useState("");
+  const [isSwitching, setIsSwitching] = useState(false);
 
+  // Initialize current model
   useEffect(() => {
-    if (modelOptions.length > 0 && !modelOptions.includes(modelLabel)) {
-      setModelLabel(modelOptions[0]);
+    let cancelled = false;
+    const fetchModel = async () => {
+      if (isTauri) return; // Currently omitted for Tauri
+      if (modelOptions.length === 0) return;
+
+      try {
+        const res = await fetch(`/api/current-model?agent=${targetAgent}`);
+        if (!res.ok) return;
+        const data = (await res.json()) as { model?: string; };
+        if (cancelled || !data.model) return;
+
+        // Try to match the returned model name (e.g. "Claude Sonnet 4") with options (e.g. "Claude Sonnet 4.6")
+        // Check contains in both directions
+        const exactOpt = modelOptions.find(
+          (opt) =>
+            opt.toLowerCase() === data.model!.toLowerCase() ||
+            opt.toLowerCase().includes(data.model!.toLowerCase()) ||
+            data.model!.toLowerCase().includes(opt.toLowerCase())
+        );
+        setModelLabel(exactOpt ?? data.model);
+      } catch (e) {
+        // Ignored
+      }
+    };
+    fetchModel();
+    return () => { cancelled = true; };
+  }, [targetAgent, modelOptions, isTauri]);
+
+  // Fallback to first option if empty and we have options, but only after a short delay so we can fetch first
+  useEffect(() => {
+    if (!modelLabel && modelOptions.length > 0) {
+      const timer = setTimeout(() => {
+        setModelLabel((prev) => (prev ? prev : modelOptions[0]));
+      }, 500);
+      return () => clearTimeout(timer);
     }
   }, [modelOptions, modelLabel]);
 
-  const applySwitch = useCallback(async () => {
-    if (!modelLabel) {
-      toast.error("Model is required");
-      return;
-    }
-    try {
-      if (isTauri) {
-        await invoke("switch_agent_model", { agent: targetAgent, label: modelLabel });
-      } else {
-        const res = await fetch("/api/model-switch", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent: targetAgent, label: modelLabel }),
-        });
-        if (!res.ok) {
-          const data = (await res.json()) as { error?: string };
-          throw new Error(data.error ?? `HTTP ${res.status}`);
+  const applySwitch = useCallback(
+    async (newModel: string) => {
+      if (!newModel) return;
+      setIsSwitching(true);
+      const prevModel = modelLabel;
+      setModelLabel(newModel); // Optimistic UI update
+
+      try {
+        if (isTauri) {
+          await invoke("switch_agent_model", { agent: targetAgent, label: newModel });
+        } else {
+          const res = await fetch("/api/model-switch", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agent: targetAgent, label: newModel }),
+          });
+          if (!res.ok) {
+            const data = (await res.json()) as { error?: string; };
+            throw new Error(data.error ?? `HTTP ${res.status}`);
+          }
         }
+        toast.success(`Switched ${targetAgent} to ${newModel}`);
+      } catch (e) {
+        toast.error(`Model switch failed: ${String(e)}`);
+        setModelLabel(prevModel); // Revert on failure
+      } finally {
+        setIsSwitching(false);
       }
-      toast.success(`Switched ${targetAgent} to ${modelLabel}`);
-    } catch (e) {
-      toast.error(`Model switch failed: ${String(e)}`);
-    }
-  }, [isTauri, modelLabel, targetAgent]);
+    },
+    [isTauri, targetAgent, modelLabel]
+  );
+
 
   if (modelOptions.length === 0) return null;
 
@@ -217,24 +260,25 @@ function ModelSwitchBar({
     <div className="flex items-center gap-1.5 px-3 py-1 border-b border-border/20 bg-background/30">
       <select
         value={modelLabel}
-        onChange={(e) => setModelLabel(e.target.value)}
-        className="flex-1 rounded border border-border/40 bg-background/60 px-2 py-0.5 text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        onChange={(e) => applySwitch(e.target.value)}
+        disabled={isSwitching}
+        className={cn(
+          "flex-1 rounded border border-border/40 bg-background/60 px-2 py-0.5 text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring",
+          isSwitching && "opacity-50 cursor-wait"
+        )}
       >
+        {/* Render a custom option if current text doesn't match the known config */}
+        {modelLabel && !modelOptions.includes(modelLabel) && (
+          <option key="custom" value={modelLabel}>
+            {modelLabel}
+          </option>
+        )}
         {modelOptions.map((opt) => (
           <option key={opt} value={opt}>
             {opt}
           </option>
         ))}
       </select>
-      <button
-        type="button"
-        onClick={applySwitch}
-        disabled={!modelLabel}
-        title={`Switch ${targetAgent} model to ${modelLabel}`}
-        className="flex items-center justify-center h-5 w-5 rounded hover:bg-white/10 disabled:opacity-40 text-muted-foreground hover:text-foreground transition-colors shrink-0"
-      >
-        <Zap className="h-3 w-3" />
-      </button>
     </div>
   );
 }
@@ -247,7 +291,7 @@ function ComradeTab({
   onClick,
 }: {
   comrade: ComradeId;
-  cfg: { label: string; imageSrc: string };
+  cfg: { label: string; imageSrc: string; };
   busy: boolean;
   isSelected: boolean;
   onClick: () => void;
@@ -468,8 +512,8 @@ export default function AgentChatColumn({
         targetAgent={
           agent === "noctis"
             ? ((partyView === "ignis" || partyView === "gladiolus" || partyView === "prompto"
-                ? partyView
-                : "noctis") as ModelSwitchAgent)
+              ? partyView
+              : "noctis") as ModelSwitchAgent)
             : "lunafreya"
         }
         modelOptions={modelOptions}

--- a/desktop/app/components/MessageComposer.tsx
+++ b/desktop/app/components/MessageComposer.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Send, RotateCcw, Crown, Moon, CheckCircle2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -9,7 +8,6 @@ import type { MainAgentId } from "@/lib/useAgentChatLog";
 const MAX_MESSAGE_LENGTH = 4000;
 
 type SendStatus = "idle" | "sending" | "sent" | "failed";
-type ModelSwitchAgent = "noctis" | "lunafreya" | "ignis" | "gladiolus" | "prompto";
 
 type SlashSuggestion = {
   label: string;
@@ -36,14 +34,6 @@ const AGENT_CONFIG: Record<MainAgentId, { label: string; Icon: React.ElementType
   },
 };
 
-const MODEL_SWITCH_AGENTS: Array<{ value: ModelSwitchAgent; label: string }> = [
-  { value: "noctis", label: "Noctis" },
-  { value: "lunafreya", label: "Lunafreya" },
-  { value: "ignis", label: "Ignis" },
-  { value: "gladiolus", label: "Gladiolus" },
-  { value: "prompto", label: "Prompto" },
-];
-
 export default function MessageComposer({ activeAgent, isTauri, onSent }: MessageComposerProps) {
   const [content, setContent] = useState("");
   const [status, setStatus] = useState<SendStatus>("idle");
@@ -55,64 +45,11 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const [modelOptions, setModelOptions] = useState<string[]>([]);
-  const [modelSwitchAgent, setModelSwitchAgent] = useState<ModelSwitchAgent>("noctis");
-  const [modelLabel, setModelLabel] = useState("");
-
   const { label, Icon, placeholder } = AGENT_CONFIG[activeAgent];
   const charCount = content.length;
   const isOverLimit = charCount > MAX_MESSAGE_LENGTH;
   const canSend =
     content.trim().length > 0 && !isOverLimit && status !== "sending";
-
-  const selectedModelLabel = useMemo(
-    () => (modelOptions.includes(modelLabel) ? modelLabel : ""),
-    [modelLabel, modelOptions]
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadModelOptions = async () => {
-      try {
-        if (isTauri) {
-          const options = await invoke<string[]>("read_model_options");
-          if (!cancelled) {
-            setModelOptions(options);
-            if (!modelLabel && options.length > 0) {
-              setModelLabel(options[0]);
-            }
-          }
-          return;
-        }
-
-        const res = await fetch("/api/model-options");
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
-        }
-
-        const data = (await res.json()) as { modelOptions?: string[] };
-        const options = Array.isArray(data.modelOptions) ? data.modelOptions : [];
-        if (!cancelled) {
-          setModelOptions(options);
-          if (!modelLabel && options.length > 0) {
-            setModelLabel(options[0]);
-          }
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setModelOptions([]);
-          setModelLabel("");
-          toast.error(`Failed to load model options: ${String(e)}`);
-        }
-      }
-    };
-
-    void loadModelOptions();
-    return () => {
-      cancelled = true;
-    };
-  }, [isTauri]);
 
   const doSend = useCallback(
     async (target: MainAgentId, message: string) => {
@@ -146,34 +83,6 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
     },
     [isTauri, onSent]
   );
-
-  const switchModel = useCallback(async () => {
-    if (!modelLabel) {
-      toast.error("Model is required");
-      return;
-    }
-
-    try {
-      if (isTauri) {
-        await invoke("switch_agent_model", { agent: modelSwitchAgent, label: modelLabel });
-      } else {
-        const res = await fetch("/api/model-switch", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent: modelSwitchAgent, label: modelLabel }),
-        });
-
-        if (!res.ok) {
-          const data = (await res.json()) as { error?: string };
-          throw new Error(data.error || `HTTP ${res.status}`);
-        }
-      }
-
-      toast.success(`Switched ${modelSwitchAgent} to ${selectedModelLabel || modelLabel}`);
-    } catch (e) {
-      toast.error(`Model switch failed: ${String(e)}`);
-    }
-  }, [isTauri, modelLabel, modelSwitchAgent, selectedModelLabel]);
 
   const handleSend = () => doSend(activeAgent, content);
 
@@ -295,59 +204,12 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
 
   return (
     <div className="border-t border-border/40 pt-3 space-y-3">
-      <div className="rounded-md border border-border/40 px-3 py-2 space-y-2">
-        <div className="text-xs text-muted-foreground">Temporary model switch</div>
-        <div className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end">
-          <label className="text-[11px] text-muted-foreground">
-            Agent
-            <select
-              value={modelSwitchAgent}
-              onChange={(e) => setModelSwitchAgent(e.target.value as ModelSwitchAgent)}
-              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
-            >
-              {MODEL_SWITCH_AGENTS.map((agent) => (
-                <option key={agent.value} value={agent.value}>
-                  {agent.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="text-[11px] text-muted-foreground">
-            Model
-            <select
-              value={modelLabel}
-              onChange={(e) => setModelLabel(e.target.value)}
-              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
-            >
-              {modelOptions.map((model) => (
-                <option key={model} value={model}>
-                  {model}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={switchModel}
-            disabled={!modelLabel || modelOptions.length === 0}
-            className="h-8 text-xs"
-          >
-            Apply
-          </Button>
-        </div>
-      </div>
-
-      {/* To: indicator (task 4.4 – always visible) */}
       <div className="flex items-center gap-2 text-xs text-muted-foreground px-1">
         <Icon className="h-3.5 w-3.5 shrink-0" />
         <span>
           To: <span className="font-semibold text-foreground">{label}</span>
         </span>
 
-        {/* Send status (task 4.7) */}
         {status === "sent" && (
           <span className="ml-auto flex items-center gap-1 text-green-400">
             <CheckCircle2 className="h-3.5 w-3.5" />

--- a/desktop/app/components/MessageComposer.tsx
+++ b/desktop/app/components/MessageComposer.tsx
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Send, RotateCcw, Crown, Moon, CheckCircle2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,8 @@ import type { MainAgentId } from "@/lib/useAgentChatLog";
 const MAX_MESSAGE_LENGTH = 4000;
 
 type SendStatus = "idle" | "sending" | "sent" | "failed";
+type ModelSwitchAgent = "noctis" | "lunafreya" | "ignis" | "gladiolus" | "prompto";
+
 
 interface MessageComposerProps {
   activeAgent: MainAgentId;
@@ -28,6 +31,14 @@ const AGENT_CONFIG: Record<MainAgentId, { label: string; Icon: React.ElementType
   },
 };
 
+const MODEL_SWITCH_AGENTS: Array<{ value: ModelSwitchAgent; label: string }> = [
+  { value: "noctis", label: "Noctis" },
+  { value: "lunafreya", label: "Lunafreya" },
+  { value: "ignis", label: "Ignis" },
+  { value: "gladiolus", label: "Gladiolus" },
+  { value: "prompto", label: "Prompto" },
+];
+
 export default function MessageComposer({ activeAgent, isTauri, onSent }: MessageComposerProps) {
   const [content, setContent] = useState("");
   const [status, setStatus] = useState<SendStatus>("idle");
@@ -35,11 +46,64 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   const [lastAgent, setLastAgent] = useState<MainAgentId>(activeAgent);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [modelSwitchAgent, setModelSwitchAgent] = useState<ModelSwitchAgent>("noctis");
+  const [modelLabel, setModelLabel] = useState("");
+
   const { label, Icon, placeholder } = AGENT_CONFIG[activeAgent];
   const charCount = content.length;
   const isOverLimit = charCount > MAX_MESSAGE_LENGTH;
   const canSend =
     content.trim().length > 0 && !isOverLimit && status !== "sending";
+
+  const selectedModelLabel = useMemo(
+    () => (modelOptions.includes(modelLabel) ? modelLabel : ""),
+    [modelLabel, modelOptions]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadModelOptions = async () => {
+      try {
+        if (isTauri) {
+          const options = await invoke<string[]>("read_model_options");
+          if (!cancelled) {
+            setModelOptions(options);
+            if (!modelLabel && options.length > 0) {
+              setModelLabel(options[0]);
+            }
+          }
+          return;
+        }
+
+        const res = await fetch("/api/model-options");
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const data = (await res.json()) as { modelOptions?: string[] };
+        const options = Array.isArray(data.modelOptions) ? data.modelOptions : [];
+        if (!cancelled) {
+          setModelOptions(options);
+          if (!modelLabel && options.length > 0) {
+            setModelLabel(options[0]);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setModelOptions([]);
+          setModelLabel("");
+          toast.error(`Failed to load model options: ${String(e)}`);
+        }
+      }
+    };
+
+    void loadModelOptions();
+    return () => {
+      cancelled = true;
+    };
+  }, [isTauri]);
 
   const doSend = useCallback(
     async (target: MainAgentId, message: string) => {
@@ -71,8 +135,36 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
         setLastAgent(target);
       }
     },
-    [isTauri]
+    [isTauri, onSent]
   );
+
+  const switchModel = useCallback(async () => {
+    if (!modelLabel) {
+      toast.error("Model is required");
+      return;
+    }
+
+    try {
+      if (isTauri) {
+        await invoke("switch_agent_model", { agent: modelSwitchAgent, label: modelLabel });
+      } else {
+        const res = await fetch("/api/model-switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: modelSwitchAgent, label: modelLabel }),
+        });
+
+        if (!res.ok) {
+          const data = (await res.json()) as { error?: string };
+          throw new Error(data.error || `HTTP ${res.status}`);
+        }
+      }
+
+      toast.success(`Switched ${modelSwitchAgent} to ${selectedModelLabel || modelLabel}`);
+    } catch (e) {
+      toast.error(`Model switch failed: ${String(e)}`);
+    }
+  }, [isTauri, modelLabel, modelSwitchAgent, selectedModelLabel]);
 
   const handleSend = () => doSend(activeAgent, content);
 
@@ -87,13 +179,57 @@ export default function MessageComposer({ activeAgent, isTauri, onSent }: Messag
   };
 
   return (
-    <div className="border-t border-border/40 pt-3 space-y-2">
+    <div className="border-t border-border/40 pt-3 space-y-3">
+      <div className="rounded-md border border-border/40 px-3 py-2 space-y-2">
+        <div className="text-xs text-muted-foreground">Temporary model switch</div>
+        <div className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end">
+          <label className="text-[11px] text-muted-foreground">
+            Agent
+            <select
+              value={modelSwitchAgent}
+              onChange={(e) => setModelSwitchAgent(e.target.value as ModelSwitchAgent)}
+              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
+            >
+              {MODEL_SWITCH_AGENTS.map((agent) => (
+                <option key={agent.value} value={agent.value}>
+                  {agent.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-[11px] text-muted-foreground">
+            Model
+            <select
+              value={modelLabel}
+              onChange={(e) => setModelLabel(e.target.value)}
+              className="mt-1 w-full rounded-md border border-border/50 bg-background/60 px-2 py-1.5 text-xs"
+            >
+              {modelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={switchModel}
+            disabled={!modelLabel || modelOptions.length === 0}
+            className="h-8 text-xs"
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+
       {/* To: indicator (task 4.4 – always visible) */}
       <div className="flex items-center gap-2 text-xs text-muted-foreground px-1">
         <Icon className="h-3.5 w-3.5 shrink-0" />
         <span>
-          To:{" "}
-          <span className="font-semibold text-foreground">{label}</span>
+          To: <span className="font-semibold text-foreground">{label}</span>
         </span>
 
         {/* Send status (task 4.7) */}

--- a/desktop/app/routes.ts
+++ b/desktop/app/routes.ts
@@ -12,6 +12,7 @@ export default [
   route("api/slash-suggestions", "routes/api.slash-suggestions.ts"),
   route("api/model-options", "routes/api.model-options.ts"),
   route("api/model-switch", "routes/api.model-switch.ts"),
+  route("api/current-model", "routes/api.current-model.ts"),
   // UI routes
   layout("routes/_layout.tsx", [
     index("routes/index.tsx"),

--- a/desktop/app/routes.ts
+++ b/desktop/app/routes.ts
@@ -9,6 +9,8 @@ export default [
   route("api/health", "routes/api.health.ts"),
   route("api/projects", "routes/api.projects.ts"),
   route("api/projects/active", "routes/api.projects.active.ts"),
+  route("api/model-options", "routes/api.model-options.ts"),
+  route("api/model-switch", "routes/api.model-switch.ts"),
   // UI routes
   layout("routes/_layout.tsx", [
     index("routes/index.tsx"),

--- a/desktop/app/routes/api.current-model.ts
+++ b/desktop/app/routes/api.current-model.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+const ALLOWED_AGENTS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto"] as const;
+
+export async function loader({ request }: { request: Request; }) {
+  const url = new URL(request.url);
+  const agent = url.searchParams.get("agent");
+
+  if (!agent || !ALLOWED_AGENTS.includes(agent as any)) {
+    return Response.json({ error: "Invalid agent" }, { status: 400 });
+  }
+
+  const root = getProjectRoot();
+  const getModelScript = join(root, "scripts/get-current-model.sh");
+
+  const result = spawnSync("bash", [getModelScript, agent], {
+    cwd: root,
+    encoding: "utf-8",
+    timeout: 2000,
+  });
+
+  if (result.status === 0) {
+    return Response.json({ model: result.stdout.trim() });
+  }
+
+  const errorMessage = (result.stderr || result.stdout || "get-current-model failed").trim();
+  return Response.json({ error: errorMessage }, { status: 500 });
+}

--- a/desktop/app/routes/api.model-options.ts
+++ b/desktop/app/routes/api.model-options.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+/**
+ * GET /api/model-options
+ * Returns whitelisted model labels for temporary runtime switch.
+ */
+export async function loader() {
+  try {
+    const root = getProjectRoot();
+    const configPath = join(root, "config/model_switch_keywords.yaml");
+
+    if (!existsSync(configPath)) {
+      return Response.json({ modelOptions: [] satisfies string[] });
+    }
+
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = parseYaml(raw) as { models?: unknown };
+
+    const modelOptions: string[] = Array.isArray(parsed?.models)
+      ? parsed.models
+          .map((item) => {
+            if (
+              item &&
+              typeof item === "object" &&
+              typeof (item as Record<string, unknown>).label === "string"
+            ) {
+              return (item as Record<string, string>).label;
+            }
+            return null;
+          })
+          .filter((item): item is string => item !== null)
+      : [];
+
+    return Response.json({ modelOptions });
+  } catch (e) {
+    return Response.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/desktop/app/routes/api.model-switch.ts
+++ b/desktop/app/routes/api.model-switch.ts
@@ -13,7 +13,7 @@ function readModelOptions(root: string): string[] {
   if (!existsSync(configPath)) return [];
 
   const raw = readFileSync(configPath, "utf-8");
-  const parsed = parseYaml(raw) as { models?: unknown };
+  const parsed = parseYaml(raw) as { models?: unknown; };
 
   if (!Array.isArray(parsed?.models)) return [];
 
@@ -35,9 +35,9 @@ function readModelOptions(root: string): string[] {
  * POST /api/model-switch
  * Body: { agent: AllowedAgent, label: string }
  */
-export async function action({ request }: { request: Request }) {
+export async function action({ request }: { request: Request; }) {
   try {
-    const body = (await request.json()) as { agent?: string; label?: string };
+    const body = (await request.json()) as { agent?: string; label?: string; };
     const agent = body.agent?.trim() ?? "";
     const label = body.label?.trim() ?? "";
 
@@ -54,7 +54,7 @@ export async function action({ request }: { request: Request }) {
       return Response.json({ error: `Invalid model label: ${label}` }, { status: 400 });
     }
 
-    const script = join(root, ".opencode/skills/switch-model/scripts/switch.sh");
+    const script = join(root, "scripts/switch-model.sh");
     const result = spawnSync("bash", [script, agent, label], {
       cwd: root,
       encoding: "utf-8",

--- a/desktop/app/routes/api.model-switch.ts
+++ b/desktop/app/routes/api.model-switch.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getProjectRoot } from "@/lib/getProjectRoot.server";
+
+const ALLOWED_AGENTS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto"] as const;
+
+type AllowedAgent = (typeof ALLOWED_AGENTS)[number];
+
+function readModelOptions(root: string): string[] {
+  const configPath = join(root, "config/model_switch_keywords.yaml");
+  if (!existsSync(configPath)) return [];
+
+  const raw = readFileSync(configPath, "utf-8");
+  const parsed = parseYaml(raw) as { models?: unknown };
+
+  if (!Array.isArray(parsed?.models)) return [];
+
+  return parsed.models
+    .map((item) => {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as Record<string, unknown>).label === "string"
+      ) {
+        return (item as Record<string, string>).label;
+      }
+      return null;
+    })
+    .filter((item): item is string => item !== null);
+}
+
+/**
+ * POST /api/model-switch
+ * Body: { agent: AllowedAgent, label: string }
+ */
+export async function action({ request }: { request: Request }) {
+  try {
+    const body = (await request.json()) as { agent?: string; label?: string };
+    const agent = body.agent?.trim() ?? "";
+    const label = body.label?.trim() ?? "";
+
+    if (!ALLOWED_AGENTS.includes(agent as AllowedAgent)) {
+      return Response.json({ error: `Invalid agent: ${agent}` }, { status: 400 });
+    }
+    if (!label) {
+      return Response.json({ error: "label is required" }, { status: 400 });
+    }
+
+    const root = getProjectRoot();
+    const modelOptions = readModelOptions(root);
+    if (!modelOptions.includes(label)) {
+      return Response.json({ error: `Invalid model label: ${label}` }, { status: 400 });
+    }
+
+    const script = join(root, ".opencode/skills/switch-model/scripts/switch.sh");
+    const result = spawnSync("bash", [script, agent, label], {
+      cwd: root,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    if (result.status === 0) {
+      return Response.json({ ok: true });
+    }
+
+    const errorMessage = (result.stderr || result.stdout || "switch-model failed").trim();
+    return Response.json({ error: errorMessage }, { status: 500 });
+  } catch (e) {
+    return Response.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/desktop/app/routes/api.model-switch.ts
+++ b/desktop/app/routes/api.model-switch.ts
@@ -54,6 +54,14 @@ export async function action({ request }: { request: Request; }) {
       return Response.json({ error: `Invalid model label: ${label}` }, { status: 400 });
     }
 
+    const getModelScript = join(root, "scripts/get-current-model.sh");
+    const beforeResult = spawnSync("bash", [getModelScript, agent], {
+      cwd: root,
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    const beforeModel = beforeResult.status === 0 ? beforeResult.stdout.trim() : "";
+
     const script = join(root, "scripts/switch-model.sh");
     const result = spawnSync("bash", [script, agent, label], {
       cwd: root,
@@ -61,12 +69,30 @@ export async function action({ request }: { request: Request; }) {
       timeout: 10_000,
     });
 
-    if (result.status === 0) {
-      return Response.json({ ok: true });
+    if (result.status !== 0) {
+      const errorMessage = (result.stderr || result.stdout || "switch-model failed").trim();
+      return Response.json({ error: errorMessage }, { status: 500 });
     }
 
-    const errorMessage = (result.stderr || result.stdout || "switch-model failed").trim();
-    return Response.json({ error: errorMessage }, { status: 500 });
+    // Verify model has changed by checking for up to 5 seconds
+    let afterModel = beforeModel;
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const afterResult = spawnSync("bash", [getModelScript, agent], {
+        cwd: root,
+        encoding: "utf-8",
+        timeout: 2000,
+      });
+      if (afterResult.status === 0) {
+        afterModel = afterResult.stdout.trim();
+        // Break early if we detected a change
+        if (afterModel && afterModel !== beforeModel) {
+          break;
+        }
+      }
+    }
+
+    return Response.json({ ok: true, beforeModel, afterModel });
   } catch (e) {
     return Response.json({ error: String(e) }, { status: 500 });
   }

--- a/desktop/app/routes/api.slash-suggestions.ts
+++ b/desktop/app/routes/api.slash-suggestions.ts
@@ -39,14 +39,14 @@ export async function loader() {
       const name = entry.replace(/\.md$/, "");
       return {
         label: `command: ${name}`,
-        value: `/${name}`,
+        value: `/${name} `,
         source: "command",
       };
     });
 
     const skillSuggestions: SlashSuggestion[] = Array.from(new Set(skillEntries)).map((entry) => ({
       label: `skill: ${entry}`,
-      value: `/${entry}`,
+      value: `/${entry} `,
       source: "skill",
     }));
 

--- a/desktop/app/routes/chat.tsx
+++ b/desktop/app/routes/chat.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useAgentChatLog, type AgentId, type MainAgentId } from "@/lib/useAgentChatLog";
 import { useInboxLog } from "@/lib/useInboxLog";
 import { COMRADES, type ComradeId } from "@/lib/useComradeStatus";
@@ -12,6 +13,28 @@ export default function UnifiedChatRoute() {
   const { getRecordsForAgent, lastUpdated, error, isTauri, refresh } =
     useAgentChatLog();
   const [activeAgent, setActiveAgent] = useState<MainAgentId>("noctis");
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        if (isTauri) {
+          const options = await invoke<string[]>("read_model_options");
+          if (!cancelled) setModelOptions(options);
+        } else {
+          const res = await fetch("/api/model-options");
+          if (!res.ok) return;
+          const data = (await res.json()) as { modelOptions?: string[] };
+          if (!cancelled && Array.isArray(data.modelOptions)) setModelOptions(data.modelOptions);
+        }
+      } catch (_) {
+        setModelOptions([]);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [isTauri]);
 
   // Filtered records per agent (memoised to minimise re-renders)
   const noctisRecords = useMemo(
@@ -170,6 +193,8 @@ export default function UnifiedChatRoute() {
             isWaiting={isWaitingMap[agent]}
             isActive={activeAgent === agent}
             onActivate={() => setActiveAgent(agent)}
+            modelOptions={modelOptions}
+            isTauri={isTauri}
             {...(agent === "noctis" && {
               partyView: noctisPartyView,
               onPartyViewChange: setNoctisPartyView,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ struct ScriptStatus {
 // ---------------------------------------------------------------------------
 
 const ALLOWED_TARGETS: &[&str] = &["noctis", "lunafreya"];
+const MODEL_SWITCH_TARGETS: &[&str] = &["noctis", "lunafreya", "ignis", "gladiolus", "prompto"];
 const ALLOWED_SENDERS: &[&str] = &[
     "crystal", "user", "noctis", "lunafreya", "ignis", "gladiolus", "prompto", "iris",
 ];
@@ -88,6 +89,16 @@ const ALLOWED_SENDERS: &[&str] = &[
 const MAX_MESSAGE_LENGTH: usize = 4000;
 const CHAT_LOG_PATH: &str = "runtime/logs/agent-chat-monitor.jsonl";
 const INBOX_LOG_PATH: &str = "runtime/logs/inbox-log.jsonl";
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ModelOption {
+    label: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ModelSwitchConfig {
+    models: Vec<ModelOption>,
+}
 
 // ---------------------------------------------------------------------------
 // Chat log types
@@ -478,6 +489,58 @@ fn health_check() -> Result<HealthResult, String> {
     })
 }
 
+/// Returns whitelisted model options from config/model_switch_keywords.yaml.
+#[tauri::command]
+fn read_model_options() -> Result<Vec<String>, String> {
+    let root = get_project_root()?;
+    let path = root.join("config/model_switch_keywords.yaml");
+
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read model switch config: {}", e))?;
+    let parsed: ModelSwitchConfig =
+        serde_yaml::from_str(&raw).map_err(|e| format!("Invalid model switch config: {}", e))?;
+
+    Ok(parsed.models.into_iter().map(|m| m.label).collect())
+}
+
+/// Switch agent model via .opencode/skills/switch-model/scripts/switch.sh.
+#[tauri::command]
+fn switch_agent_model(agent: String, label: String) -> Result<String, String> {
+    if !MODEL_SWITCH_TARGETS.contains(&agent.as_str()) {
+        return Err(format!("Invalid agent: {}", agent));
+    }
+
+    let root = get_project_root()?;
+    let model_options = read_model_options()?;
+    if !model_options.contains(&label) {
+        return Err(format!("Invalid model label: {}", label));
+    }
+
+    let script = root.join(".opencode/skills/switch-model/scripts/switch.sh");
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg(&agent)
+        .arg(&label)
+        .current_dir(&root)
+        .output()
+        .map_err(|e| format!("Failed to execute switch.sh: {}", e))?;
+
+    if output.status.success() {
+        Ok(format!("Switched {} to {}", agent, label))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(if stderr.is_empty() {
+            "switch.sh failed".to_string()
+        } else {
+            format!("switch.sh failed: {}", stderr)
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -530,6 +593,8 @@ pub fn run() {
             send_crystal_message,
             read_inbox_log,
             health_check,
+            read_model_options,
+            switch_agent_model,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/scripts/get-current-model.sh
+++ b/scripts/get-current-model.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/get-current-model.sh
+# Retrieves the current model name for the specified agent from the tmux pane.
+
+set -euo pipefail
+
+declare -A PANE_INDEX=(
+  [noctis]=0
+  [lunafreya]=1
+  [ignis]=2
+  [gladiolus]=3
+  [prompto]=4
+)
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: get-current-model.sh <agent_name>" >&2
+  exit 1
+fi
+
+agent="${1,,}" # lowercase
+pane="${PANE_INDEX[$agent]:-}"
+
+if [[ -z "$pane" ]]; then
+  echo "ERROR: Unknown agent '$agent'. Valid: ${!PANE_INDEX[*]}" >&2
+  exit 1
+fi
+
+target="ff15:main.${pane}"
+agent_capitalized="${agent^}"
+
+# Find the line containing the agent status, get the last one
+matched_line=$(tmux capture-pane -t "$target" -p | grep -E "^[[:space:]]*┃[[:space:]]*${agent_capitalized}[[:space:]]+" | tail -n 1 || true)
+
+if [[ -z "$matched_line" ]]; then
+  echo "ERROR: Could not find status line for $agent in pane $target" >&2
+  exit 1
+fi
+
+# Extract the model string between Agent Name and Provider
+# Uses sed. Example line: "  ┃  Lunafreya  MiniMax M2.5 Free (OpenCode Zen)"
+# \1 captures the model part.
+model=$(echo "$matched_line" | sed -E "s/^[[:space:]]*┃[[:space:]]*${agent_capitalized}[[:space:]]+(.*)[[:space:]]+(GitHub Copilot|OpenCode Zen).*$/\1/")
+
+# Trim trailing whitespace
+model=$(echo "$model" | sed -e 's/[[:space:]]*$//')
+
+if [[ "$model" == "$matched_line" ]]; then
+  # Regex didn't match
+  echo "ERROR: Failed to parse provider from line: $matched_line" >&2
+  exit 1
+fi
+
+echo "$model"

--- a/scripts/switch-model.sh
+++ b/scripts/switch-model.sh
@@ -2,12 +2,12 @@
 # switch-model: Dynamically switch an FF15 agent's model via OpenCode /models command
 #
 # Usage:
-#   switch.sh <agent_name> <model_keyword>
+#   switch-model.sh <agent_name> <model_keyword>
 #
 # Examples:
-#   switch.sh prompto gpt-5-mini
-#   switch.sh ignis opus
-#   switch.sh gladiolus haiku
+#   switch-model.sh prompto gpt-5-mini
+#   switch-model.sh ignis opus
+#   switch-model.sh gladiolus haiku
 #
 # The agent must be in idle state (not executing a task).
 
@@ -24,7 +24,7 @@ declare -A PANE_INDEX=(
 
 # --- Argument validation ---
 if [[ $# -ne 2 ]]; then
-  echo "Usage: switch.sh <agent_name> <model_keyword>" >&2
+  echo "Usage: switch-model.sh <agent_name> <model_keyword>" >&2
   echo "" >&2
   echo "Model keywords (must match OpenCode /models display exactly):" >&2
   echo "  Claude: opus, sonnet, haiku" >&2
@@ -50,7 +50,7 @@ tmux send-keys -t "$target" '/models'
 tmux send-keys -t "$target" Enter
 
 # Step 2: Wait for UI to appear
-sleep 2
+sleep 0.5
 
 # Step 3: Send model search keyword
 tmux send-keys -t "$target" "$model"


### PR DESCRIPTION
## Summary

- Removes the bulky \"Temporary model switch\" block from the message composer area
- Adds a compact `ModelSwitchBar` (model dropdown + ⚡ icon button) directly inside each `AgentChatColumn` header
- For the Noctis column, the target agent follows the selected party tab (Noctis / Ignis / Gladiolus / Prompto)
- For the Lunafreya column, the target is always Lunafreya

## Changes

| File | Change |
|------|--------|
| `AgentChatColumn.tsx` | Added `ModelSwitchBar` component; added `modelOptions` / `isTauri` props |
| `MessageComposer.tsx` | Removed model switch state, effects, and JSX block |
| `chat.tsx` | Fetch model options once at page level; pass down to `AgentChatColumn` |