### PR TITLE
fix: show active party member's model and context usage in Noctis column

### DIFF
--- a/desktop/app/routes/_layout.chat.tsx
+++ b/desktop/app/routes/_layout.chat.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import AgentChatColumn from "@/components/agent-chat-column";
 import MessageComposer from "@/components/message-composer";
 import StatusBar from "@/components/status-bar";
-import { ALL_MODEL_SWITCH_AGENTS, type ModelSwitchAgent } from "@/lib/agents";
 import { type MainAgentId, useAgentChatLog } from "@/lib/use-agent-chat-log";
 import { COMRADES, type ComradeId } from "@/lib/use-comrade-status";
 import { type InboxLogRecord, useInboxLog } from "@/lib/use-inbox-log";
@@ -272,28 +271,32 @@ export default function UnifiedChatRoute() {
 
       {/* 2-column chat area */}
       <div className="grid min-h-0 flex-1 grid-cols-2 gap-3">
-        {AGENTS.map((agent) => (
-          <AgentChatColumn
-            agent={agent}
-            contextPercent={contextUsage[agent] ?? null}
-            inboxMessages={getInboxMessages(agent)}
-            isActive={activeAgent === agent}
-            isTauri={isTauri}
-            key={agent}
-            modelOptions={modelOptions}
-            onActivate={() => setActiveAgent(agent)}
-            optimisticMessages={optimisticMessages[agent]}
-            records={recordsMap[agent]}
-            status={effectiveStatuses[agent]}
-            {...(agent === "noctis" && {
-              partyView: noctisPartyView,
-              onPartyViewChange: setNoctisPartyView,
-              partyRecords: comradeRecords,
-              partyInboxMessages: comradeInboxMessages,
-              busyMap: effectiveStatuses as any,
-            })}
-          />
-        ))}
+        {AGENTS.map((agent) => {
+          const effectiveContextAgent =
+            agent === "noctis" && noctisPartyView ? noctisPartyView : agent;
+          return (
+            <AgentChatColumn
+              agent={agent}
+              contextPercent={contextUsage[effectiveContextAgent] ?? null}
+              inboxMessages={getInboxMessages(agent)}
+              isActive={activeAgent === agent}
+              isTauri={isTauri}
+              key={agent}
+              modelOptions={modelOptions}
+              onActivate={() => setActiveAgent(agent)}
+              optimisticMessages={optimisticMessages[agent]}
+              records={recordsMap[agent]}
+              status={effectiveStatuses[agent]}
+              {...(agent === "noctis" && {
+                partyView: noctisPartyView,
+                onPartyViewChange: setNoctisPartyView,
+                partyRecords: comradeRecords,
+                partyInboxMessages: comradeInboxMessages,
+                busyMap: effectiveStatuses as any,
+              })}
+            />
+          );
+        })}
       </div>
 
       {/* Message composer */}


### PR DESCRIPTION
## Summary

- **Bug**: In the Noctis chat column, switching to a comrade (ignis/gladiolus/prompto/iris) via the party tab showed Noctis's context usage % instead of the selected comrade's.
- **Root cause**: `contextPercent={contextUsage[agent] ?? null}` always passed `contextUsage["noctis"]` regardless of `noctisPartyView`.
- **Fix**: Compute `effectiveContextAgent` from `noctisPartyView` before passing `contextPercent` to `AgentChatColumn`. When a comrade is selected, their context usage is shown; otherwise Noctis's own value is used.

## Note

The model selector (`ModelSwitchBar`) was already correct — `switchTargetAgent` was derived from `partyView` inside `AgentChatColumn` and triggered a re-fetch via `useEffect`. Only `contextPercent` needed fixing.