### PR TITLE
fix: New Session / Abort Session target correct agent when switching party tab

### DIFF
--- a/desktop/app/components/agent-chat-column.tsx
+++ b/desktop/app/components/agent-chat-column.tsx
@@ -758,6 +758,7 @@ export default function AgentChatColumn({
       <ModelSwitchBar
         contextPercent={contextPercent}
         isTauri={isTauri}
+        key={switchTargetAgent}
         modelOptions={modelOptions}
         targetAgent={switchTargetAgent}
       />


### PR DESCRIPTION
## Problem

In the Noctis chat column, switching to a Comrade tab (Ignis, Gladiolus, Prompto, Iris) and then clicking **New Session** or **Abort Session** always targeted **Noctis** instead of the selected Comrade.

## Root Cause

`ModelSwitchBar` was rendered without a `key` prop, so React kept the same component instance across party-view switches. The internal `modelLabel` state (and therefore the visual state of the bar) was never reset, and the user could not tell which agent was actually targeted.

While `targetAgent` prop was correctly computed as the selected Comrade, the stale internal state created confusing UX. Adding `key={switchTargetAgent}` forces a full remount whenever the active target agent changes.

## Fix

```tsx
<ModelSwitchBar
  key={switchTargetAgent}   // ← added
  targetAgent={switchTargetAgent}
  ...
/>
```

- On party-view change, `ModelSwitchBar` is fully remounted
- `modelLabel` state resets and re-fetches the correct model for the selected agent
- New Session / Abort Session buttons now visually and functionally target the selected Comrade