### PR TITLE
Improve PR assistant skill portability and output handling

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package.json
+package-lock.json
+bun.lock

--- a/.opencode/skills/pr-assistant/.gitignore
+++ b/.opencode/skills/pr-assistant/.gitignore
@@ -1,0 +1,2 @@
+# Temporary generated artifacts for PR drafting
+outputs/

--- a/.opencode/skills/pr-assistant/SKILL.md
+++ b/.opencode/skills/pr-assistant/SKILL.md
@@ -5,11 +5,13 @@ description: Analyzes git changes and assists with creating comprehensive pull r
 
 # PR Assistant
 
-Assists with creating well-structured pull requests by analyzing changes and generating comprehensive PR descriptions.
+Assists with creating well-structured pull requests by analyzing changes and generating reviewer-friendly PR descriptions.
 
 ## Core Philosophy
 
-**Human-in-the-loop**: This skill generates PR drafts that MUST be reviewed and approved by the user before submission. Never auto-create PRs without explicit confirmation.
+**Default: human-in-the-loop**. Prepare a draft, show it to the user, and ask for approval before creating the PR.
+
+**Explicit fast-path**. If the user clearly asks you to create the PR immediately, you may generate the draft, run sanity checks, and create the PR without a separate approval turn.
 
 ## Workflow
 
@@ -32,33 +34,60 @@ git log $TARGET_BRANCH...$CURRENT_BRANCH --oneline
 git diff $TARGET_BRANCH...$CURRENT_BRANCH --name-status
 ```
 
-Use `scripts/analyze_changes.py` to categorize changes into:
-- Backend changes (apis/, requirements.txt)
-- Frontend changes (ui/)
-- Database changes (supabase/)
-- DevOps changes (docker-compose.yml, Dockerfile, etc.)
-- Documentation (doc/, *.md)
+Use `scripts/analyze_changes.py` to categorize changes into generic buckets:
+- Frontend
+- Backend
+- Application
+- Tests
+- Documentation
+- Configuration
+- CI
+- Infrastructure
+- Scripts
+- Assets
+- Data
+- Other
+
+If classification confidence is low, do not force category-based prose in the PR body. Fall back to diff stats and top-level area summaries.
 
 ### 2. Determine PR Type
 
-Based on the analysis, select the appropriate template:
+Prefer the branch name first when selecting the template:
 - **Feature**: New functionality or enhancements
 - **Bugfix**: Bug fixes or corrections
 - **Docs**: Documentation updates
 - **Refactor**: Code restructuring without behavior change
 - **Chore**: Dependencies, config, tooling updates
 
-### 3. Generate PR Draft
+If the branch name is inconclusive, use commit prefixes and the change mix. Do not switch to a bugfix template just because a feature branch contains a single `fix:` commit.
+
+### 3. Prepare Output Files
+
+Store generated artifacts inside skill-local output storage:
+
+```bash
+mkdir -p .opencode/skills/pr-assistant/outputs
+BRANCH_SLUG=$(git branch --show-current | sed 's#/#-#g; s#[^A-Za-z0-9._-]#-#g')
+STAMP=$(date +%Y%m%d-%H%M%S)
+ANALYSIS_FILE=".opencode/skills/pr-assistant/outputs/pr-analysis-${BRANCH_SLUG}-${STAMP}.json"
+PR_BODY_FILE=".opencode/skills/pr-assistant/outputs/pr-body-${BRANCH_SLUG}-${STAMP}.md"
+```
+
+Always save both the analysis JSON and the generated PR body.
+
+### 4. Generate PR Draft
 
 Use `scripts/generate_pr_body.py` with the appropriate template from `assets/templates/`.
 
 Auto-fill sections:
-- **Summary**: Generated from commit messages and file changes
-- **Changes breakdown**: Categorized list of modified files
+- **Summary**: Commit themes, capped to a short list
+- **Changes breakdown**: Diff stats plus category or top-level area summaries
 - **Related issues**: Parse commit messages for `#123`, `fixes #456` patterns
 - **Checklist**: Auto-populate based on change types
 
-### 4. Quality Checks
+After auto-generation, edit the body if necessary. Avoid dumping every changed file into the PR body.
+
+### 5. Quality Checks
 
 Run `scripts/quality_checks.sh` to check for:
 - Uncommitted changes
@@ -67,11 +96,13 @@ Run `scripts/quality_checks.sh` to check for:
 - Missing test files (for significant code changes)
 - Large file additions (>1MB)
 
-Present warnings to user but don't block PR creation.
+Run validation commands sequentially when a repository has generated artifacts or known typegen/test interactions. Avoid parallel validation unless the repository is known to support it.
 
-### 5. Present Draft for Review
+Present warnings to the user but don't block PR creation unless there is a hard failure or the user says otherwise.
 
-**CRITICAL**: Present the generated PR body in a clear, editable format and explicitly ask the user to review and approve it.
+### 6. Present Draft or Create Immediately
+
+By default, present the generated PR body in a clear, editable format and explicitly ask the user to review and approve it.
 
 Example presentation:
 ```
@@ -88,40 +119,39 @@ Would you like me to:
 4. Add/remove reviewers
 ```
 
-### 6. Create PR Only After Approval
+If the user explicitly requested immediate PR creation, briefly summarize the generated draft and then create the PR.
 
-Once the user approves, use `gh` CLI:
+### 7. Create the PR
+
+Once the user approves, or when the user explicitly requested immediate creation, use `gh` CLI:
 
 ```bash
 gh pr create \
   --title "PR Title" \
-  --body-file /tmp/pr-body.md \
+  --body-file "$PR_BODY_FILE" \
   --base main \
   --head current-branch \
   [--reviewer user1,user2] \
   [--label label1,label2]
 ```
 
-## Project-Specific Configuration
+Only suggest reviewers or labels when repository conventions are obvious or the user asks.
 
-For this repository (tomodachi/srms):
+## Generic Classification Strategy
 
-**Categories**:
-- Backend: `apis/`, `requirements.txt`
-- Frontend: `ui/src/`, `ui/package.json`
-- Database: `supabase/`
-- DevOps: `docker-compose.yml`, `Dockerfile`, `nginx.conf`, `supervisord.conf`
-- Docs: `doc/`, `README.md`, `CLAUDE.md`
-
-**Default reviewers** (suggest based on changes):
-- Backend changes → Backend team
-- Frontend changes → Frontend team
-- Database changes → DBA/Backend team
+- Use coarse categories that travel well across repositories.
+- Prefer confidence-aware output. If the analysis reports low confidence, summarize top-level areas instead of pretending the category split is precise.
+- Keep `Other` as an escape hatch instead of overfitting repository-specific path rules.
+- When the category split is weak, prefer diff stats plus the major top-level directories that changed.
 
 **Branch naming conventions**:
 - `feature/*` → Feature template
+- `feat/*` → Feature template
 - `bugfix/*` or `fix/*` → Bugfix template
+- `hotfix/*` → Bugfix template
 - `docs/*` → Docs template
+- `refactor/*` → Refactor template
+- `chore/*`, `build/*`, `ci/*` → Chore template
 - Other → Feature template (default)
 
 ## Best Practices
@@ -135,6 +165,7 @@ Key points:
 - Include testing evidence
 - Link to related issues
 - Self-review before requesting review
+- Prefer concise, reviewer-friendly summaries over exhaustive file inventories
 
 ## Interactive Editing
 
@@ -163,9 +194,14 @@ If issues arise:
 
 ## Output Format
 
-Always save the generated PR body to a temporary file for easy editing:
+Always save the generated analysis and PR body to skill-local output files for easy editing:
+
 ```bash
-PR_BODY_FILE=".tmp/outputs/pr-body-$(date +%s).md"
+mkdir -p .opencode/skills/pr-assistant/outputs
+BRANCH_SLUG=$(git branch --show-current | sed 's#/#-#g; s#[^A-Za-z0-9._-]#-#g')
+STAMP=$(date +%Y%m%d-%H%M%S)
+ANALYSIS_FILE=".opencode/skills/pr-assistant/outputs/pr-analysis-${BRANCH_SLUG}-${STAMP}.json"
+PR_BODY_FILE=".opencode/skills/pr-assistant/outputs/pr-body-${BRANCH_SLUG}-${STAMP}.md"
 ```
 
-This allows the user to edit it manually if needed before submission.
+The local `.gitignore` in `pr-assistant/` should ignore `outputs/` so these artifacts stay out of version control.

--- a/.opencode/skills/pr-assistant/assets/templates/pr-template-bugfix.md
+++ b/.opencode/skills/pr-assistant/assets/templates/pr-template-bugfix.md
@@ -2,7 +2,7 @@
 
 <!-- What was the bug? How did it manifest? -->
 
-## 📝 Changes
+## 📝 Fix Summary
 
 <!-- AUTO_CHANGES -->
 
@@ -12,7 +12,7 @@
 
 ## ✅ Fix Verification
 
-<!-- How was the fix tested? -->
+<!-- Fill in commands run, reproduction notes, and any manual checks -->
 
 - [ ] Bug reproduced before fix
 - [ ] Bug no longer occurs after fix

--- a/.opencode/skills/pr-assistant/assets/templates/pr-template-docs.md
+++ b/.opencode/skills/pr-assistant/assets/templates/pr-template-docs.md
@@ -6,7 +6,7 @@
 
 <!-- Why were these documentation changes needed? -->
 
-## 📄 Changes
+## 📄 Changes Overview
 
 <!-- AUTO_CHANGES -->
 

--- a/.opencode/skills/pr-assistant/assets/templates/pr-template-feature.md
+++ b/.opencode/skills/pr-assistant/assets/templates/pr-template-feature.md
@@ -6,13 +6,13 @@
 
 <!-- Why is this change needed? What problem does it solve? -->
 
-## 🔧 Changes
+## 🔧 Changes Overview
 
 <!-- AUTO_CHANGES -->
 
 ## ✅ Testing
 
-<!-- Describe what testing was performed -->
+<!-- Fill in commands run and any notable manual checks -->
 
 - [ ] Tested locally
 - [ ] Manual testing completed

--- a/.opencode/skills/pr-assistant/scripts/analyze_changes.py
+++ b/.opencode/skills/pr-assistant/scripts/analyze_changes.py
@@ -3,27 +3,45 @@
 Analyze git changes and categorize them for PR creation.
 
 Usage:
-    python analyze_changes.py [target_branch]
+    python analyze_changes.py [target_branch] [--output OUTPUT]
 
-Output: JSON with categorized changes and summary statistics
+Output: JSON with categorized changes, confidence metadata, and summary statistics
 """
 
+import argparse
 import json
+import re
 import subprocess
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Tuple
 
 
-# Project-specific categories
-CATEGORIES = {
-    'backend': ['apis/', 'requirements.txt'],
-    'frontend': ['ui/src/', 'ui/package.json', 'ui/quasar.config.js', 'ui/eslint.config.js'],
-    'database': ['supabase/'],
-    'devops': ['docker-compose.yml', 'Dockerfile', 'nginx.conf', 'supervisord.conf'],
-    'docs': ['doc/', 'README.md', 'CLAUDE.md', 'LICENSE'],
-    'config': ['.gitignore', '.env', 'jsconfig.json', 'postcss.config.js'],
+DOC_EXTENSIONS = {".md", ".mdx", ".rst", ".txt"}
+DOC_BASENAMES = {
+    "README",
+    "README.md",
+    "README.mdx",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "LICENSE",
+    "LICENSE.md",
 }
+FRONTEND_EXTENSIONS = {".tsx", ".jsx", ".css", ".scss", ".sass", ".less", ".html", ".vue", ".svelte"}
+BACKEND_EXTENSIONS = {".py", ".rb", ".go", ".rs", ".java", ".kt", ".cs", ".php", ".scala"}
+SCRIPT_EXTENSIONS = {".sh", ".bash", ".zsh", ".ps1"}
+CONFIG_EXTENSIONS = {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf", ".properties"}
+ASSET_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".bmp", ".avif", ".ttf", ".otf", ".woff", ".woff2"}
+DATA_EXTENSIONS = {".sql", ".csv", ".tsv", ".parquet", ".jsonl"}
+SOURCE_EXTENSIONS = {".ts", ".js", ".mjs", ".cjs"}
+CI_PATH_PREFIXES = (".github/workflows/", ".circleci/", ".buildkite/")
+CI_FILENAMES = {"Jenkinsfile", ".gitlab-ci.yml", "azure-pipelines.yml", "azure-pipelines.yaml"}
+INFRA_MARKERS = {"terraform", "infra", "infrastructure", "helm", "charts", "k8s", "kubernetes", "ansible"}
+FRONTEND_MARKERS = {"web", "ui", "frontend", "client"}
+BACKEND_MARKERS = {"api", "apis", "server", "backend", "worker", "workers"}
+TEST_MARKERS = {"test", "tests", "spec", "specs", "__tests__", "__snapshots__"}
 
 
 def run_command(cmd: List[str]) -> Tuple[str, int]:
@@ -44,6 +62,12 @@ def get_current_branch() -> str:
     """Get the current git branch name."""
     output, _ = run_command(['git', 'branch', '--show-current'])
     return output
+
+
+def sanitize_branch_name(branch_name: str) -> str:
+    """Return a filesystem-safe branch slug."""
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", branch_name.replace("/", "-"))
+    return slug.strip("-") or "head"
 
 
 def get_changed_files(target_branch: str) -> List[Tuple[str, str]]:
@@ -73,17 +97,53 @@ def get_changed_files(target_branch: str) -> List[Tuple[str, str]]:
 
 
 def categorize_file(filepath: str) -> str:
-    """Categorize a file based on its path."""
-    for category, patterns in CATEGORIES.items():
-        for pattern in patterns:
-            if pattern.endswith('/'):
-                # Directory pattern
-                if filepath.startswith(pattern):
-                    return category
-            else:
-                # File or extension pattern
-                if filepath == pattern or filepath.endswith(pattern):
-                    return category
+    """Categorize a file using generic, repository-agnostic heuristics."""
+    path = PurePosixPath(filepath)
+    suffix = path.suffix.lower()
+    basename = path.name
+    lowered = filepath.lower()
+    parts = {part.lower() for part in path.parts}
+
+    if parts & TEST_MARKERS or re.search(r"(^|[._-])(test|spec)([._-]|$)", basename.lower()):
+        return 'tests'
+
+    if basename in DOC_BASENAMES or suffix in DOC_EXTENSIONS or 'docs' in parts or 'doc' in parts:
+        return 'docs'
+
+    if lowered.startswith(CI_PATH_PREFIXES) or basename in CI_FILENAMES:
+        return 'ci'
+
+    if basename == 'Dockerfile' or 'docker-compose' in basename.lower() or parts & INFRA_MARKERS:
+        return 'infrastructure'
+
+    if (path.parts and path.parts[0] == 'scripts') or suffix in SCRIPT_EXTENSIONS:
+        return 'scripts'
+
+    if basename.startswith('.') and suffix not in DOC_EXTENSIONS:
+        return 'config'
+
+    if basename in {'package.json', 'package-lock.json', 'pnpm-lock.yaml', 'yarn.lock'} or suffix in CONFIG_EXTENSIONS:
+        return 'config'
+
+    if suffix in ASSET_EXTENSIONS or parts & {'assets', 'images', 'img', 'media', 'static', 'public'}:
+        return 'assets'
+
+    if suffix in DATA_EXTENSIONS or parts & {'data', 'fixtures', 'migrations', 'seeds'}:
+        return 'data'
+
+    if suffix in FRONTEND_EXTENSIONS:
+        return 'frontend'
+
+    if suffix in BACKEND_EXTENSIONS:
+        return 'backend'
+
+    if suffix in SOURCE_EXTENSIONS:
+        if parts & FRONTEND_MARKERS:
+            return 'frontend'
+        if parts & BACKEND_MARKERS:
+            return 'backend'
+        return 'application'
+
     return 'other'
 
 
@@ -139,29 +199,137 @@ def get_diff_stats(target_branch: str) -> Dict[str, int]:
     return stats
 
 
-def infer_pr_type(changes_by_category: Dict[str, List], commit_messages: List[str]) -> str:
-    """Infer PR type from changes and commits."""
-    # Check commit messages for keywords
-    all_messages = ' '.join(commit_messages).lower()
+def summarize_categories(changes_by_category: Dict[str, List[Dict[str, str]]]) -> List[Dict[str, object]]:
+    """Return compact category summaries with sample files."""
+    summaries: List[Dict[str, object]] = []
+    for category, files in changes_by_category.items():
+        samples = [file_info['file'] for file_info in files[:3]]
+        statuses = Counter(file_info['status'] for file_info in files)
+        summaries.append({
+            'category': category,
+            'file_count': len(files),
+            'samples': samples,
+            'statuses': dict(sorted(statuses.items())),
+        })
 
-    if 'fix' in all_messages or 'bugfix' in all_messages:
-        return 'bugfix'
+    summaries.sort(key=lambda item: (-int(item['file_count']), str(item['category'])))
+    return summaries
 
-    # Check if only docs changed
-    if len(changes_by_category) == 1 and 'docs' in changes_by_category:
+
+def summarize_top_level_areas(changed_files: List[Tuple[str, str]]) -> List[Dict[str, object]]:
+    """Summarize changed files by top-level area."""
+    area_counts: Counter[str] = Counter()
+    area_samples: Dict[str, List[str]] = defaultdict(list)
+
+    for _, filepath in changed_files:
+        parts = filepath.split('/', 1)
+        area = parts[0] if len(parts) > 1 else '(repo root)'
+        area_counts[area] += 1
+        if len(area_samples[area]) < 3:
+            area_samples[area].append(filepath)
+
+    summaries = [
+        {
+            'area': area,
+            'file_count': count,
+            'samples': area_samples[area],
+        }
+        for area, count in area_counts.items()
+    ]
+    summaries.sort(key=lambda item: (-int(item['file_count']), str(item['area'])))
+    return summaries
+
+
+def measure_classification_confidence(changes_by_category: Dict[str, List[Dict[str, str]]], total_files: int) -> Dict[str, object]:
+    """Estimate whether the generic category split is trustworthy enough to show directly."""
+    other_files = len(changes_by_category.get('other', []))
+    coverage = 1.0 if total_files == 0 else (total_files - other_files) / total_files
+
+    if coverage >= 0.85:
+        confidence = 'high'
+    elif coverage >= 0.6:
+        confidence = 'medium'
+    else:
+        confidence = 'low'
+
+    return {
+        'strategy': 'generic',
+        'confidence': confidence,
+        'matched_files': total_files - other_files,
+        'other_files': other_files,
+        'coverage': round(coverage, 3),
+    }
+
+
+def extract_commit_subject(commit_line: str) -> str:
+    """Return the commit subject from a `git log --oneline` entry."""
+    parts = commit_line.split(' ', 1)
+    return parts[1] if len(parts) > 1 else commit_line
+
+
+def infer_pr_type(current_branch: str, changes_by_category: Dict[str, List[Dict[str, str]]], commit_messages: List[str]) -> str:
+    """Infer PR type from branch, changes, and commits."""
+    branch_prefix = current_branch.lower().split('/', 1)[0]
+    branch_type_map = {
+        'feature': 'feature',
+        'feat': 'feature',
+        'bugfix': 'bugfix',
+        'fix': 'bugfix',
+        'hotfix': 'bugfix',
+        'docs': 'docs',
+        'doc': 'docs',
+        'refactor': 'refactor',
+        'chore': 'chore',
+        'build': 'chore',
+        'ci': 'chore',
+    }
+    if branch_prefix in branch_type_map:
+        return branch_type_map[branch_prefix]
+
+    categories = set(changes_by_category)
+    if categories == {'docs'}:
         return 'docs'
 
-    # Check for chore/config only changes
-    config_only = all(cat in ['config', 'devops'] for cat in changes_by_category.keys())
-    if config_only:
+    if categories and categories.issubset({'config', 'ci', 'infrastructure', 'scripts'}):
         return 'chore'
 
-    # Default to feature
+    commit_type_counts: Counter[str] = Counter()
+    for message in commit_messages:
+        subject = extract_commit_subject(message)
+        match = re.match(r'(?P<kind>feat|fix|docs|refactor|chore|build|ci|test)(\(.+\))?!?:', subject)
+        if match:
+            commit_type_counts[match.group('kind')] += 1
+
+    total_typed_commits = sum(commit_type_counts.values())
+    fix_count = commit_type_counts.get('fix', 0)
+    feat_count = commit_type_counts.get('feat', 0)
+
+    if total_typed_commits > 0:
+        if fix_count > feat_count and fix_count >= max(2, (total_typed_commits + 1) // 2):
+            return 'bugfix'
+        if commit_type_counts.get('docs', 0) == total_typed_commits:
+            return 'docs'
+        if feat_count > 0:
+            return 'feature'
+        if commit_type_counts.get('refactor', 0) == total_typed_commits:
+            return 'refactor'
+        if commit_type_counts.get('chore', 0) + commit_type_counts.get('build', 0) + commit_type_counts.get('ci', 0) == total_typed_commits:
+            return 'chore'
+
     return 'feature'
 
 
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Analyze git changes for PR generation.')
+    parser.add_argument('target_branch', nargs='?', default='main', help='Target branch to compare against (default: main)')
+    parser.add_argument('--output', '-o', help='Optional JSON output path')
+    return parser
+
+
 def main():
-    target_branch = sys.argv[1] if len(sys.argv) > 1 else 'main'
+    parser = build_parser()
+    args = parser.parse_args()
+    target_branch = args.target_branch
 
     current_branch = get_current_branch()
     changed_files = get_changed_files(target_branch)
@@ -170,7 +338,7 @@ def main():
     diff_stats = get_diff_stats(target_branch)
 
     # Categorize changes
-    changes_by_category = defaultdict(list)
+    changes_by_category: Dict[str, List[Dict[str, str]]] = defaultdict(list)
     for status, filepath in changed_files:
         category = categorize_file(filepath)
         changes_by_category[category].append({
@@ -179,21 +347,35 @@ def main():
         })
 
     # Infer PR type
-    pr_type = infer_pr_type(changes_by_category, commit_messages)
+    pr_type = infer_pr_type(current_branch, changes_by_category, commit_messages)
+    total_files = len(changed_files)
+    category_summary = summarize_categories(dict(changes_by_category))
+    top_level_areas = summarize_top_level_areas(changed_files)
+    classification = measure_classification_confidence(dict(changes_by_category), total_files)
 
     # Build result
     result = {
         'current_branch': current_branch,
+        'branch_slug': sanitize_branch_name(current_branch),
         'target_branch': target_branch,
         'pr_type': pr_type,
         'stats': diff_stats,
         'commits': commit_messages,
         'issue_references': issue_refs,
         'changes_by_category': dict(changes_by_category),
-        'total_files': len(changed_files)
+        'category_summary': category_summary,
+        'top_level_areas': top_level_areas,
+        'classification': classification,
+        'total_files': total_files,
     }
 
-    print(json.dumps(result, indent=2))
+    payload = json.dumps(result, indent=2)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + '\n', encoding='utf-8')
+    else:
+        print(payload)
     return 0
 
 

--- a/.opencode/skills/pr-assistant/scripts/generate_pr_body.py
+++ b/.opencode/skills/pr-assistant/scripts/generate_pr_body.py
@@ -9,6 +9,7 @@ If output_file is not specified, prints to stdout.
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Dict, List
@@ -26,80 +27,112 @@ def load_analysis(analysis_path: str) -> Dict:
         return json.load(f)
 
 
+def strip_commit_prefix(subject: str) -> str:
+    """Drop conventional commit prefixes for cleaner prose."""
+    cleaned = re.sub(r'^(feat|fix|docs|refactor|chore|build|ci|test)(\(.+?\))?!?:\s*', '', subject)
+    return cleaned[:1].upper() + cleaned[1:] if cleaned else subject
+
+
+def format_stats(analysis: Dict) -> str:
+    """Format high-level diff statistics."""
+    stats = analysis.get('stats', {})
+    files = stats.get('files', 0)
+    insertions = stats.get('insertions', 0)
+    deletions = stats.get('deletions', 0)
+    return f"{files} files changed, {insertions} insertions, {deletions} deletions"
+
+
 def generate_summary(analysis: Dict) -> str:
     """Generate summary section from commits and changes."""
     commits = analysis.get('commits', [])
+    top_level_areas = analysis.get('top_level_areas', [])
 
     if not commits:
-        return "No commits found."
+        if top_level_areas:
+            areas = ', '.join(f"`{area['area']}`" for area in top_level_areas[:3])
+            return f"- Updates {format_stats(analysis)} across {areas}."
+        return f"- Updates {format_stats(analysis)}."
 
-    # Extract meaningful parts from commit messages (remove hash)
-    messages = []
+    messages: List[str] = []
+    seen = set()
     for commit in commits:
-        # Remove leading hash (e.g., "abc1234 Fix bug" -> "Fix bug")
         parts = commit.split(' ', 1)
-        if len(parts) > 1:
-            messages.append(parts[1])
-        else:
-            messages.append(commit)
+        subject = strip_commit_prefix(parts[1] if len(parts) > 1 else commit)
+        if subject not in seen:
+            seen.add(subject)
+            messages.append(subject)
 
     if len(messages) == 1:
-        return messages[0]
+        return f"- {messages[0]}"
 
-    # Multiple commits: create a list
     summary_lines = []
-    for msg in messages:
+    for msg in messages[:4]:
         summary_lines.append(f"- {msg}")
+
+    if len(messages) > 4:
+        additional_count = len(messages) - 4
+        summary_lines.append(f"- Additional supporting updates across {additional_count} more commit themes")
+
+    summary_lines.append(f"- Diff scope: {format_stats(analysis)}")
 
     return '\n'.join(summary_lines)
 
 
-def generate_changes_breakdown(analysis: Dict) -> str:
-    """Generate changes breakdown by category."""
-    changes = analysis.get('changes_by_category', {})
+def format_label(raw_label: str) -> str:
+    """Format category names for markdown output."""
+    return raw_label.replace('_', ' ').title()
 
-    if not changes:
+
+def format_samples(samples: List[str]) -> str:
+    """Format representative samples for summary bullets."""
+    if not samples:
+        return ""
+
+    sample_labels = [f"`{sample}`" for sample in samples[:3]]
+    if len(sample_labels) == 1:
+        return f", including {sample_labels[0]}"
+    if len(sample_labels) == 2:
+        return f", including {sample_labels[0]} and {sample_labels[1]}"
+    return f", including {sample_labels[0]}, {sample_labels[1]}, and {sample_labels[2]}"
+
+
+def generate_area_breakdown(analysis: Dict) -> str:
+    """Generate fallback changes breakdown using top-level areas."""
+    areas = analysis.get('top_level_areas', [])
+    lines = [f"- Diff scope: {format_stats(analysis)}."]
+
+    for area in areas[:5]:
+        lines.append(
+            f"- `{area['area']}`: {area['file_count']} file(s){format_samples(area.get('samples', []))}."
+        )
+
+    return '\n'.join(lines)
+
+
+def generate_changes_breakdown(analysis: Dict) -> str:
+    """Generate changes breakdown by category or top-level area."""
+    category_summary = analysis.get('category_summary', [])
+    classification = analysis.get('classification', {})
+
+    if not category_summary:
         return "No changes detected."
 
-    lines = []
+    if classification.get('confidence') == 'low':
+        return generate_area_breakdown(analysis)
 
-    category_icons = {
-        'backend': '🔧',
-        'frontend': '🎨',
-        'database': '🗄️',
-        'devops': '🚀',
-        'docs': '📝',
-        'config': '⚙️',
-        'other': '📦'
-    }
+    lines = [f"- Diff scope: {format_stats(analysis)}."]
+    for item in category_summary[:5]:
+        category = item['category']
+        if category == 'other':
+            continue
+        lines.append(
+            f"- {format_label(category)}: {item['file_count']} file(s){format_samples(item.get('samples', []))}."
+        )
 
-    category_names = {
-        'backend': 'Backend',
-        'frontend': 'Frontend',
-        'database': 'Database',
-        'devops': 'DevOps',
-        'docs': 'Documentation',
-        'config': 'Configuration',
-        'other': 'Other'
-    }
-
-    for category, files in sorted(changes.items()):
-        icon = category_icons.get(category, '📦')
-        name = category_names.get(category, category.capitalize())
-        lines.append(f"\n### {icon} {name}")
-
-        for file_info in files:
-            status = file_info['status']
-            filepath = file_info['file']
-
-            status_icon = {
-                'A': '➕',
-                'M': '✏️',
-                'D': '➖',
-                'R': '🔄'
-            }.get(status, '•')
-
-            lines.append(f"- {status_icon} `{filepath}`")
+    if classification.get('confidence') == 'medium':
+        other_files = classification.get('other_files', 0)
+        if other_files:
+            lines.append(f"- Additional uncategorized changes: {other_files} file(s); reviewer notes may need manual refinement.")
 
     return '\n'.join(lines)
 
@@ -119,35 +152,29 @@ def generate_checklist(analysis: Dict) -> str:
     changes = analysis.get('changes_by_category', {})
     checklist = []
 
-    # Always include basic items
     checklist.append("- [ ] Self-reviewed the code")
-    checklist.append("- [ ] No breaking changes (or documented)")
+    checklist.append("- [ ] Breaking changes documented (if any)")
 
-    # Add category-specific items
-    if 'backend' in changes:
-        checklist.append("- [ ] Backend tests added/updated")
-        checklist.append("- [ ] API documentation updated")
+    if 'frontend' in changes or 'backend' in changes or 'application' in changes:
+        checklist.append("- [ ] Automated tests added or updated as appropriate")
 
     if 'frontend' in changes:
-        checklist.append("- [ ] UI/UX reviewed")
-        checklist.append("- [ ] Browser compatibility checked")
-
-    if 'database' in changes:
-        checklist.append("- [ ] Database migration tested")
-        checklist.append("- [ ] Rollback plan documented")
+        checklist.append("- [ ] UI changes reviewed; screenshots added if useful")
 
     if 'docs' in changes:
-        checklist.append("- [ ] Documentation is clear and accurate")
+        checklist.append("- [ ] Documentation updated or confirmed unnecessary")
 
-    # Check for test files
+    if 'config' in changes or 'ci' in changes or 'infrastructure' in changes:
+        checklist.append("- [ ] Config, CI, or deployment impact reviewed")
+
     has_tests = any(
         'test' in file_info['file'].lower()
         for files in changes.values()
         for file_info in files
     )
 
-    if not has_tests and ('backend' in changes or 'frontend' in changes):
-        checklist.append("- [ ] ⚠️ Tests need to be added")
+    if not has_tests and ('backend' in changes or 'frontend' in changes or 'application' in changes):
+        checklist.append("- [ ] Follow-up test coverage considered")
 
     return '\n'.join(checklist)
 

--- a/.opencode/skills/pr-assistant/scripts/quality_checks.sh
+++ b/.opencode/skills/pr-assistant/scripts/quality_checks.sh
@@ -2,23 +2,17 @@
 # Quality checks before creating a PR
 # Returns JSON with check results
 
-set -e
+set -euo pipefail
 
 TARGET_BRANCH="${1:-main}"
-OUTPUT_JSON="{}"
+RESULTS=()
 
-# Function to add check result to JSON
 add_check() {
     local name="$1"
-    local status="$2"  # pass, warn, fail
+    local status="$2"
     local message="$3"
-
-    OUTPUT_JSON=$(echo "$OUTPUT_JSON" | jq --arg name "$name" --arg status "$status" --arg message "$message" \
-        '.checks += [{name: $name, status: $status, message: $message}]')
+    RESULTS+=("${name}"$'\t'"${status}"$'\t'"${message}")
 }
-
-# Initialize checks array
-OUTPUT_JSON=$(echo "$OUTPUT_JSON" | jq '.checks = []')
 
 # Check 1: Uncommitted changes
 if [[ -n $(git status --porcelain) ]]; then
@@ -28,7 +22,7 @@ else
 fi
 
 # Check 2: Merge conflicts
-if git merge-tree $(git merge-base HEAD "$TARGET_BRANCH") "$TARGET_BRANCH" HEAD | grep -q "^<<<<<"; then
+if git merge-tree "$(git merge-base HEAD "$TARGET_BRANCH")" "$TARGET_BRANCH" HEAD | grep -q "^<<<<<"; then
     add_check "merge_conflicts" "fail" "Merge conflicts detected with $TARGET_BRANCH"
 else
     add_check "merge_conflicts" "pass" "No merge conflicts"
@@ -43,15 +37,15 @@ else
 fi
 
 # Check 4: TODO/FIXME in changed files
-CHANGED_FILES=$(git diff --name-only "$TARGET_BRANCH...HEAD" | grep -E '\.(py|js|ts|vue|jsx|tsx)$' || true)
 TODO_COUNT=0
-if [[ -n "$CHANGED_FILES" ]]; then
-    while IFS= read -r file; do
-        if [[ -f "$file" ]]; then
-            TODO_COUNT=$((TODO_COUNT + $(grep -c -E '(TODO|FIXME)' "$file" 2>/dev/null || echo 0)))
+while IFS= read -r file; do
+    if [[ -f "$file" ]]; then
+        count=$(grep -c -E '(TODO|FIXME)' "$file" 2>/dev/null || true)
+        if [[ -n "$count" ]]; then
+            TODO_COUNT=$((TODO_COUNT + count))
         fi
-    done <<< "$CHANGED_FILES"
-fi
+    fi
+done < <(git diff --name-only "$TARGET_BRANCH...HEAD" | grep -E '\.(py|js|ts|tsx|jsx|vue)$' || true)
 
 if [[ "$TODO_COUNT" -gt 0 ]]; then
     add_check "todo_comments" "warn" "Found $TODO_COUNT TODO/FIXME comment(s) in changed files"
@@ -60,17 +54,19 @@ else
 fi
 
 # Check 5: Large files (>1MB)
-LARGE_FILES=$(git diff --name-only "$TARGET_BRANCH...HEAD" | while read -r file; do
+LARGE_FILES=()
+while IFS= read -r file; do
     if [[ -f "$file" ]]; then
         size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null || echo 0)
         if [[ "$size" -gt 1048576 ]]; then
-            echo "$file ($(numfmt --to=iec-i --suffix=B $size 2>/dev/null || echo "${size}B"))"
+            human_size=$(numfmt --to=iec-i --suffix=B "$size" 2>/dev/null || echo "${size}B")
+            LARGE_FILES+=("$file ($human_size)")
         fi
     fi
-done)
+done < <(git diff --name-only "$TARGET_BRANCH...HEAD")
 
-if [[ -n "$LARGE_FILES" ]]; then
-    add_check "large_files" "warn" "Large files detected: $(echo "$LARGE_FILES" | tr '\n' ', ' | sed 's/,$//')"
+if [[ ${#LARGE_FILES[@]} -gt 0 ]]; then
+    add_check "large_files" "warn" "Large files detected: $(printf '%s, ' "${LARGE_FILES[@]}" | sed 's/, $//')"
 else
     add_check "large_files" "pass" "No large files"
 fi
@@ -78,9 +74,8 @@ fi
 # Check 6: Test files for code changes
 HAS_CODE_CHANGES=false
 HAS_TEST_CHANGES=false
-
 while IFS= read -r file; do
-    if [[ "$file" =~ \.(py|js|ts|vue|jsx|tsx)$ ]]; then
+    if [[ "$file" =~ \.(py|js|ts|tsx|jsx|vue)$ ]]; then
         if [[ "$file" =~ (test|spec|__tests__|\.test\.|\.spec\.) ]]; then
             HAS_TEST_CHANGES=true
         else
@@ -98,19 +93,30 @@ else
 fi
 
 # Check 7: Dependencies changed
-DEPS_CHANGED=false
-if git diff --name-only "$TARGET_BRANCH...HEAD" | grep -qE '(requirements\.txt|package\.json|package-lock\.json)'; then
-    DEPS_CHANGED=true
+if git diff --name-only "$TARGET_BRANCH...HEAD" | grep -qE '(requirements\.txt|package\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)'; then
     add_check "dependencies" "warn" "Dependency files changed - ensure they are properly reviewed"
 else
     add_check "dependencies" "pass" "No dependency changes"
 fi
 
-# Summary
-FAIL_COUNT=$(echo "$OUTPUT_JSON" | jq '[.checks[] | select(.status == "fail")] | length')
-WARN_COUNT=$(echo "$OUTPUT_JSON" | jq '[.checks[] | select(.status == "warn")] | length')
+printf '%s\n' "${RESULTS[@]}" | python3 -c '
+import json
+import sys
 
-OUTPUT_JSON=$(echo "$OUTPUT_JSON" | jq --arg fc "$FAIL_COUNT" --arg wc "$WARN_COUNT" \
-    '.summary = {failures: ($fc | tonumber), warnings: ($wc | tonumber)}')
+checks = []
+for raw_line in sys.stdin.read().splitlines():
+    if not raw_line:
+        continue
+    name, status, message = raw_line.split("\t", 2)
+    checks.append({"name": name, "status": status, "message": message})
 
-echo "$OUTPUT_JSON" | jq .
+payload = {
+    "checks": checks,
+    "summary": {
+        "failures": sum(1 for check in checks if check["status"] == "fail"),
+        "warnings": sum(1 for check in checks if check["status"] == "warn"),
+    },
+}
+
+print(json.dumps(payload, indent=2))
+'


### PR DESCRIPTION
## 📝 Summary

- Improve the `pr-assistant` skill so it can generate cleaner PR drafts across repositories.
- Move generated PR artifacts into skill-local `outputs/` storage with local ignore rules.

## 🎯 Motivation

The previous `pr-assistant` implementation was too repository-specific, depended on `jq` for quality checks, and produced PR drafts that were often too verbose to review comfortably.

This update makes the skill more portable across repositories, reduces environment assumptions, and improves the default PR drafting workflow and output storage model.

## 🔧 Changes Overview

- Diff scope: 9 files changed, 436 insertions, 179 deletions.
- Skill and templates: update the workflow guidance, immediate-create behavior, and template wording for more concise reviewer-facing PR bodies.
- Analysis pipeline: replace repository-specific categorization with generic confidence-aware classification and better PR-type inference.
- Quality checks: remove the `jq` dependency and keep JSON output using `bash + python3` only.
- Output handling: standardize skill-local generated artifact storage under `pr-assistant/outputs/` and ignore it locally.
- Local ignore support: add `.opencode/.gitignore` and `.opencode/skills/pr-assistant/.gitignore` for generated files.

## ✅ Testing

- [x] `python3 -m py_compile .opencode/skills/pr-assistant/scripts/analyze_changes.py .opencode/skills/pr-assistant/scripts/generate_pr_body.py`
- [x] `bash -n .opencode/skills/pr-assistant/scripts/quality_checks.sh`
- [x] `bash .opencode/skills/pr-assistant/scripts/quality_checks.sh origin/main`
- [x] `python3 .opencode/skills/pr-assistant/scripts/analyze_changes.py origin/main --output ...`
- [x] `python3 .opencode/skills/pr-assistant/scripts/generate_pr_body.py ...`
- [x] Confirmed `outputs/` is ignored by `.opencode/skills/pr-assistant/.gitignore`

## 📸 Screenshots

Not applicable.

## 🔗 Related Issues

None

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented or not required
- [x] Documentation and skill guidance updated
- [x] Config impact reviewed for local ignore files
- [x] Follow-up test coverage considered

## 📌 Notes

- This PR is intentionally scoped to the `pr-assistant` skill and related local ignore behavior.
- No dedicated test files were added; validation was done by executing the updated helper scripts directly.
