### PR TITLE
refactor: update project metadata structure and paths

### DIFF
--- a/.opencode/skills/project-manage/SKILL.md
+++ b/.opencode/skills/project-manage/SKILL.md
@@ -15,7 +15,7 @@ Registers external projects and manages active project state. Projects can have 
 
 ### 1. Register a New Project
 
-Detects instruction files at the project root and stores metadata in `projects/<id>.yaml`.
+Detects instruction files at the project root and stores metadata in `projects/<id>/project.yaml`.
 
 ```bash
 scripts/project_register.sh \
@@ -45,7 +45,7 @@ scripts/project_register.sh \
   --serena-project "my-app"   # value confirmed by activate_project
 ```
 
-Output: `projects/my-app.yaml` with detected instruction files, SHA256 hashes, and `serena_project`.
+Output: `projects/my-app/project.yaml` with detected instruction files and `serena_project`.
 
 ---
 
@@ -55,34 +55,34 @@ Control which projects are currently active. Active projects have their instruct
 
 ```bash
 # Add projects to active list (preserves existing)
-scripts/projects_activate.sh add <project_id...>
+scripts/projects_activate.sh <scope> add <project_id...>
 
 # Remove projects from active list
-scripts/projects_activate.sh remove <project_id...>
+scripts/projects_activate.sh <scope> remove <project_id...>
 
 # Replace active list entirely
-scripts/projects_activate.sh set <project_id...>
+scripts/projects_activate.sh <scope> set <project_id...>
 
 # Show currently active projects
-scripts/projects_activate.sh list
+scripts/projects_activate.sh <scope> list
 ```
 
 **Example — enable two projects:**
 
 ```bash
-scripts/projects_activate.sh add my-app another-project
+scripts/projects_activate.sh noctis_team add my-app another-project
 ```
 
 **Example — switch to a single project:**
 
 ```bash
-scripts/projects_activate.sh set my-app
+scripts/projects_activate.sh noctis_team set my-app
 ```
 
 **Example — deactivate all:**
 
 ```bash
-scripts/projects_activate.sh remove my-app
+scripts/projects_activate.sh noctis_team remove my-app
 ```
 
 ---
@@ -103,10 +103,10 @@ scripts/project_register.sh \
   --serena-project "<confirmed_value>"   # value confirmed in step 1
 
 # 3. Add to active project list
-scripts/projects_activate.sh add client-x
+scripts/projects_activate.sh noctis_team add client-x
 
 # 4. Verify
-scripts/projects_activate.sh list
+scripts/projects_activate.sh noctis_team list
 ```
 
 After activation, the `project-instruction-injection` plugin automatically adds a project-instruction-context block to every user message, listing instruction file paths for agents to read on demand.
@@ -135,7 +135,7 @@ Pass the successful value as `--serena-project` when running `project_register.s
 
 ## What Gets Stored
 
-`projects/<id>.yaml`:
+`projects/<id>/project.yaml`:
 
 ```yaml
 id: 'client-x'
@@ -143,17 +143,8 @@ name: 'Client X'
 root_path: '/home/atman/repos/client-x'
 serena_project: '\\wsl$\Ubuntu\home\atman\repos\client-x'  # optional; use the confirmed Serena activation value
 instruction_files:
-  - type: agents
-    path: '/home/atman/repos/client-x/AGENTS.md'
-    exists: true
-    sha256: 'abc123...'
-    last_checked_at: '2026-02-22T12:00:00Z'
-  - type: claude
-    path: '/home/atman/repos/client-x/CLAUDE.md'
-    exists: false
-    sha256: ''
-    last_checked_at: '2026-02-22T12:00:00Z'
-updated_at: '2026-02-22T12:00:00Z'
+  - path: '/home/atman/repos/client-x/AGENTS.md'
+    enabled: true
 ```
 
 `config/current_projects.yaml`:
@@ -183,7 +174,7 @@ scripts/project_register.sh \
   --force
 ```
 
-The SHA256 hash will be updated. No need to re-activate.
+Detected instruction files will be refreshed with `enabled: true`. No need to re-activate.
 
 If `serena_project` is already present in the existing YAML, re-registering without `--serena-project` preserves that value.
 
@@ -208,5 +199,5 @@ Note: `project_register.sh` now writes YAML-safe single-quoted scalars for path-
 - Re-registering after instruction files were added or changed
 
 **Don't use when:**
-- Editing project metadata directly — edit `projects/<id>.yaml` manually
+- Editing project metadata directly — edit `projects/<id>/project.yaml` manually
 - The project has no instruction files — registration still works (with a warning)

--- a/scripts/project_register.sh
+++ b/scripts/project_register.sh
@@ -5,7 +5,7 @@
 #   project_register.sh --id <id> --name <name> --root <path> [--serena-project <value>] [--force]
 #
 # Detects instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) at project root.
-# Stores metadata in projects/<id>.yaml including existence, path, and SHA256 hash.
+# Stores metadata in projects/<id>/project.yaml with existing instruction file paths.
 # If --serena-project is provided, stores it in serena_project field for Serena MCP activation.
 #
 # Exit codes: 0=success, 1=error, 2=usage error
@@ -17,7 +17,6 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PROJECTS_DIR="${REPO_ROOT}/projects"
 YAML_WRITE="${SCRIPT_DIR}/yaml_write_flock.sh"
 
-# Instruction file types to detect (root only)
 INSTRUCTION_FILES=("AGENTS.md" "CLAUDE.md" "GEMINI.md")
 
 # Defaults
@@ -134,7 +133,8 @@ while [[ "$CURRENT_PATH" != "/" ]]; do
 done
 
 # --- Re-registration handling (Task 2.7) ---
-OUTPUT_FILE="${PROJECTS_DIR}/${PROJECT_ID}.yaml"
+OUTPUT_DIR="${PROJECTS_DIR}/${PROJECT_ID}"
+OUTPUT_FILE="${OUTPUT_DIR}/project.yaml"
 if [[ -f "$OUTPUT_FILE" ]]; then
   if [[ "$FORCE" == true ]]; then
     echo "INFO: Re-registering project '${PROJECT_ID}' (--force)" >&2
@@ -159,39 +159,17 @@ if [[ -z "$SERENA_PROJECT" && -f "$OUTPUT_FILE" ]]; then
 fi
 
 # --- Instruction file detection (Task 2.2) ---
-TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
 INSTRUCTION_ENTRIES=""
 FILES_FOUND=0
 
 for FILENAME in "${INSTRUCTION_FILES[@]}"; do
   FILEPATH="${NORMALIZED_ROOT}/${FILENAME}"
-  
-  # Determine type from filename
-  case "$FILENAME" in
-    AGENTS.md)  FILE_TYPE="agents" ;;
-    CLAUDE.md)  FILE_TYPE="claude" ;;
-    GEMINI.md)  FILE_TYPE="gemini" ;;
-    *)          FILE_TYPE="unknown" ;;
-  esac
 
   if [[ -f "$FILEPATH" && ! -L "$FILEPATH" ]]; then
-    # File exists and is not a symlink — compute SHA256 (Task 2.3)
-    SHA256=$(sha256sum "$FILEPATH" | awk '{print $1}')
-    INSTRUCTION_ENTRIES+="  - type: ${FILE_TYPE}
-    path: $(yaml_quote "$FILEPATH")
-    exists: true
-    sha256: $(yaml_quote "$SHA256")
-    last_checked_at: $(yaml_quote "$TIMESTAMP")
+    INSTRUCTION_ENTRIES+="  - path: $(yaml_quote "$FILEPATH")
+    enabled: true
 "
     FILES_FOUND=$((FILES_FOUND + 1))
-  else
-    # File does not exist or is a symlink
-    INSTRUCTION_ENTRIES+="  - type: ${FILE_TYPE}
-    path: $(yaml_quote "$FILEPATH")
-    exists: false
-    sha256: ''
-    last_checked_at: $(yaml_quote "$TIMESTAMP")
-"
   fi
 done
 
@@ -202,7 +180,7 @@ if [[ "$FILES_FOUND" -eq 0 ]]; then
 fi
 
 # --- YAML output generation (Task 2.4) ---
-mkdir -p "$PROJECTS_DIR" 2>/dev/null
+mkdir -p "$OUTPUT_DIR" 2>/dev/null
 
 # Build serena_project line only if value was provided
 SERENA_PROJECT_LINE=""
@@ -214,11 +192,16 @@ elif [[ -n "$EXISTING_SERENA_PROJECT_LINE" ]]; then
 "
 fi
 
+INSTRUCTION_FILES_BLOCK="instruction_files: []"
+if [[ -n "$INSTRUCTION_ENTRIES" ]]; then
+  INSTRUCTION_FILES_BLOCK="instruction_files:
+${INSTRUCTION_ENTRIES}"
+fi
+
 YAML_CONTENT="id: $(yaml_quote "$PROJECT_ID")
 name: $(yaml_quote "$PROJECT_NAME")
 root_path: $(yaml_quote "$NORMALIZED_ROOT")
-${SERENA_PROJECT_LINE}instruction_files:
-${INSTRUCTION_ENTRIES}updated_at: $(yaml_quote "$TIMESTAMP")"
+${SERENA_PROJECT_LINE}${INSTRUCTION_FILES_BLOCK}"
 
 # Write using yaml_write_flock.sh for atomic writes
 if ! "$YAML_WRITE" "$OUTPUT_FILE" "$YAML_CONTENT"; then

--- a/scripts/projects_activate.sh
+++ b/scripts/projects_activate.sh
@@ -75,7 +75,7 @@ validate_scope "$SCOPE"
 # --- Helper: validate project ID exists in projects/ directory (Task 3.6) ---
 validate_project_id() {
   local pid="$1"
-  if [[ ! -f "${PROJECTS_DIR}/${pid}.yaml" ]]; then
+  if [[ ! -f "${PROJECTS_DIR}/${pid}/project.yaml" ]]; then
     echo "ERROR: Project '${pid}' not found in ${PROJECTS_DIR}/" >&2
     echo "  Register it first with: scripts/project_register.sh --id ${pid} ..." >&2
     return 1

--- a/web/app/hooks/use-active-projects.ts
+++ b/web/app/hooks/use-active-projects.ts
@@ -6,7 +6,6 @@ export interface ProjectEntry {
   displayName: string;
   id: string;
   path: string;
-  updatedAt: string;
 }
 
 export interface ActiveProjectsData {
@@ -26,7 +25,6 @@ function areProjectEntriesEqual(left: ProjectEntry[], right: ProjectEntry[]) {
       project.id === other?.id &&
       project.displayName === other.displayName &&
       project.path === other.path &&
-      project.updatedAt === other.updatedAt &&
       project.branchName === other.branchName
     );
   });

--- a/web/app/lib/project-config.server.test.ts
+++ b/web/app/lib/project-config.server.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getActiveProjectRootsForScope,
+  readRegisteredProjectDefinition,
+  readRegisteredProjects,
+} from "./project-config.server";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-project-config-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeProjectManifest(
+  root: string,
+  id: string,
+  yamlContent: string
+): void {
+  const projectDir = join(root, "projects", id);
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, "project.yaml"), yamlContent, "utf-8");
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("project-config.server", () => {
+  it("reads registered projects from projects/<id>/project.yaml", () => {
+    const root = createTempRoot();
+
+    writeProjectManifest(
+      root,
+      "alpha",
+      [
+        'id: "alpha"',
+        'name: "Alpha Project"',
+        `root_path: "${root}/external-alpha"`,
+        'serena_project: "alpha"',
+        "instruction_files:",
+        `  - path: "${root}/external-alpha/AGENTS.md"`,
+        "    enabled: true",
+        "",
+      ].join("\n")
+    );
+
+    const projects = readRegisteredProjects(root);
+
+    expect(projects).toEqual([
+      {
+        id: "alpha",
+        displayName: "Alpha Project",
+        path: `${root}/external-alpha`,
+        branchName: undefined,
+      },
+    ]);
+  });
+
+  it("reads enabled instruction files and active roots from nested manifests", () => {
+    const root = createTempRoot();
+    mkdirSync(join(root, "config"), { recursive: true });
+    writeFileSync(
+      join(root, "config", "current_projects.yaml"),
+      [
+        "project_scopes:",
+        "  noctis_team:",
+        "    active_project_ids:",
+        '      - "alpha"',
+        "  lunafreya:",
+        "    active_project_ids: []",
+        'updated_at: "2026-03-25T00:00:00.000Z"',
+        'updated_by: "test"',
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const projectRoot = join(root, "external-alpha");
+    mkdirSync(projectRoot, { recursive: true });
+
+    writeProjectManifest(
+      root,
+      "alpha",
+      [
+        'id: "alpha"',
+        'name: "Alpha Project"',
+        `root_path: "${projectRoot}"`,
+        'serena_project: "alpha"',
+        "instruction_files:",
+        `  - path: "${projectRoot}/AGENTS.md"`,
+        "    enabled: true",
+        `  - path: "${projectRoot}/CLAUDE.md"`,
+        "    enabled: false",
+        "",
+      ].join("\n")
+    );
+
+    const definition = readRegisteredProjectDefinition(root, "alpha");
+
+    expect(definition).toEqual({
+      id: "alpha",
+      name: "Alpha Project",
+      rootPath: projectRoot,
+      serenaProject: "alpha",
+      instructionFiles: [
+        { path: `${projectRoot}/AGENTS.md`, enabled: true },
+        { path: `${projectRoot}/CLAUDE.md`, enabled: false },
+      ],
+    });
+
+    expect(getActiveProjectRootsForScope(root, "noctis_team")).toEqual([projectRoot]);
+  });
+});

--- a/web/app/lib/project-config.server.ts
+++ b/web/app/lib/project-config.server.ts
@@ -6,11 +6,8 @@ import { PROJECT_SCOPES, type ProjectScope } from "@/lib/project-scopes";
 import { ensureRequiredWebConfigFiles } from "@/lib/required-config.server";
 
 export interface ProjectInstructionFile {
-  exists: boolean;
-  lastCheckedAt: string;
+  enabled: boolean;
   path: string;
-  sha256: string;
-  type: string;
 }
 
 export interface RegisteredProjectDefinition {
@@ -19,7 +16,6 @@ export interface RegisteredProjectDefinition {
   name: string;
   rootPath: string;
   serenaProject: string;
-  updatedAt: string;
 }
 
 export interface ProjectEntry {
@@ -27,7 +23,6 @@ export interface ProjectEntry {
   displayName: string;
   id: string;
   path: string;
-  updatedAt: string;
 }
 
 export interface ProjectScopeState {
@@ -104,6 +99,10 @@ export function buildScopedProjectsYaml(
   ].join("\n");
 }
 
+export function getProjectDefinitionPath(root: string, id: string): string {
+  return join(root, "projects", id, "project.yaml");
+}
+
 export function readRegisteredProjects(root: string): ProjectEntry[] {
   const projectsDir = join(root, "projects");
   const projects: ProjectEntry[] = [];
@@ -112,13 +111,13 @@ export function readRegisteredProjects(root: string): ProjectEntry[] {
     return projects;
   }
 
-  const files = readdirSync(projectsDir).filter(
-    (file) => file.endsWith(".yaml") && !file.startsWith(".")
+  const directories = readdirSync(projectsDir, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && !entry.name.startsWith(".")
   );
 
-  for (const file of files) {
+  for (const directory of directories) {
     try {
-      const raw = readFileSync(join(projectsDir, file), "utf-8");
+      const raw = readFileSync(join(projectsDir, directory.name, "project.yaml"), "utf-8");
       const parsed = parseYaml(raw);
       if (!parsed?.id) {
         continue;
@@ -141,7 +140,6 @@ export function readRegisteredProjects(root: string): ProjectEntry[] {
         id: parsed.id,
         displayName: parsed.name ?? parsed.id,
         path: parsed.root_path ?? "",
-        updatedAt: parsed.updated_at ?? "",
         branchName: branchName || undefined,
       });
     } catch {
@@ -156,7 +154,7 @@ export function readRegisteredProjectDefinition(
   root: string,
   id: string
 ): RegisteredProjectDefinition | null {
-  const projectPath = join(root, "projects", `${id}.yaml`);
+  const projectPath = getProjectDefinitionPath(root, id);
 
   if (!existsSync(projectPath)) {
     return null;
@@ -176,11 +174,8 @@ export function readRegisteredProjectDefinition(
             (file: unknown): file is Record<string, unknown> => !!file && typeof file === "object"
           )
           .map((file: Record<string, unknown>) => ({
-            type: typeof file.type === "string" ? file.type : "unknown",
             path: typeof file.path === "string" ? file.path : "",
-            exists: file.exists === true,
-            sha256: typeof file.sha256 === "string" ? file.sha256 : "",
-            lastCheckedAt: typeof file.last_checked_at === "string" ? file.last_checked_at : "",
+            enabled: file.enabled !== false,
           }))
       : [];
 
@@ -189,7 +184,6 @@ export function readRegisteredProjectDefinition(
       name: typeof parsed.name === "string" ? parsed.name : parsed.id,
       rootPath: typeof parsed.root_path === "string" ? parsed.root_path : "",
       serenaProject: typeof parsed.serena_project === "string" ? parsed.serena_project : "",
-      updatedAt: typeof parsed.updated_at === "string" ? parsed.updated_at : "",
       instructionFiles,
     };
   } catch {
@@ -208,10 +202,9 @@ export function getActiveProjectRootsForScope(
   const { projectScopes } = readScopedProjectsConfig(appRoot);
   const activeProjectIds = projectScopes[scope].activeProjectIds;
   const roots: string[] = [];
-  const projectsDir = join(appRoot, "projects");
 
   for (const id of activeProjectIds) {
-    const projectPath = join(projectsDir, `${id}.yaml`);
+    const projectPath = getProjectDefinitionPath(appRoot, id);
     if (!existsSync(projectPath)) {
       continue;
     }

--- a/web/app/lib/prompt-context.server.test.ts
+++ b/web/app/lib/prompt-context.server.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildInjectedPromptContext } from "./prompt-context.server";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-prompt-context-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("buildInjectedPromptContext", () => {
+  it("injects only enabled and existing instruction files", () => {
+    const root = createTempRoot();
+    const projectRoot = join(root, "external-alpha");
+
+    mkdirSync(join(root, "config"), { recursive: true });
+    mkdirSync(join(root, "projects", "alpha"), { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+
+    writeFileSync(join(projectRoot, "AGENTS.md"), "# Agents\n", "utf-8");
+    writeFileSync(
+      join(root, "config", "current_projects.yaml"),
+      [
+        "project_scopes:",
+        "  noctis_team:",
+        "    active_project_ids:",
+        '      - "alpha"',
+        "  lunafreya:",
+        "    active_project_ids: []",
+        'updated_at: "2026-03-25T00:00:00.000Z"',
+        'updated_by: "test"',
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+    writeFileSync(
+      join(root, "projects", "alpha", "project.yaml"),
+      [
+        'id: "alpha"',
+        'name: "Alpha Project"',
+        `root_path: "${projectRoot}"`,
+        'serena_project: "alpha"',
+        "instruction_files:",
+        `  - path: "${projectRoot}/AGENTS.md"`,
+        "    enabled: true",
+        `  - path: "${projectRoot}/CLAUDE.md"`,
+        "    enabled: false",
+        `  - path: "${projectRoot}/GEMINI.md"`,
+        "    enabled: true",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const promptContext = buildInjectedPromptContext({
+      agent: "noctis",
+      appRoot: root,
+      sessionId: "session-1",
+    });
+
+    expect(promptContext).toContain(`      - ${projectRoot}/AGENTS.md`);
+    expect(promptContext).not.toContain(`${projectRoot}/CLAUDE.md`);
+    expect(promptContext).not.toContain(`${projectRoot}/GEMINI.md`);
+    expect(promptContext).toContain("project_scope: noctis_team");
+    expect(promptContext).toContain(
+      "on_success: write successful value back to projects/alpha/project.yaml as serena_project"
+    );
+  });
+});

--- a/web/app/lib/prompt-context.server.ts
+++ b/web/app/lib/prompt-context.server.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import {
   type RegisteredProjectDefinition,
   readRegisteredProjectDefinition,
@@ -113,7 +114,9 @@ export function buildInjectedPromptContext({
     lines.push(`  - id: ${project.id}`);
     lines.push(`    root_path: ${project.rootPath}`);
 
-    const existingFiles = project.instructionFiles.filter((file) => file.exists && file.path);
+    const existingFiles = project.instructionFiles.filter(
+      (file) => file.enabled && file.path && existsSync(file.path)
+    );
     if (existingFiles.length === 0) {
       lines.push("    instruction_files: []");
       continue;
@@ -135,7 +138,7 @@ export function buildInjectedPromptContext({
     }`
   );
   lines.push(
-    `  on_success: write successful value back to projects/${firstProject.id}.yaml as serena_project`
+    `  on_success: write successful value back to projects/${firstProject.id}/project.yaml as serena_project`
   );
   lines.push("openspec_context:");
   lines.push(`  root: ${firstProject.rootPath || "not set"}`);

--- a/web/app/routes/_layout.projects/route.tsx
+++ b/web/app/routes/_layout.projects/route.tsx
@@ -89,22 +89,6 @@ const formatPath = (path: string): string => {
   return `…${path.slice(-39)}`;
 };
 
-const formatDate = (iso: string): string => {
-  if (!iso) {
-    return "—";
-  }
-  try {
-    return new Date(iso).toLocaleString("ja-JP", {
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-};
-
 const ProjectsPage = (_props: Route.ComponentProps) => {
   const [serverData, setServerData] = useState<ProjectsApiData | null>(null);
   const [savingIds, setSavingIds] = useState<Set<string>>(new Set());
@@ -358,12 +342,6 @@ const ProjectsPage = (_props: Route.ComponentProps) => {
                       <span className="truncate font-mono" title={project.path}>
                         {formatPath(project.path)}
                       </span>
-                      {project.updatedAt && (
-                        <>
-                          <span className="shrink-0">·</span>
-                          <span className="shrink-0">{formatDate(project.updatedAt)}</span>
-                        </>
-                      )}
                     </div>
                   </div>
 

--- a/web/app/routes/_layout/route.tsx
+++ b/web/app/routes/_layout/route.tsx
@@ -103,19 +103,6 @@ function formatActiveProjectTitle(projects: ProjectEntry[], error: string | null
     .join("\n");
 }
 
-function formatProjectUpdatedAt(value: string) {
-  if (!value) {
-    return "-";
-  }
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return date.toLocaleString();
-}
-
 function getServerStatusLabel(status: HeaderServerStatus | null) {
   if (!status) {
     return "OpenCode: checking";
@@ -505,15 +492,6 @@ const Layout = (_props: Route.ComponentProps) => {
                           <span className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-500/20 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[10px] text-amber-700 dark:text-amber-300">
                             <GitBranch className="h-2.5 w-2.5" />
                             {project.branchName ?? "unknown"}
-                          </span>
-                        </div>
-
-                        <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-                          <span className="uppercase tracking-[0.14em] text-[9px]">
-                            Updated
-                          </span>
-                          <span className="text-foreground/90">
-                            {formatProjectUpdatedAt(project.updatedAt)}
                           </span>
                         </div>
                       </div>

--- a/web/app/routes/api.projects.active.ts
+++ b/web/app/routes/api.projects.active.ts
@@ -5,6 +5,7 @@ import { getProjectRoot } from "@/lib/get-project-root.server";
 import {
   buildScopedProjectsYaml,
   createEmptyProjectScopes,
+  getProjectDefinitionPath,
   type ProjectScopeState,
   readScopedProjectsConfig,
 } from "@/lib/project-config.server";
@@ -41,11 +42,10 @@ export async function action({ request }: { request: Request }) {
       };
     }
 
-    const projectsDir = join(root, "projects");
     const allIds = Array.from(
       new Set(PROJECT_SCOPES.flatMap((scope) => nextProjectScopes[scope].activeProjectIds))
     );
-    const invalidIds = allIds.filter((id) => !existsSync(join(projectsDir, `${id}.yaml`)));
+    const invalidIds = allIds.filter((id) => !existsSync(getProjectDefinitionPath(root, id)));
     if (invalidIds.length > 0) {
       return Response.json(
         { error: `Unknown project IDs: ${invalidIds.join(", ")}` },


### PR DESCRIPTION
Changed project metadata storage from `projects/<id>.yaml` to `projects/<id>/project.yaml` for better organization. Updated related scripts and interfaces to reflect this new structure. Removed unused fields and improved instruction file handling.