### PR TITLE
Add GitHub issue to OpenSpec artifact generation prompt

### DIFF
--- a/.github/prompts/github-issue-openspec.prompt.md
+++ b/.github/prompts/github-issue-openspec.prompt.md
@@ -1,0 +1,70 @@
+---
+description: Create apply-ready OpenSpec artifacts from a GitHub issue URL
+name: GitHub Issue to OpenSpec FF
+argument-hint: <github-issue-url>
+agent: agent
+---
+
+Create apply-ready OpenSpec artifacts from a GitHub issue.
+
+**Input**: The argument after `/github-issue-openspec` must be a GitHub issue URL.
+
+**Steps**
+
+1. **If no usable issue URL is provided, ask for it**
+
+   Ask User for the exact GitHub issue URL before proceeding.
+
+2. **Refresh remote state**
+   ```bash
+   git fetch origin --prune
+   ```
+
+3. **Investigate from the latest `origin/main` state**
+   - Base the investigation on the current tip of `origin/main`
+   - Do not rely on a stale local `main` branch
+
+4. **Read the target GitHub issue and extract the planning input**
+   Organize:
+   - Goal
+   - Acceptance criteria
+   - Constraints
+   - Related links or references
+
+5. **If a direct parent issue exists, inspect it too**
+   - Prefer an explicit GitHub parent relationship when available
+   - Otherwise follow only one explicit parent reference from the issue body or template
+   - Do not expand into a broad related-issue graph
+
+6. **Derive stable names from the issue intent**
+   Create:
+   - Change name: `<issue-number>-<change-slug>`
+   - Branch name: `feature/<issue-number>-<change-slug>`
+
+7. **Check whether the working tree is safe before switching branches**
+   - If there are unrelated local changes, merge conflicts, or another unsafe git state, stop and report the blocker
+
+8. **Create or reuse the feature branch from `origin/main` and switch to it**
+   - Reuse an existing matching branch only if it clearly belongs to the same issue and intent
+
+9. **Use the `openspec-ff-change` skill to generate apply-ready artifacts**
+   - Use the same change name derived above
+   - Keep the branch name and OpenSpec change name aligned
+   - Do not restate or inline the skill instructions
+
+10. **Stop after artifact generation and report the result**
+    Summarize:
+    - Issue summary
+    - Parent issue summary, if used
+    - Change name
+    - Branch name
+    - Change path
+    - Artifacts created
+    - Any unresolved questions or blockers
+
+**Guardrails**
+
+- Respect repository and workspace instructions while generating artifacts
+- Prefer momentum, but ask a focused question if the issue content is too ambiguous to derive a reliable change name
+- If the issue cannot be accessed, ask User to provide the issue text or a reachable URL
+- Do not implement code, open a PR, or continue beyond artifact generation

--- a/.github/prompts/prd-linked-issues.prompt.md
+++ b/.github/prompts/prd-linked-issues.prompt.md
@@ -1,0 +1,61 @@
+---
+description: "Create implementation GitHub issues from a PRD issue or raw PRD text, then set parent and blocked-by relationships"
+argument-hint: "PRD issue number/URL or PRD text"
+agent: "agent"
+---
+
+Create implementation GitHub issues from a PRD source.
+
+Use this prompt when the user wants executable implementation issues, not only a proposed breakdown.
+
+**Input**
+
+The argument after this prompt may be:
+- A PRD GitHub issue number
+- A PRD GitHub issue URL
+- Raw PRD text
+
+If the argument is empty, use the current editor selection or recent chat context only when it clearly contains the PRD.
+
+**Goal**
+
+- Resolve the PRD source
+- If the PRD is not already a GitHub issue, create a parent PRD issue first
+- Use the `prd-to-issues` skill to derive the implementation issue set
+- Create the implementation issues immediately
+- Set GitHub issue relationships:
+  - Parent issue -> the PRD issue
+  - Blocked by -> only strict start-blocking dependencies
+- Return a concise summary of created issues and relationships
+
+**Steps**
+
+1. Resolve the target repository and PRD source. Ask only if the repository or PRD source is genuinely unclear.
+2. If the input is raw PRD text, create a parent PRD issue first and use it as the canonical anchor.
+3. Use the `prd-to-issues` skill to generate the implementation issue breakdown and issue bodies. Do not stop for an approval round unless the PRD is ambiguous or contradictory.
+4. Create issues in dependency order so blocker issue numbers are available before dependent issues are created.
+5. After issue creation, set GitHub issue relationships for each issue:
+   - Assign the PRD issue as the parent when applicable
+   - Add `blocked by` relationships only for strict dependencies that prevent starting work
+   - Do not encode preferred sequencing as dependencies
+6. Verify the final graph is internally consistent: every blocked issue points to an existing blocker, and every child issue points to the PRD parent.
+7. Respond with:
+   - The parent PRD issue
+   - The created implementation issues
+   - The `blocked by` relationships that were set
+   - Any relationships that could not be set programmatically
+
+**Ask Only If Blocked**
+
+- Which repository should receive the issues?
+- Is this PRD text final enough to create a parent PRD issue?
+- Which ambiguity must be resolved before creating issues?
+
+**Guardrails**
+
+- Do not create implementation issues without a PRD anchor
+- Do not ask for a manual breakdown review by default
+- Use `blocked by` only for strict start blockers
+- Prefer GitHub issue relationships over writing dependency text only in issue bodies
+- If relationships cannot be set with the available tools, stop after issue creation and report the exact missing relationships
+- Keep the response concise and execution-focused


### PR DESCRIPTION
Introduce a prompt that creates apply-ready OpenSpec artifacts from a GitHub issue URL. This enhancement streamlines the process of generating artifacts by extracting relevant information from the specified issue. It includes steps for handling input, refreshing state, and ensuring safe branch operations. Guardrails are also established to maintain clarity and focus during artifact generation.