### PR TITLE
Persist mission transport snapshots and session ownership

### DIFF
--- a/web/app/lib/mission-runtime-compatibility.server.ts
+++ b/web/app/lib/mission-runtime-compatibility.server.ts
@@ -43,14 +43,6 @@ export function getMissionCompatibilityIssue(mission: Mission): MissionResumeBlo
     };
   }
 
-  const transportMode = normalizeMissionTransportMode(mission.transportMode);
-  if (transportMode !== getConfiguredMissionTransportMode()) {
-    return {
-      code: "unsupported_mission_runtime",
-      message: UNSUPPORTED_MISSION_RUNTIME_MESSAGE,
-    };
-  }
-
   return null;
 }
 

--- a/web/app/lib/mission-store.test.ts
+++ b/web/app/lib/mission-store.test.ts
@@ -98,6 +98,29 @@ describe("mission store", () => {
     expect(reloaded?.workspaceStatus).toBe("ready");
   });
 
+  it("persists transport snapshots and primary session ownership metadata", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-transport-state", "session-primary-owner", {
+      title: "Transport State Mission",
+      objective: "Verify transport snapshot persistence",
+    });
+    missionIds.push(mission.id);
+
+    expect(mission.transportMode).toBe("app-owned");
+    expect(mission.sessionOwners).toEqual({
+      "session-primary-owner": "noctis",
+    });
+
+    deleteMission(mission.id);
+
+    const reloaded = getMission(mission.id);
+    expect(reloaded?.transportMode).toBe("app-owned");
+    expect(reloaded?.sessionOwners).toEqual({
+      "session-primary-owner": "noctis",
+    });
+  });
+
   it("persists Lunafreya mission surface metadata and facet selections", () => {
     process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
 
@@ -324,5 +347,33 @@ describe("mission store", () => {
         activitySessionIds: ["session-primary", "session-ignis", "session-prompto"],
       }),
     ]);
+  });
+
+  it("persists lazy worker session ownership metadata only after the worker session is created", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-worker-owners", "session-primary", {
+      title: "Worker ownership mission",
+      objective: "Verify lazy worker ownership persistence",
+    });
+    missionIds.push(mission.id);
+
+    expect(mission.sessionOwners).toEqual({
+      "session-primary": "noctis",
+    });
+
+    setWorkerSession(mission.id, "ignis", "session-ignis");
+
+    expect(getMission(mission.id)?.sessionOwners).toEqual({
+      "session-primary": "noctis",
+      "session-ignis": "ignis",
+    });
+
+    deleteMission(mission.id);
+
+    expect(getMission(mission.id)?.sessionOwners).toEqual({
+      "session-primary": "noctis",
+      "session-ignis": "ignis",
+    });
   });
 });

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -58,6 +58,55 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeMissionSessionOwners(value: unknown): Record<string, AgentId> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const normalizedOwners: Record<string, AgentId> = {};
+  for (const [sessionId, ownerAgent] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedSessionId = normalizeOptionalString(sessionId);
+    if (!normalizedSessionId) {
+      continue;
+    }
+
+    if (
+      ownerAgent !== "noctis" &&
+      ownerAgent !== "lunafreya" &&
+      ownerAgent !== "ignis" &&
+      ownerAgent !== "gladiolus" &&
+      ownerAgent !== "prompto"
+    ) {
+      continue;
+    }
+
+    normalizedOwners[normalizedSessionId] = ownerAgent;
+  }
+
+  return normalizedOwners;
+}
+
+function setMissionSessionOwner(
+  mission: Mission,
+  sessionId: string,
+  ownerAgent: AgentId,
+  previousSessionId?: string | null,
+): void {
+  const normalizedSessionId = normalizeOptionalString(sessionId);
+  if (!normalizedSessionId) {
+    return;
+  }
+
+  const normalizedPreviousSessionId = normalizeOptionalString(previousSessionId);
+  const sessionOwners = mission.sessionOwners ?? {};
+  if (normalizedPreviousSessionId && normalizedPreviousSessionId !== normalizedSessionId) {
+    delete sessionOwners[normalizedPreviousSessionId];
+  }
+
+  sessionOwners[normalizedSessionId] = ownerAgent;
+  mission.sessionOwners = sessionOwners;
+}
+
 function normalizeMissionSurfaceId(value: unknown): MissionSurfaceId | undefined {
   return value === "lunafreya" || value === "noctis_team" ? value : undefined;
 }
@@ -271,6 +320,7 @@ function readMissionFromDisk(id: string): Mission | null {
     parsed.surfaceId = normalizeMissionSurfaceId(parsed.surfaceId);
     parsed.primaryAgentId = normalizeMissionPrimaryAgentId(parsed.primaryAgentId);
     parsed.primarySessionId = normalizeOptionalString(parsed.primarySessionId);
+    parsed.sessionOwners = normalizeMissionSessionOwners(parsed.sessionOwners);
     parsed.contextProjectIds = normalizeContextProjectIds(
       parsed.executionProjectId,
       parsed.contextProjectIds,
@@ -394,15 +444,19 @@ export function createMission(
     options?.executionTargetMode,
     executionProjectId,
   );
+  const normalizedPrimarySessionId = noctisSessionId.trim();
   const primaryAgentId = options?.primaryAgentId ?? "noctis";
   const surfaceId = options?.surfaceId ?? (primaryAgentId === "lunafreya" ? "lunafreya" : "noctis_team");
   const mission: Mission = {
     id,
     ...buildCurrentMissionRuntimeMetadata(),
-    noctisSessionId: primaryAgentId === "noctis" ? noctisSessionId : "",
+    noctisSessionId: primaryAgentId === "noctis" ? normalizedPrimarySessionId : "",
     surfaceId,
     primaryAgentId,
-    primarySessionId: noctisSessionId,
+    primarySessionId: normalizedPrimarySessionId,
+    sessionOwners: normalizedPrimarySessionId
+      ? { [normalizedPrimarySessionId]: primaryAgentId }
+      : {},
     workerSessions: {},
     executionProjectId,
     ...(executionTargetMode ? { executionTargetMode } : {}),
@@ -519,7 +573,9 @@ export function setWorkerSession(
 ): void {
   const mission = getMission(missionId);
   if (!mission) return;
+  const previousSessionId = mission.workerSessions[agentId];
   mission.workerSessions[agentId] = sessionId;
+  setMissionSessionOwner(mission, sessionId, agentId, previousSessionId);
   touchMission(mission);
 }
 
@@ -535,12 +591,19 @@ export function setMissionPrimarySession(
   const mission = getMission(missionId);
   if (!mission) return;
   const normalizedSessionId = sessionId.trim();
+  const previousSessionId =
+    agentId === "noctis"
+      ? normalizeOptionalString(mission.noctisSessionId)
+      : getMissionPrimaryAgentId(mission) === agentId
+        ? getMissionPrimarySessionId(mission)
+        : null;
   if (agentId === "noctis") {
     mission.noctisSessionId = normalizedSessionId;
   }
   if (getMissionPrimaryAgentId(mission) === agentId) {
     mission.primarySessionId = normalizedSessionId;
   }
+  setMissionSessionOwner(mission, normalizedSessionId, agentId, previousSessionId);
   touchMission(mission);
 }
 
@@ -598,6 +661,7 @@ export function clearMissionSessions(missionId: string): void {
   if (!mission) return;
   mission.noctisSessionId = "";
   mission.primarySessionId = "";
+  mission.sessionOwners = {};
   mission.workerSessions = {};
   touchMission(mission);
 }

--- a/web/app/lib/tmux-transport-bootstrap.server.ts
+++ b/web/app/lib/tmux-transport-bootstrap.server.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { readAppConfig, type AppConfig } from "@/lib/app-config.server";
+import type { MissionTransportMode } from "@/lib/types/mission";
 
 export const TMUX_TRANSPORT_ENDPOINT_MANIFEST_FILE = "opencode-endpoints.json";
 export const TMUX_TRANSPORT_DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
@@ -230,12 +231,24 @@ export async function getConfiguredMissionTransportStatus(
 ): Promise<ConfiguredMissionTransportStatus> {
   const { transportMode } = readAppConfig(root);
 
-  if (transportMode !== "tmux-resident") {
+  return getMissionTransportStatus(root, transportMode);
+}
+
+export async function getMissionTransportStatus(
+  root: string,
+  transportMode?: MissionTransportMode | null,
+): Promise<ConfiguredMissionTransportStatus> {
+  const effectiveTransportMode =
+    transportMode === "app-owned" || transportMode === "tmux-resident"
+      ? transportMode
+      : readAppConfig(root).transportMode;
+
+  if (effectiveTransportMode !== "tmux-resident") {
     return {
       bootstrapStatus: null,
       error: null,
       isReady: true,
-      transportMode,
+      transportMode: effectiveTransportMode,
     };
   }
 
@@ -244,6 +257,6 @@ export async function getConfiguredMissionTransportStatus(
     bootstrapStatus,
     error: bootstrapStatus.error,
     isReady: bootstrapStatus.isReady,
-    transportMode,
+    transportMode: effectiveTransportMode,
   };
 }

--- a/web/app/lib/types/mission.ts
+++ b/web/app/lib/types/mission.ts
@@ -114,6 +114,7 @@ export interface Mission {
   surfaceId?: MissionSurfaceId;
   primaryAgentId?: MissionPrimaryAgentId;
   primarySessionId?: string;
+  sessionOwners?: Record<string, AgentId>;
   workerSessions: Partial<Record<WorkerAgentId, string>>;
   executionProjectId?: string;
   executionTargetMode?: MissionExecutionTargetMode;

--- a/web/app/routes/api.lunafreya.mission.continue.ts
+++ b/web/app/routes/api.lunafreya.mission.continue.ts
@@ -21,6 +21,7 @@ import { buildBuiltinOperationRef } from "@/lib/operation-definition/operation-c
 import { readOperationLanguage } from "@/lib/operation-definition/language";
 import { composeUserToPrimaryAgentPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
+import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 
 function listBuiltinLanguages(language: string): string[] {
@@ -153,8 +154,17 @@ export const action = async ({ request }: { request: Request }) => {
   const { model, variant } = splitModelSelection(effectiveModel);
 
   try {
-    const client = getOpencodeClient();
     const appRoot = getProjectRoot();
+    const transportStatus = await getMissionTransportStatus(appRoot, mission.transportMode);
+    if (!transportStatus.isReady) {
+      return Response.json(
+        {
+          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
+        },
+        { status: 503 },
+      );
+    }
+    const client = getOpencodeClient();
     const executionRoot = resolveMissionExecutionRoot({
       appRoot,
       mission,

--- a/web/app/routes/api.lunafreya.mission.start.ts
+++ b/web/app/routes/api.lunafreya.mission.start.ts
@@ -16,6 +16,7 @@ import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeUserToPrimaryAgentPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
+import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 
 function listBuiltinLanguages(language: string): string[] {
@@ -110,8 +111,17 @@ export const action = async ({ request }: { request: Request }) => {
   }
 
   try {
-    const client = getOpencodeClient();
     const projectRoot = getProjectRoot();
+    const transportStatus = await getMissionTransportStatus(projectRoot);
+    if (!transportStatus.isReady) {
+      return Response.json(
+        {
+          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
+        },
+        { status: 503 },
+      );
+    }
+    const client = getOpencodeClient();
     const executionProject = readRegisteredProjectDefinition(projectRoot, executionProjectId);
     if (!executionProject) {
       return Response.json({ error: "Execution project is not registered." }, { status: 409 });

--- a/web/app/routes/api.lunafreya.mission.test.ts
+++ b/web/app/routes/api.lunafreya.mission.test.ts
@@ -192,6 +192,33 @@ describe("Lunafreya mission routing", () => {
     });
   });
 
+  it("refuses Lunafreya mission start when tmux transport bootstrap is unhealthy", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/lunafreya/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Guide me through tmux transport.",
+          executionProjectId: "alpha",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(503);
+    await expect(readJson<{ error: string }>(response)).resolves.toEqual({
+      error: expect.stringContaining("Missing tmux transport endpoint manifest"),
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
   it("starts a Lunafreya mission with the implicit default Job when no explicit override is selected", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;
@@ -431,6 +458,49 @@ describe("Lunafreya mission routing", () => {
       }),
     );
     expect(getMission(mission.id)?.primarySessionId).toBe("session-lunafreya-recreated");
+  });
+
+  it("continues to require tmux readiness for Lunafreya based on the mission transport snapshot", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const mission = createMission(`mission-luna-tmux-${crypto.randomUUID()}`, "session-luna-tmux", {
+      title: "Lunafreya tmux snapshot mission",
+      objective: "Keep using the stored tmux transport mode",
+      surfaceId: "lunafreya",
+      primaryAgentId: "lunafreya",
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "app-owned"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/lunafreya/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Resume through the stored tmux transport mode.",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(503);
+    await expect(readJson<{ error: string }>(response)).resolves.toEqual({
+      error: expect.stringContaining("Missing tmux transport endpoint manifest"),
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
   });
 
   it("blocks continue for Lunafreya missions with an unsupported runtime format", async () => {

--- a/web/app/routes/api.noctis.mission.continue.ts
+++ b/web/app/routes/api.noctis.mission.continue.ts
@@ -17,7 +17,7 @@ import { getOpencodeClient } from "@/lib/opencode-client";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
-import { getConfiguredMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
+import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { Route } from "./+types/api.noctis.mission.continue";
 
 export const action = async ({ request }: Route.ActionArgs) => {
@@ -105,7 +105,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   try {
     const appRoot = getProjectRoot();
-    const transportStatus = await getConfiguredMissionTransportStatus(appRoot);
+    const transportStatus = await getMissionTransportStatus(appRoot, mission.transportMode);
     if (!transportStatus.isReady) {
       return Response.json(
         {

--- a/web/app/routes/api.noctis.mission.execution-workspace.test.ts
+++ b/web/app/routes/api.noctis.mission.execution-workspace.test.ts
@@ -488,6 +488,81 @@ describe("Noctis mission execution workspace lifecycle", () => {
     });
   });
 
+  it("continues to require tmux readiness based on the mission transport snapshot", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const mission = createMission(`mission-tmux-snapshot-${crypto.randomUUID()}`, "session-tmux", {
+      title: "Tmux snapshot mission",
+      objective: "Keep using the stored tmux transport mode",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "app-owned"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Resume through the stored tmux transport mode.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(503);
+    expect(await readJson<{ error: string }>(response)).toEqual({
+      error: expect.stringContaining("Missing tmux transport endpoint manifest"),
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("continues app-owned missions even after the global transport mode changes to tmux-resident", async () => {
+    const root = createTempRoot({ transportMode: "app-owned" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const mission = createMission(`mission-app-owned-snapshot-${crypto.randomUUID()}`, "session-app-owned", {
+      title: "App-owned snapshot mission",
+      objective: "Keep using the stored app-owned transport mode",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+    promptAsyncMock.mockResolvedValue({ data: { id: "prompt-app-owned-continue" } });
+
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Resume through the stored app-owned transport mode.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await readJson<{ noctisSessionId: string }>(response)).toEqual({
+      noctisSessionId: "session-app-owned",
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
   it("refuses mission continue when tmux transport bootstrap is unhealthy", async () => {
     process.env.MULTI_AGENT_FF15_ROOT = createTempRoot({ transportMode: "tmux-resident" });
     const mission = createMission(`mission-tmux-${crypto.randomUUID()}`, "", {

--- a/web/app/routes/api.noctis.mission.start.ts
+++ b/web/app/routes/api.noctis.mission.start.ts
@@ -20,7 +20,7 @@ import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
-import { getConfiguredMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
+import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 import type { Route } from "./+types/api.noctis.mission.start";
 
@@ -108,7 +108,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   try {
     const projectRoot = getProjectRoot();
-    const transportStatus = await getConfiguredMissionTransportStatus(projectRoot);
+    const transportStatus = await getMissionTransportStatus(projectRoot);
     if (!transportStatus.isReady) {
       return Response.json(
         {

--- a/web/app/routes/api.noctis.missions.$missionId.test.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.test.ts
@@ -146,4 +146,34 @@ describe("api.noctis.missions.$missionId", () => {
       isTerminal: true,
     });
   });
+
+  it("keeps read-only mission inspection available when tmux transport is unhealthy", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    mkdirSync(join(root, "config"), { recursive: true });
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+
+    const missionId = `mission-readonly-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-readonly", {
+      title: "Readonly mission",
+      objective: "Inspect mission details while tmux is unhealthy",
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+
+    const response = await loader({ params: { missionId } } as never);
+    expect(response.status).toBe(200);
+
+    await expect(readJson<{ missionId: string; transportMode: string | null }>(response)).resolves.toEqual(
+      expect.objectContaining({
+        missionId,
+        transportMode: "tmux-resident",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## 📝 Summary

- Persist mission transport snapshots and durable session ownership metadata for mission lifecycle operations.
- Keep mission resume behavior aligned with the stored mission transport mode instead of the mutable global transport setting.
- Fail fast on tmux-backed mission start and continue paths while preserving read-only mission inspection.

## 🎯 Motivation

- Missions must resume against the transport mode they were created with, even after the app-wide transport setting changes.
- Tmux-backed missions should stop early when bootstrap/readiness is unhealthy instead of creating or resuming inconsistent runtime state.
- Read-only mission detail loading should stay available even when write-path transport readiness is degraded.

## 🔧 Changes Overview

- Diff scope: 12 files changed, 335 insertions, 19 deletions.
- Persist `sessionOwners` in mission state and keep primary/worker ownership metadata synchronized as sessions are created or cleared.
- Route continue-time compatibility checks through the stored `mission.transportMode` and stop blocking resumes just because the global transport config changed later.
- Introduce mission-scoped tmux readiness checks for Noctis and Lunafreya start/continue flows.
- Extend tests for mission persistence, tmux fail-fast behavior, transport-snapshot resume behavior, and read-only mission inspection under degraded tmux readiness.

## ✅ Testing

- `npm run web:typecheck`
- Focused Vitest run covering mission store, Noctis mission lifecycle, Lunafreya mission lifecycle, and read-only mission detail loading.
- Focused behavioral verification of the issue 57 mission lifecycle scenarios during implementation.

- [x] Tested locally
- [x] Manual testing completed
- [x] Edge cases considered

## 📸 Screenshots

Not applicable. This PR does not change the UI.

## 🔗 Related Issues

Closes #57

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots added if useful

## 📌 Notes

- No breaking API changes are intended for callers. The behavior change is limited to mission persistence, resume compatibility, and tmux readiness gating.
