### PR TITLE
perf: reduce chat input lag in desktop app

### DIFF
--- a/desktop/app/components/message-composer.tsx
+++ b/desktop/app/components/message-composer.tsx
@@ -7,7 +7,7 @@ import {
   Send,
   XCircle,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { MainAgentId } from "@/lib/use-agent-chat-log";
 import { cn } from "@/lib/utils";
@@ -54,7 +54,7 @@ const AGENT_CONFIG: Record<
   },
 };
 
-export default function MessageComposer({
+function MessageComposer({
   activeAgent,
   isTauri,
   onSent,
@@ -443,3 +443,5 @@ export default function MessageComposer({
     </div>
   );
 }
+
+export default memo(MessageComposer);

--- a/desktop/app/lib/use-agent-statuses.ts
+++ b/desktop/app/lib/use-agent-statuses.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STATUS_POLL_INTERVAL_MS = 2000;
+
+export function useAgentStatuses(): Record<string, string> {
+  const [statuses, setStatuses] = useState<Record<string, string>>({});
+
+  const fetchStatuses = useCallback(async () => {
+    try {
+      const res = await fetch("/api/agent-statuses");
+      if (res.ok) {
+        const data = await res.json();
+        setStatuses(data);
+      }
+    } catch (e) {
+      console.error("Failed to fetch agent statuses:", e);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatuses();
+    const interval = setInterval(fetchStatuses, STATUS_POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchStatuses]);
+
+  return statuses;
+}

--- a/desktop/app/lib/use-context-usage.ts
+++ b/desktop/app/lib/use-context-usage.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+
+const CONTEXT_POLL_INTERVAL_MS = 3000;
+
+export function useContextUsage(): Record<string, number | null> {
+  const [contextUsage, setContextUsage] = useState<
+    Record<string, number | null>
+  >({});
+
+  const fetchContextUsage = useCallback(async () => {
+    try {
+      const res = await fetch("/api/context-usage");
+      if (res.ok) {
+        const data = await res.json();
+        setContextUsage(data);
+      }
+    } catch {
+      setContextUsage({});
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchContextUsage();
+    const interval = setInterval(fetchContextUsage, CONTEXT_POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchContextUsage]);
+
+  return contextUsage;
+}

--- a/desktop/app/routes/_layout.chat.tsx
+++ b/desktop/app/routes/_layout.chat.tsx
@@ -4,7 +4,9 @@ import AgentChatColumn from "@/components/agent-chat-column";
 import MessageComposer from "@/components/message-composer";
 import StatusBar from "@/components/status-bar";
 import { type MainAgentId, useAgentChatLog } from "@/lib/use-agent-chat-log";
+import { useAgentStatuses } from "@/lib/use-agent-statuses";
 import { COMRADES, type ComradeId } from "@/lib/use-comrade-status";
+import { useContextUsage } from "@/lib/use-context-usage";
 import { type InboxLogRecord, useInboxLog } from "@/lib/use-inbox-log";
 
 const AGENTS: MainAgentId[] = ["noctis", "lunafreya"];
@@ -123,43 +125,8 @@ export default function UnifiedChatRoute() {
     [getInboxMessages]
   );
 
-  const [statuses, setStatuses] = useState<Record<string, string>>({});
-  const [contextUsage, setContextUsage] = useState<Record<string, number | null>>({});
-
-  const fetchStatuses = useCallback(async () => {
-    try {
-      const res = await fetch("/api/agent-statuses");
-      if (res.ok) {
-        const data = await res.json();
-        setStatuses(data);
-      }
-    } catch (e) {
-      console.error("Failed to fetch agent statuses:", e);
-    }
-  }, []);
-
-  const fetchContextUsage = useCallback(async () => {
-    try {
-      const res = await fetch("/api/context-usage");
-      if (res.ok) {
-        const data = await res.json();
-        setContextUsage(data);
-      }
-    } catch (_e) {
-      setContextUsage({});
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchStatuses();
-    fetchContextUsage();
-    const statusInterval = setInterval(fetchStatuses, 2000);
-    const contextInterval = setInterval(fetchContextUsage, 3000);
-    return () => {
-      clearInterval(statusInterval);
-      clearInterval(contextInterval);
-    };
-  }, [fetchStatuses, fetchContextUsage]);
+  const statuses = useAgentStatuses();
+  const contextUsage = useContextUsage();
 
   // Optimistic "just-sent" timestamp per agent — bridges the polling gap (3 s)
   // until inbox-log.jsonl catches up with the Crystal message.


### PR DESCRIPTION
## Summary

- **案3**: `MessageComposer` を `React.memo` でラップし、親コンポーネントのstate更新（ステータスポーリング等）による不要な再レンダリングを防止
- **案4**: `fetchStatuses` / `fetchContextUsage` をそれぞれ `useAgentStatuses` / `useContextUsage` カスタムフックへ抽出し、`_layout.chat.tsx` から除去することでポーリング更新の影響範囲を局所化

## Changed Files

| File | Change |
|------|--------|
| `app/components/message-composer.tsx` | `React.memo` でラップ |
| `app/routes/_layout.chat.tsx` | `useAgentStatuses` / `useContextUsage` フックを使用、`fetchStatuses` / `fetchContextUsage` の定義と `setInterval` を削除 |
| `app/lib/use-agent-statuses.ts` | 新規作成: エージェントステータス取得フック |
| `app/lib/use-context-usage.ts` | 新規作成: コンテキスト使用率取得フック |

## Effect

`statuses` / `contextUsage` の2〜3秒ごとの更新が `MessageComposer` に波及しなくなり、テキスト入力時のレスポンスが改善されます。

TypeScript: 0 errors / Biome: 0 errors