### PR TITLE
feat: preserve mission layout and show in-progress missions

### DIFF
--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -138,6 +138,7 @@ export interface MissionSummary {
   updatedAt: string;
   archivedAt?: string | null;
   status: "active" | "completed" | "archived";
+  activitySessionIds: string[];
 }
 
 export type MissionResumePayload = {

--- a/web/app/hooks/use-session-status-feed.ts
+++ b/web/app/hooks/use-session-status-feed.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from "react";
+import {
+  coerceSessionStatus,
+  fetchSessionStatuses,
+  isSessionStatusActive,
+  type SessionStatus,
+} from "@/lib/session-status";
+import { useChatStore } from "@/stores/chat-store";
+
+type SessionStatusEventPayload = {
+  type: string;
+  properties: {
+    sessionID?: string;
+    status?: {
+      type?: SessionStatus;
+    };
+  };
+};
+
+export function useSessionStatusFeed(options?: {
+  enabled?: boolean;
+  onSessionIdle?: (sessionId: string) => void;
+}): Record<string, SessionStatus> {
+  const enabled = options?.enabled ?? true;
+  const onSessionIdle = options?.onSessionIdle;
+  const sessionStates = useChatStore((state) => state.sessionStates);
+  const setServerSessionState = useChatStore((state) => state.setServerSessionState);
+  const replaceServerSessionStates = useChatStore((state) => state.replaceServerSessionStates);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      return;
+    }
+
+    let cancelled = false;
+
+    void fetchSessionStatuses()
+      .then((statuses) => {
+        if (!cancelled) {
+          replaceServerSessionStates(statuses);
+        }
+      })
+      .catch(() => undefined);
+
+    const source = new EventSource("/api/event-stream");
+    source.onmessage = (event) => {
+      const payload = JSON.parse(event.data as string) as
+        | { payload?: SessionStatusEventPayload }
+        | SessionStatusEventPayload;
+      const actual = ("payload" in payload ? payload.payload : payload) as SessionStatusEventPayload;
+      if (!actual?.type) {
+        return;
+      }
+
+      if (actual.type === "session.status") {
+        const eventSessionId = actual.properties.sessionID;
+        const nextStatus = coerceSessionStatus(actual.properties.status?.type);
+        if (eventSessionId && nextStatus) {
+          setServerSessionState(eventSessionId, nextStatus);
+        }
+      }
+
+      if (actual.type === "session.idle") {
+        const eventSessionId = actual.properties.sessionID;
+        if (eventSessionId) {
+          setServerSessionState(eventSessionId, "idle");
+          onSessionIdle?.(eventSessionId);
+        }
+      }
+    };
+    source.onerror = () => {
+      source.close();
+    };
+
+    return () => {
+      cancelled = true;
+      source.close();
+    };
+  }, [enabled, onSessionIdle, replaceServerSessionStates, setServerSessionState]);
+
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const hasBusy = Object.values(sessionStates).some((status) => isSessionStatusActive(status));
+
+    if (hasBusy && !pollingIntervalRef.current) {
+      pollingIntervalRef.current = setInterval(async () => {
+        try {
+          const statuses = await fetchSessionStatuses();
+          replaceServerSessionStates(statuses);
+        } catch (_) {
+          void _;
+        }
+      }, 3000);
+    }
+
+    if (!hasBusy && pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+        pollingIntervalRef.current = null;
+      }
+    };
+  }, [enabled, replaceServerSessionStates, sessionStates]);
+
+  return sessionStates;
+}

--- a/web/app/lib/mission-list-running-state.test.ts
+++ b/web/app/lib/mission-list-running-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { MissionSummary } from "@/lib/types/mission";
+import { isMissionSummaryRunning } from "./mission-list-running-state";
+
+function createMissionSummary(activitySessionIds: string[]): MissionSummary {
+  return {
+    missionId: "mission-1",
+    title: "Mission",
+    createdAt: "2026-04-13T00:00:00.000Z",
+    updatedAt: "2026-04-13T00:00:00.000Z",
+    status: "active",
+    activitySessionIds,
+  };
+}
+
+describe("mission-list-running-state", () => {
+  it("returns true when the primary mission session is active", () => {
+    expect(
+      isMissionSummaryRunning(createMissionSummary(["session-primary"]), {
+        "session-primary": "busy",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when only a worker mission session is active", () => {
+    expect(
+      isMissionSummaryRunning(createMissionSummary(["session-primary", "session-worker"]), {
+        "session-primary": "idle",
+        "session-worker": "retry",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when all mission-owned sessions are settled", () => {
+    expect(
+      isMissionSummaryRunning(createMissionSummary(["session-primary", "session-worker"]), {
+        "session-primary": "idle",
+        "session-worker": "idle",
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/app/lib/mission-list-running-state.ts
+++ b/web/app/lib/mission-list-running-state.ts
@@ -1,0 +1,11 @@
+import { isSessionStatusActive, type SessionStatus } from "@/lib/session-status";
+import type { MissionSummary } from "@/lib/types/mission";
+
+export function isMissionSummaryRunning(
+  mission: Pick<MissionSummary, "activitySessionIds">,
+  sessionStates: Record<string, SessionStatus | null | undefined>,
+): boolean {
+  return mission.activitySessionIds.some((sessionId) =>
+    isSessionStatusActive(sessionStates[sessionId] ?? null),
+  );
+}

--- a/web/app/lib/mission-store.test.ts
+++ b/web/app/lib/mission-store.test.ts
@@ -12,6 +12,7 @@ import {
   getMission,
   getMissionFilePath,
   listMissionSummaries,
+  setWorkerSession,
 } from "./mission-store";
 
 const tempRoots: string[] = [];
@@ -303,6 +304,25 @@ describe("mission store", () => {
     expect(getMission("legacy-flat")).toBeUndefined();
     expect(listMissionSummaries({ view: "all" })).toEqual([
       expect.objectContaining({ missionId: "mission-listed", title: "Listed Mission" }),
+    ]);
+  });
+
+  it("flattens primary and worker activity session ids into mission summaries", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-running-summary", "session-primary", {
+      title: "Running Summary Mission",
+    });
+    missionIds.push(mission.id);
+
+    setWorkerSession(mission.id, "ignis", "session-ignis");
+    setWorkerSession(mission.id, "prompto", "session-prompto");
+
+    expect(listMissionSummaries({ view: "all" })).toEqual([
+      expect.objectContaining({
+        missionId: "mission-running-summary",
+        activitySessionIds: ["session-primary", "session-ignis", "session-prompto"],
+      }),
     ]);
   });
 });

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -331,6 +331,17 @@ function readMissionFromDisk(id: string): Mission | null {
 }
 
 function toMissionSummary(mission: Mission): MissionSummary {
+  const activitySessionIds = [
+    getMissionPrimarySessionId(mission),
+    mission.workerSessions.ignis,
+    mission.workerSessions.gladiolus,
+    mission.workerSessions.prompto,
+  ].filter((sessionId, index, values): sessionId is string => {
+    return (
+      typeof sessionId === "string" && sessionId.length > 0 && values.indexOf(sessionId) === index
+    );
+  });
+
   return {
     missionId: mission.id,
     title: mission.title,
@@ -339,6 +350,7 @@ function toMissionSummary(mission: Mission): MissionSummary {
     updatedAt: mission.updatedAt,
     archivedAt: mission.archivedAt,
     status: mission.status,
+    activitySessionIds,
   };
 }
 

--- a/web/app/lib/types/mission.ts
+++ b/web/app/lib/types/mission.ts
@@ -300,6 +300,7 @@ export interface MissionSummary {
   updatedAt: string;
   archivedAt?: string;
   status: MissionStatus;
+  activitySessionIds: string[];
 }
 
 export interface MissionOutputSummary {

--- a/web/app/routes/_layout.lunafreya.mission.$id/route.test.tsx
+++ b/web/app/routes/_layout.lunafreya.mission.$id/route.test.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+
+  return {
+    ...actual,
+    Outlet: () => <div>nested-route</div>,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+import { LunafreyaMissionPage } from "./route";
+
+const TestPage = LunafreyaMissionPage as unknown as (props: { loaderData: unknown }) => ReactNode;
+
+describe("lunafreya mission route", () => {
+  it("renders only nested mission detail content when the mission exists", () => {
+    const markup = renderToStaticMarkup(
+      <TestPage loaderData={{ exists: true, requestedMissionId: "mission-luna" }} />,
+    );
+
+    expect(markup).toContain("nested-route");
+    expect(markup).not.toContain("screen:");
+  });
+});

--- a/web/app/routes/_layout.lunafreya.mission.$id/route.tsx
+++ b/web/app/routes/_layout.lunafreya.mission.$id/route.tsx
@@ -1,12 +1,9 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router";
 import { toast } from "sonner";
-import { readAppLanguage } from "@/lib/app-language.server";
-import type { MessageInfo } from "@/routes/_layout.opencode.session.$id/types";
-import { NoctisTeamScreen } from "../_layout.noctis-team/components/noctis-team-screen";
 import type { Route } from "./+types/route";
 
-const LunafreyaMissionPage = ({ loaderData }: Route.ComponentProps) => {
+export const LunafreyaMissionPage = ({ loaderData }: Route.ComponentProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -22,66 +19,26 @@ const LunafreyaMissionPage = ({ loaderData }: Route.ComponentProps) => {
     navigate("/lunafreya", { replace: true });
   }, [loaderData.exists, loaderData.requestedMissionId, navigate]);
 
-  return (
-    <>
-      <NoctisTeamScreen
-        activeMissionId={loaderData.exists ? loaderData.requestedMissionId : null}
-        language={loaderData.language}
-        initialMessageInfos={loaderData.messages}
-        initialMissionData={loaderData.mission}
-        surfaceId="lunafreya"
-      />
-      <Outlet />
-    </>
-  );
+  return <Outlet />;
 };
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
-  const language = readAppLanguage();
   const requestedMissionId = params.id ?? null;
   if (!requestedMissionId) {
-    return { exists: false, requestedMissionId, language };
+    return { exists: false, requestedMissionId };
   }
 
   try {
     const url = new URL(request.url);
     const response = await fetch(`${url.origin}/api/lunafreya/missions/${requestedMissionId}`);
-    if (!response.ok) {
-      return {
-        exists: false,
-        language,
-        requestedMissionId,
-        mission: null,
-        messages: null,
-      };
-    }
-
-    const mission = await response.json();
-    const primarySessionId =
-      mission.primarySessionId ?? mission.sessions?.primary ?? mission.sessions?.noctis ?? null;
-    const messages = primarySessionId
-      ? await (async () => {
-          const messagesResponse = await fetch(`${url.origin}/api/session/${primarySessionId}`);
-          return messagesResponse.ok
-            ? (((await messagesResponse.json()) as { messages?: MessageInfo[] }).messages ?? [])
-            : null;
-        })()
-      : [];
-
     return {
-      exists: true,
-      language,
+      exists: response.ok,
       requestedMissionId,
-      mission,
-      messages,
     };
   } catch {
     return {
       exists: false,
-      language,
       requestedMissionId,
-      mission: null,
-      messages: null,
     };
   }
 };

--- a/web/app/routes/_layout.lunafreya/route.test.tsx
+++ b/web/app/routes/_layout.lunafreya/route.test.tsx
@@ -12,7 +12,10 @@ vi.mock("react-router", async () => {
 
   return {
     ...actual,
-    Outlet: () => <div>nested-route</div>,
+    Outlet: () => {
+      const params = paramsMock();
+      return params.id ? <div>nested-route</div> : null;
+    },
     useLocation: () => ({ state: null }),
     useNavigate: () => navigateMock,
     useParams: () => paramsMock(),
@@ -43,12 +46,12 @@ describe("lunafreya layout route", () => {
     expect(markup).not.toContain("nested-route");
   });
 
-  it("renders the child mission route when a mission URL is active", () => {
+  it("keeps the Lunafreya mission surface screen mounted when a mission URL is active", () => {
     paramsMock.mockReturnValue({ id: "mission-luna" });
 
     const markup = renderToStaticMarkup(<TestPage loaderData={{ language: "other" }} />);
 
     expect(markup).toContain("nested-route");
-    expect(markup).not.toContain("screen:lunafreya:mission-luna");
+    expect(markup).toContain("screen:lunafreya:mission-luna");
   });
 });

--- a/web/app/routes/_layout.lunafreya/route.tsx
+++ b/web/app/routes/_layout.lunafreya/route.tsx
@@ -1,64 +1,9 @@
-import { useEffect } from "react";
-import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { readAppLanguage } from "@/lib/app-language.server";
 import type { Route } from "./+types/route";
-import { NoctisTeamScreen } from "../_layout.noctis-team/components/noctis-team-screen";
-
-const LAST_MISSION_STORAGE_KEY = "lunafreya:last-mission-id";
+import { MissionSurfaceRouteShell } from "../_layout.noctis-team/components/mission-surface-route-shell";
 
 export const LunafreyaPage = ({ loaderData }: Route.ComponentProps) => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const params = useParams();
-  const activeMissionId = params.id ?? null;
-  const shouldSkipMissionRestore =
-    location.state !== null &&
-    typeof location.state === "object" &&
-    "skipMissionRestore" in location.state &&
-    location.state.skipMissionRestore === true;
-
-  useEffect(() => {
-    if (activeMissionId || shouldSkipMissionRestore || typeof window === "undefined") {
-      return;
-    }
-
-    const lastMissionId = window.localStorage.getItem(LAST_MISSION_STORAGE_KEY);
-    if (!lastMissionId) {
-      return;
-    }
-
-    void (async () => {
-      try {
-        const response = await fetch(`/api/lunafreya/missions/${lastMissionId}`);
-        if (!response.ok) {
-          window.localStorage.removeItem(LAST_MISSION_STORAGE_KEY);
-          return;
-        }
-
-        const mission = (await response.json()) as { status?: string };
-        if (mission.status === "archived") {
-          window.localStorage.removeItem(LAST_MISSION_STORAGE_KEY);
-          return;
-        }
-
-        navigate(`/lunafreya/mission/${lastMissionId}`, { replace: true });
-      } catch {
-        return;
-      }
-    })();
-  }, [activeMissionId, navigate, shouldSkipMissionRestore]);
-
-  if (activeMissionId) {
-    return <Outlet />;
-  }
-
-  return (
-    <NoctisTeamScreen
-      activeMissionId={activeMissionId}
-      language={loaderData.language}
-      surfaceId="lunafreya"
-    />
-  );
+  return <MissionSurfaceRouteShell language={loaderData.language} surfaceId="lunafreya" />;
 };
 
 export const loader = async () => {

--- a/web/app/routes/_layout.noctis-team.mission.$id/route.test.tsx
+++ b/web/app/routes/_layout.noctis-team.mission.$id/route.test.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+
+  return {
+    ...actual,
+    Outlet: () => <div>nested-route</div>,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+import { NoctisTeamMissionPage } from "./route";
+
+const TestPage = NoctisTeamMissionPage as unknown as (props: { loaderData: unknown }) => ReactNode;
+
+describe("noctis-team mission route", () => {
+  it("renders only nested mission detail content when the mission exists", () => {
+    const markup = renderToStaticMarkup(
+      <TestPage loaderData={{ exists: true, requestedMissionId: "mission-123" }} />,
+    );
+
+    expect(markup).toContain("nested-route");
+    expect(markup).not.toContain("screen:");
+  });
+});

--- a/web/app/routes/_layout.noctis-team.mission.$id/route.tsx
+++ b/web/app/routes/_layout.noctis-team.mission.$id/route.tsx
@@ -1,12 +1,9 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router";
 import { toast } from "sonner";
-import { readAppLanguage } from "@/lib/app-language.server";
-import type { MessageInfo } from "@/routes/_layout.opencode.session.$id/types";
-import { NoctisTeamScreen } from "../_layout.noctis-team/components/noctis-team-screen";
 import type { Route } from "./+types/route";
 
-const NoctisTeamMissionPage = ({ loaderData }: Route.ComponentProps) => {
+export const NoctisTeamMissionPage = ({ loaderData }: Route.ComponentProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -22,63 +19,26 @@ const NoctisTeamMissionPage = ({ loaderData }: Route.ComponentProps) => {
     navigate("/noctis-team", { replace: true });
   }, [loaderData.exists, loaderData.requestedMissionId, navigate]);
 
-  return (
-    <>
-      <NoctisTeamScreen
-        activeMissionId={loaderData.exists ? loaderData.requestedMissionId : null}
-        language={loaderData.language}
-        initialMessageInfos={loaderData.messages}
-        initialMissionData={loaderData.mission}
-      />
-      <Outlet />
-    </>
-  );
+  return <Outlet />;
 };
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
-  const language = readAppLanguage();
   const requestedMissionId = params.id ?? null;
   if (!requestedMissionId) {
-    return { exists: false, requestedMissionId, language };
+    return { exists: false, requestedMissionId };
   }
 
   try {
     const url = new URL(request.url);
     const response = await fetch(`${url.origin}/api/noctis/missions/${requestedMissionId}`);
-    if (!response.ok) {
-      return {
-        exists: false,
-        language,
-        requestedMissionId,
-        mission: null,
-        messages: null,
-      };
-    }
-
-    const mission = await response.json();
-    const messages = mission.sessions?.noctis
-      ? await (async () => {
-          const messagesResponse = await fetch(`${url.origin}/api/session/${mission.sessions.noctis}`);
-          return messagesResponse.ok
-            ? (((await messagesResponse.json()) as { messages?: MessageInfo[] }).messages ?? [])
-            : null;
-        })()
-      : [];
-
     return {
-      exists: true,
-      language,
+      exists: response.ok,
       requestedMissionId,
-      mission,
-      messages,
     };
   } catch {
     return {
       exists: false,
-      language,
       requestedMissionId,
-      mission: null,
-      messages: null,
     };
   }
 };

--- a/web/app/routes/_layout.noctis-team/components/mission-history-item.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/mission-history-item.test.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { MissionSummary } from "@/lib/types/mission";
+import { MissionHistoryItem } from "./mission-history-item";
+
+vi.mock("react-router", () => ({
+  NavLink: ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+}));
+
+function createMissionSummary(overrides: Partial<MissionSummary> = {}): MissionSummary {
+  return {
+    missionId: "mission-1",
+    title: "Mission One",
+    createdAt: "2026-04-13T00:00:00.000Z",
+    updatedAt: "2026-04-13T00:00:00.000Z",
+    status: "active",
+    activitySessionIds: ["session-1"],
+    ...overrides,
+  };
+}
+
+describe("MissionHistoryItem", () => {
+  it("shows the running spinner for a running Noctis Team mission row", () => {
+    const markup = renderToStaticMarkup(
+      <MissionHistoryItem
+        mission={createMissionSummary()}
+        routeBase="/noctis-team"
+        isActive={false}
+        isArchivedView={false}
+        isEditing={false}
+        isArchivePending={false}
+        isArchiveDisabled={false}
+        isRenaming={false}
+        isRunning={true}
+        onBeginRename={vi.fn()}
+        onArchiveAction={vi.fn()}
+        onCancelRename={vi.fn()}
+        onSubmitRename={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("animate-spin");
+    expect(markup).toContain("/noctis-team/mission/mission-1");
+  });
+
+  it("keeps the shared running indicator behavior for Lunafreya mission rows", () => {
+    const markup = renderToStaticMarkup(
+      <MissionHistoryItem
+        mission={createMissionSummary({ missionId: "mission-luna" })}
+        routeBase="/lunafreya"
+        isActive={false}
+        isArchivedView={false}
+        isEditing={false}
+        isArchivePending={false}
+        isArchiveDisabled={false}
+        isRenaming={false}
+        isRunning={true}
+        onBeginRename={vi.fn()}
+        onArchiveAction={vi.fn()}
+        onCancelRename={vi.fn()}
+        onSubmitRename={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("animate-spin");
+    expect(markup).toContain("/lunafreya/mission/mission-luna");
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/mission-history-item.tsx
+++ b/web/app/routes/_layout.noctis-team/components/mission-history-item.tsx
@@ -1,0 +1,171 @@
+import { Archive, Check, LoaderCircle, Pencil, RotateCcw, X } from "lucide-react";
+import { memo, useEffect, useState } from "react";
+import { NavLink } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { MissionSummary } from "@/hooks/use-agent-session";
+import { cn } from "@/lib/utils";
+import { buildMissionPath } from "./output-detail-routing";
+
+export type MissionHistoryItemProps = {
+  mission: MissionSummary;
+  routeBase: string;
+  isActive: boolean;
+  isArchivedView: boolean;
+  isEditing: boolean;
+  isArchivePending: boolean;
+  isArchiveDisabled: boolean;
+  isRenaming: boolean;
+  isRunning: boolean;
+  onBeginRename: (mission: MissionSummary) => void;
+  onArchiveAction: (mission: MissionSummary, action: "archive" | "restore") => void;
+  onCancelRename: () => void;
+  onSubmitRename: (missionId: string, title: string) => void;
+};
+
+export const MissionHistoryItem = memo(
+  ({
+    mission,
+    routeBase,
+    isActive,
+    isArchivedView,
+    isEditing,
+    isArchivePending,
+    isArchiveDisabled,
+    isRenaming,
+    isRunning,
+    onBeginRename,
+    onArchiveAction,
+    onCancelRename,
+    onSubmitRename,
+  }: MissionHistoryItemProps) => {
+    const [draftTitle, setDraftTitle] = useState(mission.title || "Untitled mission");
+
+    useEffect(() => {
+      if (isEditing) {
+        setDraftTitle(mission.title || "Untitled mission");
+      }
+    }, [isEditing, mission.title]);
+
+    if (isEditing) {
+      return (
+        <div className="rounded-xl border border-primary/30 bg-primary/8 p-3">
+          <Textarea
+            value={draftTitle}
+            onChange={(event) => setDraftTitle(event.target.value)}
+            rows={2}
+            disabled={isRenaming}
+            className="min-h-14 resize-none bg-transparent text-xs"
+          />
+          <div className="mt-2 flex items-center justify-end gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onCancelRename}
+              disabled={isRenaming}
+              title="Cancel rename"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => onSubmitRename(mission.missionId, draftTitle)}
+              disabled={isRenaming || !draftTitle.trim()}
+              title="Save title"
+            >
+              <Check className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={cn(
+          "group relative w-full min-w-0 max-w-full overflow-hidden rounded-xl border p-3 transition-colors",
+          isActive ? "border-primary/40 bg-primary/10" : "border-border/50 bg-card/40 hover:bg-card/70",
+        )}
+      >
+        <NavLink
+          aria-label={`Open mission ${mission.title}`}
+          className="absolute inset-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
+          to={buildMissionPath(mission.missionId, routeBase)}
+        />
+        <div className="grid w-full min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-2 overflow-hidden">
+          <div className="pointer-events-none min-w-0 overflow-hidden">
+            <div className="flex min-w-0 items-start gap-2">
+              {isRunning ? <LoaderCircle className="mt-0.5 h-4 w-4 shrink-0 animate-spin" /> : null}
+              <span className="block min-w-0 font-semibold text-sm leading-5 line-clamp-2 wrap-break-word">
+                {mission.title}
+              </span>
+            </div>
+            <div className="mt-2 flex min-w-0 items-center gap-2">
+              <span className="max-w-24 shrink-0 truncate rounded-full border border-border/50 px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-muted-foreground/70">
+                {mission.status}
+              </span>
+              <p className="min-w-0 flex-1 truncate text-right font-mono text-[9px] uppercase tracking-widest text-muted-foreground/40">
+                {new Date(mission.updatedAt).toLocaleString("en-US", {
+                  year: "numeric",
+                  month: "2-digit",
+                  day: "2-digit",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  hour12: false,
+                })}
+              </p>
+            </div>
+          </div>
+          <div className="relative z-10 flex items-center gap-1">
+            {!isArchivedView ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "h-6 w-6 shrink-0 transition-[opacity,color,background-color]",
+                  "bg-background/30 text-foreground/70 opacity-0",
+                  "group-hover:opacity-100 hover:bg-accent hover:text-foreground",
+                  "focus-visible:opacity-100",
+                )}
+                onClick={() => onBeginRename(mission)}
+                title="Rename mission"
+              >
+                <Pencil className="h-3 w-3" />
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-6 w-6 shrink-0 transition-[opacity,color,background-color]",
+                "bg-background/30 text-foreground/70 opacity-0",
+                "group-hover:opacity-100 hover:bg-accent hover:text-foreground",
+                "focus-visible:opacity-100",
+              )}
+              onClick={() => onArchiveAction(mission, isArchivedView ? "restore" : "archive")}
+              disabled={isArchivePending || isArchiveDisabled}
+              title={
+                isArchivedView
+                  ? "Restore mission"
+                  : isArchiveDisabled
+                    ? "Active mission cannot be archived while running"
+                    : "Archive mission"
+              }
+            >
+              {isArchivedView ? <RotateCcw className="h-3 w-3" /> : <Archive className="h-3 w-3" />}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+MissionHistoryItem.displayName = "MissionHistoryItem";

--- a/web/app/routes/_layout.noctis-team/components/mission-surface-route-shell.tsx
+++ b/web/app/routes/_layout.noctis-team/components/mission-surface-route-shell.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { Outlet, useLocation, useNavigate, useParams } from "react-router";
+import type { AppLanguage } from "@/lib/app-language.server";
+import { getMissionSurface } from "@/lib/mission-surface";
+import type { MissionSurfaceId } from "@/lib/types/mission";
+import { NoctisTeamScreen } from "./noctis-team-screen";
+
+export interface MissionSurfaceRouteShellProps {
+  language: AppLanguage;
+  surfaceId?: MissionSurfaceId;
+}
+
+const getMissionApiBase = (surfaceId: MissionSurfaceId) =>
+  surfaceId === "lunafreya" ? "/api/lunafreya/missions" : "/api/noctis/missions";
+
+export const MissionSurfaceRouteShell = ({
+  language,
+  surfaceId = "noctis_team",
+}: MissionSurfaceRouteShellProps) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const params = useParams();
+  const activeMissionId = params.id ?? null;
+  const surface = getMissionSurface(surfaceId);
+  const shouldSkipMissionRestore =
+    location.state !== null &&
+    typeof location.state === "object" &&
+    "skipMissionRestore" in location.state &&
+    location.state.skipMissionRestore === true;
+
+  useEffect(() => {
+    if (activeMissionId || shouldSkipMissionRestore || typeof window === "undefined") {
+      return;
+    }
+
+    const lastMissionId = window.localStorage.getItem(surface.lastMissionStorageKey);
+    if (!lastMissionId) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const response = await fetch(`${getMissionApiBase(surface.id)}/${lastMissionId}`);
+        if (!response.ok) {
+          window.localStorage.removeItem(surface.lastMissionStorageKey);
+          return;
+        }
+
+        const mission = (await response.json()) as { status?: string };
+        if (mission.status === "archived") {
+          window.localStorage.removeItem(surface.lastMissionStorageKey);
+          return;
+        }
+
+        navigate(`${surface.routeBase}/mission/${lastMissionId}`, { replace: true });
+      } catch {
+        return;
+      }
+    })();
+  }, [activeMissionId, navigate, shouldSkipMissionRestore, surface]);
+
+  return (
+    <>
+      <NoctisTeamScreen activeMissionId={activeMissionId} language={language} surfaceId={surface.id} />
+      <Outlet />
+    </>
+  );
+};

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -1,6 +1,6 @@
-import { Archive, Check, Ellipsis, History, Pencil, Plus, RotateCcw, X } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { NavLink, useMatch, useNavigate, useParams } from "react-router";
+import { Ellipsis, History, Plus } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMatch, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { WorkspaceLaunchActions } from "@/components/workspace-launch-actions";
 import { Button } from "@/components/ui/button";
@@ -27,7 +27,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   type MissionResumePayload,
@@ -35,6 +34,7 @@ import {
   useAgentSession,
 } from "@/hooks/use-agent-session";
 import { useProjectRegistry } from "@/hooks/use-project-registry";
+import { useSessionStatusFeed } from "@/hooks/use-session-status-feed";
 import { useVSCodePreferences } from "@/hooks/use-vscode-preferences";
 import type { AppLanguage } from "@/lib/app-language.server";
 import { normalizeContextProjectIds } from "@/lib/execution-context";
@@ -54,12 +54,14 @@ import type {
   MissionOutputSummary,
   MissionSurfaceId,
 } from "@/lib/types/mission";
+import { isMissionSummaryRunning } from "@/lib/mission-list-running-state";
 import { cn } from "@/lib/utils";
 import type { PromptPart } from "@/lib/prompt-parts";
 import type { MessageInfo } from "@/routes/_layout.opencode.session.$id/types";
 import { BanterLog } from "./banter-log";
 import { ChatArea } from "./chat-area";
 import { LunafreyaStatusPanel, type LunafreyaFacetOption } from "./lunafreya-status-panel";
+import { MissionHistoryItem } from "./mission-history-item";
 import { MissionActivityLog } from "./mission-activity-log";
 import {
   getMissionOutputKey,
@@ -82,162 +84,6 @@ type BulkMissionDialogState = {
 } | null;
 
 type InspectorTab = "banter" | "activity" | "outputs";
-
-type MissionHistoryItemProps = {
-  mission: MissionSummary;
-  routeBase: string;
-  isActive: boolean;
-  isArchivedView: boolean;
-  isEditing: boolean;
-  isArchivePending: boolean;
-  isArchiveDisabled: boolean;
-  isRenaming: boolean;
-  onBeginRename: (mission: MissionSummary) => void;
-  onArchiveAction: (mission: MissionSummary, action: "archive" | "restore") => void;
-  onCancelRename: () => void;
-  onSubmitRename: (missionId: string, title: string) => void;
-};
-
-const MissionHistoryItem = memo(
-  ({
-    mission,
-    routeBase,
-    isActive,
-    isArchivedView,
-    isEditing,
-    isArchivePending,
-    isArchiveDisabled,
-    isRenaming,
-    onBeginRename,
-    onArchiveAction,
-    onCancelRename,
-    onSubmitRename,
-  }: MissionHistoryItemProps) => {
-    const [draftTitle, setDraftTitle] = useState(mission.title || "Untitled mission");
-
-    useEffect(() => {
-      if (isEditing) {
-        setDraftTitle(mission.title || "Untitled mission");
-      }
-    }, [isEditing, mission.title]);
-
-    if (isEditing) {
-      return (
-        <div className="rounded-xl border border-primary/30 bg-primary/8 p-3">
-          <Textarea
-            value={draftTitle}
-            onChange={(event) => setDraftTitle(event.target.value)}
-            rows={2}
-            disabled={isRenaming}
-            className="min-h-14 resize-none bg-transparent text-xs"
-          />
-          <div className="mt-2 flex items-center justify-end gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={onCancelRename}
-              disabled={isRenaming}
-              title="Cancel rename"
-            >
-              <X className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => onSubmitRename(mission.missionId, draftTitle)}
-              disabled={isRenaming || !draftTitle.trim()}
-              title="Save title"
-            >
-              <Check className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div
-        className={cn(
-          "group relative w-full min-w-0 max-w-full overflow-hidden rounded-xl border p-3 transition-colors",
-          isActive ? "border-primary/40 bg-primary/10" : "border-border/50 bg-card/40 hover:bg-card/70"
-        )}
-      >
-        <NavLink
-          aria-label={`Open mission ${mission.title}`}
-          className="absolute inset-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
-          to={buildMissionPath(mission.missionId, routeBase)}
-        />
-        <div className="grid w-full min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-2 overflow-hidden">
-          <div className="pointer-events-none min-w-0 overflow-hidden">
-            <span className="block min-w-0 font-semibold text-sm leading-5 line-clamp-2 wrap-break-word">
-              {mission.title}
-            </span>
-            <div className="mt-2 flex min-w-0 items-center gap-2">
-              <span className="max-w-24 shrink-0 truncate rounded-full border border-border/50 px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-muted-foreground/70">
-                {mission.status}
-              </span>
-              <p className="min-w-0 flex-1 truncate text-right font-mono text-[9px] uppercase tracking-widest text-muted-foreground/40">
-                {new Date(mission.updatedAt).toLocaleString("en-US", {
-                  year: "numeric",
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  hour12: false,
-                })}
-              </p>
-            </div>
-          </div>
-          <div className="relative z-10 flex items-center gap-1">
-            {!isArchivedView ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  "h-6 w-6 shrink-0 transition-[opacity,color,background-color]",
-                  "bg-background/30 text-foreground/70 opacity-0",
-                  "group-hover:opacity-100 hover:bg-accent hover:text-foreground",
-                  "focus-visible:opacity-100"
-                )}
-                onClick={() => onBeginRename(mission)}
-                title="Rename mission"
-              >
-                <Pencil className="h-3 w-3" />
-              </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "h-6 w-6 shrink-0 transition-[opacity,color,background-color]",
-                "bg-background/30 text-foreground/70 opacity-0",
-                "group-hover:opacity-100 hover:bg-accent hover:text-foreground",
-                "focus-visible:opacity-100"
-              )}
-              onClick={() => onArchiveAction(mission, isArchivedView ? "restore" : "archive")}
-              disabled={isArchivePending || isArchiveDisabled}
-              title={
-                isArchivedView
-                  ? "Restore mission"
-                  : isArchiveDisabled
-                    ? "Active mission cannot be archived while running"
-                    : "Archive mission"
-              }
-            >
-              {isArchivedView ? <RotateCcw className="h-3 w-3" /> : <Archive className="h-3 w-3" />}
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-);
 
 export interface NoctisTeamScreenProps {
   activeMissionId: string | null;
@@ -653,6 +499,8 @@ export function NoctisTeamScreen({
       setIsLoadingMissions(false);
     }
   }, [missionApiBase]);
+
+  const sessionStates = useSessionStatusFeed({ onSessionIdle: () => void loadMissions() });
 
   const loadMissionOutputs = useCallback(async () => {
     if (!effectiveMissionId) {
@@ -1228,6 +1076,7 @@ export function NoctisTeamScreen({
                       key={mission.missionId}
                       mission={mission}
                       routeBase={missionRouteBase}
+                      isRunning={isMissionSummaryRunning(mission, sessionStates)}
                       isActive={effectiveMissionId === mission.missionId}
                       isArchivedView={missionView === "archived"}
                       isEditing={editingMissionId === mission.missionId}

--- a/web/app/routes/_layout.noctis-team/route.test.tsx
+++ b/web/app/routes/_layout.noctis-team/route.test.tsx
@@ -12,7 +12,10 @@ vi.mock("react-router", async () => {
 
   return {
     ...actual,
-    Outlet: () => <div>nested-route</div>,
+    Outlet: () => {
+      const params = paramsMock();
+      return params.id ? <div>nested-route</div> : null;
+    },
     useLocation: () => ({ state: null }),
     useNavigate: () => navigateMock,
     useParams: () => paramsMock(),
@@ -41,7 +44,7 @@ describe("noctis-team layout route", () => {
     expect(markup).not.toContain("nested-route");
   });
 
-  it("renders the child mission route when a mission URL is active", () => {
+  it("keeps the mission surface screen mounted when a mission URL is active", () => {
     paramsMock.mockReturnValue({ id: "mission-123" });
 
     const markup = renderToStaticMarkup(
@@ -49,6 +52,6 @@ describe("noctis-team layout route", () => {
     );
 
     expect(markup).toContain("nested-route");
-    expect(markup).not.toContain("screen:mission-123");
+    expect(markup).toContain("screen:mission-123");
   });
 });

--- a/web/app/routes/_layout.noctis-team/route.tsx
+++ b/web/app/routes/_layout.noctis-team/route.tsx
@@ -1,66 +1,9 @@
-import { useEffect } from "react";
-import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { readAppLanguage } from "@/lib/app-language.server";
 import type { Route } from "./+types/route";
-import { NoctisTeamScreen } from "./components/noctis-team-screen";
-
-const LAST_MISSION_STORAGE_KEY = "noctis-team:last-mission-id";
+import { MissionSurfaceRouteShell } from "./components/mission-surface-route-shell";
 
 export const NoctisTeamPage = ({ loaderData }: Route.ComponentProps) => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const params = useParams();
-  const activeMissionId = params.id ?? null;
-  const shouldSkipMissionRestore =
-    location.state !== null &&
-    typeof location.state === "object" &&
-    "skipMissionRestore" in location.state &&
-    location.state.skipMissionRestore === true;
-
-  useEffect(() => {
-    if (activeMissionId) {
-      return;
-    }
-
-    if (shouldSkipMissionRestore) {
-      return;
-    }
-
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const lastMissionId = window.localStorage.getItem(LAST_MISSION_STORAGE_KEY);
-    if (!lastMissionId) {
-      return;
-    }
-
-    void (async () => {
-      try {
-        const response = await fetch(`/api/noctis/missions/${lastMissionId}`);
-        if (!response.ok) {
-          window.localStorage.removeItem(LAST_MISSION_STORAGE_KEY);
-          return;
-        }
-
-        const mission = (await response.json()) as { status?: string };
-        if (mission.status === "archived") {
-          window.localStorage.removeItem(LAST_MISSION_STORAGE_KEY);
-          return;
-        }
-
-        navigate(`/noctis-team/mission/${lastMissionId}`, { replace: true });
-      } catch {
-        return;
-      }
-    })();
-  }, [activeMissionId, navigate, shouldSkipMissionRestore]);
-
-  if (activeMissionId) {
-    return <Outlet />;
-  }
-
-  return <NoctisTeamScreen activeMissionId={activeMissionId} language={loaderData.language} />;
+  return <MissionSurfaceRouteShell language={loaderData.language} />;
 };
 
 export const loader = async () => {

--- a/web/app/routes/_layout.opencode/route.tsx
+++ b/web/app/routes/_layout.opencode/route.tsx
@@ -1,5 +1,5 @@
 import { Archive, Check, Ellipsis, History, LoaderCircle, MessagesSquare, Pencil, Plus, RefreshCw, RotateCcw, X } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, Outlet, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -21,36 +21,12 @@ import { ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  coerceSessionStatus,
-  fetchSessionStatuses,
-  isSessionStatusActive,
-  type SessionStatus,
-} from "@/lib/session-status";
+import { useSessionStatusFeed } from "@/hooks/use-session-status-feed";
+import { isSessionStatusActive } from "@/lib/session-status";
 import { NEW_OPENCODE_SESSION_DRAFT_KEY } from "@/lib/opencode-session";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
 import type { Route } from "./+types/route";
-
-type EventPayload = {
-  type: string;
-  properties: {
-    sessionID?: string;
-    status?: {
-      type: SessionStatus;
-      attempt?: number;
-      message?: string;
-      next?: number;
-    };
-    part?: {
-      type: string;
-      text?: string;
-      messageID?: string;
-      sessionID?: string;
-    };
-    delta?: string;
-  };
-};
 
 type Session = {
   id: string;
@@ -281,9 +257,6 @@ const OpenCodeLayout = ({ loaderData }: Route.ComponentProps) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const clearSessionDraft = useChatStore((state) => state.clearSessionDraft);
   const setCurrentSessionId = useChatStore((state) => state.setCurrentSessionId);
-  const sessionStates = useChatStore((state) => state.sessionStates);
-  const setServerSessionState = useChatStore((state) => state.setServerSessionState);
-  const replaceServerSessionStates = useChatStore((state) => state.replaceServerSessionStates);
   const activeSessionId = params.id;
 
   const loadSessions = useCallback(async () => {
@@ -314,6 +287,8 @@ const OpenCodeLayout = ({ loaderData }: Route.ComponentProps) => {
       setCurrentSessionId(activeSessionId);
     }
   }, [activeSessionId, setCurrentSessionId]);
+
+  const sessionStates = useSessionStatusFeed({ onSessionIdle: () => void loadSessions() });
 
   const handleNewSession = useCallback(() => {
     clearSessionDraft(NEW_OPENCODE_SESSION_DRAFT_KEY);
@@ -366,74 +341,6 @@ const OpenCodeLayout = ({ loaderData }: Route.ComponentProps) => {
       window.removeEventListener("sessions:refresh", handleRefresh);
     };
   }, [loadSessions]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    void fetchSessionStatuses()
-      .then((statuses) => {
-        replaceServerSessionStates(statuses);
-      })
-      .catch(() => undefined);
-
-    const source = new EventSource("/api/event-stream");
-    source.onmessage = (event) => {
-      const payload = JSON.parse(event.data as string) as { payload?: EventPayload } | EventPayload;
-      const actual = ("payload" in payload ? payload.payload : payload) as EventPayload;
-      if (!actual?.type) return;
-
-      if (actual.type === "session.status") {
-        const eventSessionId = actual.properties.sessionID;
-        const nextStatus = coerceSessionStatus(actual.properties.status?.type);
-        if (eventSessionId && nextStatus) {
-          setServerSessionState(eventSessionId, nextStatus);
-        }
-      }
-
-      if (actual.type === "session.idle") {
-        const eventSessionId = actual.properties.sessionID;
-        if (eventSessionId) {
-          setServerSessionState(eventSessionId, "idle");
-          loadSessions();
-        }
-      }
-    };
-    source.onerror = () => {
-      source.close();
-    };
-    return () => {
-      source.close();
-    };
-  }, [loadSessions, replaceServerSessionStates, setServerSessionState]);
-
-  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    const hasBusy = Object.values(sessionStates).some((status) => isSessionStatusActive(status));
-
-    if (hasBusy && !pollingIntervalRef.current) {
-      pollingIntervalRef.current = setInterval(async () => {
-        try {
-          const statuses = await fetchSessionStatuses();
-          replaceServerSessionStates(statuses);
-        } catch (_) {
-          void _;
-        }
-      }, 3000);
-    }
-
-    if (!hasBusy && pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current);
-      pollingIntervalRef.current = null;
-    }
-
-    return () => {
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-        pollingIntervalRef.current = null;
-      }
-    };
-  }, [replaceServerSessionStates, sessionStates]);
 
   const beginRename = useCallback((session: Session) => {
     setEditingSessionId(session.id);


### PR DESCRIPTION
## 📝 Summary

- Keep mission surfaces mounted across route transitions so history stays visible
- Restore the last active mission from a shared surface shell for Noctis Team and Lunafreya
- Show in-progress missions from activity session status and cover the behavior with route-transition tests

## 🎯 Motivation

Mission history and detail state were tied to screen-local mounts, so creating or selecting a mission could briefly replace populated history with a loading state and drop view continuity.

This change moves persistence and restore behavior into a shared mission-surface boundary and uses live session status to mark missions as running, so in-progress work remains visible while routes change.

## 🔧 Changes Overview

- Diff scope: 20 files changed, 624 insertions, 471 deletions.
- Added a shared mission-surface route shell that keeps mission history mounted and restores the last active non-archived mission.
- Refactored Noctis Team and Lunafreya mission routing so detail transitions update the active mission without remounting the shared history surface.
- Added live session-status feeding and mission running-state derivation from `activitySessionIds` so active missions can be highlighted in history.
- Expanded route-transition and mission-history tests to cover continuity and running-state behavior.

## ✅ Testing

- `npm run web:typecheck`
- `npm run web:test` (101 test files, 362 tests passed)

- [x] Tested locally
- [ ] Manual testing completed
- [x] Edge cases considered

## 📸 Screenshots

Not included. The change is primarily route continuity and running-state behavior.

## 🔗 Related Issues

None

## 📋 Checklist

- [ ] Self-reviewed the code
- [ ] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [ ] UI changes reviewed; screenshots added if useful

## 📌 Notes

- Quality checks passed before PR creation: no merge conflicts, no uncommitted changes, no TODO/FIXME additions, and no dependency changes.
