### PR TITLE
Add tmux transport runtime and primary-agent outbox dispatch

### DIFF
--- a/scripts/standby_transport_mode.test.mjs
+++ b/scripts/standby_transport_mode.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import {
+  chmodSync,
   cpSync,
   mkdirSync,
   mkdtempSync,
@@ -21,6 +22,7 @@ function createTempRoot() {
   const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-standby-transport-"));
   tempRoots.push(root);
 
+  mkdirSync(join(root, "bin"), { recursive: true });
   mkdirSync(join(root, "scripts"), { recursive: true });
   mkdirSync(join(root, "config"), { recursive: true });
   mkdirSync(join(root, "web", "app", "lib"), { recursive: true });
@@ -43,15 +45,112 @@ function createTempRoot() {
     "utf-8",
   );
 
+  writeFileSync(join(root, "bin", "lsof"), "#!/usr/bin/env bash\nexit 0\n", "utf-8");
+  chmodSync(join(root, "bin", "lsof"), 0o755);
+
   return root;
 }
 
-function runStandby(root, args) {
+function writeStatusControlScript(root, relativePath, payload) {
+  writeFileSync(
+    join(root, relativePath),
+    [
+      `const payload = ${JSON.stringify(payload)};`,
+      "process.stdout.write(JSON.stringify(payload));",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeExecutableScript(root, relativePath, content) {
+  const filePath = join(root, relativePath);
+  writeFileSync(filePath, content, "utf-8");
+  chmodSync(filePath, 0o755);
+}
+
+function shellEscape(value) {
+  return `'${String(value).replace(/'/g, `'"'"'`)}'`;
+}
+
+function prepareAttachStartFixture(root, runtimeState = "running") {
+  mkdirSync(join(root, "web", "build", "server"), { recursive: true });
+  writeFileSync(join(root, "web", "build", "server", "index.js"), "export {};\n", "utf-8");
+  writeFileSync(
+    join(root, "config", "settings.yaml"),
+    [
+      'language: "en"',
+      'transport_mode: "tmux-resident"',
+      'shared_skills_root: "skills"',
+      'theme: "desert"',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  writeFileSync(
+    join(root, "scripts", "tmux_transport_runtime.mts"),
+    [
+      'import { appendFileSync } from "node:fs";',
+      "const action = process.argv[2];",
+      "const logPath = process.env.TMUX_RUNTIME_LOG;",
+      "if (logPath) { appendFileSync(logPath, `${action}\\n`); }",
+      "if (action === 'start') { process.stdout.write('{}'); process.exit(0); }",
+      `if (action === 'status') { process.stdout.write(JSON.stringify(${JSON.stringify({
+        state: runtimeState,
+        sessionName: 'ff15',
+        dispatcherPid: runtimeState === 'running' ? 4321 : null,
+        endpointManifestExists: runtimeState === 'running',
+      })})); process.exit(0); }`,
+      "if (action === 'stop') { process.stdout.write('{}'); process.exit(0); }",
+      "process.exit(1);",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  writeExecutableScript(
+    root,
+    join("bin", "npm"),
+    "#!/usr/bin/env bash\nexit 0\n",
+  );
+  writeExecutableScript(
+    root,
+    join("bin", "curl"),
+    "#!/usr/bin/env bash\nexit 0\n",
+  );
+  writeExecutableScript(
+    root,
+    join("bin", "tmux"),
+    "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"${TMUX_LOG:?}\"\nexit 0\n",
+  );
+}
+
+function runStandby(root, args, envOverrides = {}, options = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn("bash", ["./standby.sh", ...args], {
-      cwd: root,
-      env: { ...process.env },
-    });
+    const env = {
+      ...process.env,
+      PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}`,
+      ...envOverrides,
+    };
+    const usePty = options.usePty === true;
+    const child = usePty
+      ? spawn(
+          "script",
+          [
+            "-qefc",
+            `bash ./standby.sh ${args.map(shellEscape).join(" ")}`,
+            "/dev/null",
+          ],
+          {
+            cwd: root,
+            env,
+          },
+        )
+      : spawn("bash", ["./standby.sh", ...args], {
+          cwd: root,
+          env,
+        });
 
     let stdout = "";
     let stderr = "";
@@ -89,4 +188,89 @@ test("updates transport mode through standby.sh without starting services", asyn
   const settings = readFileSync(join(root, "config", "settings.yaml"), "utf-8");
   assert.match(settings, /transport_mode: "tmux-resident"/);
   assert.match(settings, /theme: "desert"/);
+});
+
+test("reports dispatcher status from --status even in app-owned mode", async () => {
+  const root = createTempRoot();
+
+  writeStatusControlScript(root, join("scripts", "opencode_server_control.mts"), {
+    state: "running",
+    managedByApp: true,
+    pid: 1234,
+    url: "http://127.0.0.1:4096",
+  });
+  writeStatusControlScript(root, join("scripts", "tmux_transport_runtime.mts"), {
+    state: "running",
+    sessionName: "ff15",
+    dispatcherPid: 4321,
+    endpointManifestExists: true,
+  });
+
+  const result = await runStandby(root, ["--status"]);
+
+  assert.equal(result.code, 1, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /Web server is not running\./);
+  assert.match(result.stdout, /OpenCode server is running: http:\/\/127\.0\.0\.1:4096 \(PID: 1234\)/);
+  assert.match(result.stdout, /Tmux transport is running: session ff15 \(dispatcher PID: 4321\)/);
+});
+
+test("attaches to ff15 when --attach is used outside tmux", async () => {
+  const root = createTempRoot();
+  const tmuxLog = join(root, "tmux.log");
+  const runtimeLog = join(root, "tmux-runtime.log");
+  prepareAttachStartFixture(root);
+
+  const result = await runStandby(
+    root,
+    ["--attach"],
+    { TMUX: "", TMUX_LOG: tmuxLog, TMUX_RUNTIME_LOG: runtimeLog },
+    { usePty: true },
+  );
+
+  assert.equal(result.code, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /Reusing existing tmux transport runtime\./);
+  assert.match(result.stdout, /Attaching to tmux session ff15/);
+  assert.match(readFileSync(tmuxLog, "utf-8"), /attach-session -t ff15/);
+  assert.match(readFileSync(runtimeLog, "utf-8"), /^status$/m);
+  assert.doesNotMatch(readFileSync(runtimeLog, "utf-8"), /^start$/m);
+});
+
+test("switches the current client when --attach is used inside tmux", async () => {
+  const root = createTempRoot();
+  const tmuxLog = join(root, "tmux.log");
+  const runtimeLog = join(root, "tmux-runtime.log");
+  prepareAttachStartFixture(root);
+
+  const result = await runStandby(root, ["--attach"], {
+    TMUX: "/tmp/fake-client,123,0",
+    TMUX_LOG: tmuxLog,
+    TMUX_RUNTIME_LOG: runtimeLog,
+  }, { usePty: true });
+
+  assert.equal(result.code, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /Reusing existing tmux transport runtime\./);
+  assert.match(result.stdout, /Switching tmux client to session ff15/);
+  assert.match(readFileSync(tmuxLog, "utf-8"), /switch-client -t ff15/);
+  assert.match(readFileSync(runtimeLog, "utf-8"), /^status$/m);
+  assert.doesNotMatch(readFileSync(runtimeLog, "utf-8"), /^start$/m);
+});
+
+test("starts tmux transport before attaching when the runtime is down", async () => {
+  const root = createTempRoot();
+  const tmuxLog = join(root, "tmux.log");
+  const runtimeLog = join(root, "tmux-runtime.log");
+  prepareAttachStartFixture(root, "down");
+
+  const result = await runStandby(
+    root,
+    ["--attach"],
+    { TMUX: "", TMUX_LOG: tmuxLog, TMUX_RUNTIME_LOG: runtimeLog },
+    { usePty: true },
+  );
+
+  assert.equal(result.code, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /Bootstrapping tmux-resident OpenCode transport/);
+  assert.match(readFileSync(tmuxLog, "utf-8"), /attach-session -t ff15/);
+  assert.match(readFileSync(runtimeLog, "utf-8"), /^status$/m);
+  assert.match(readFileSync(runtimeLog, "utf-8"), /^start$/m);
 });

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -1,7 +1,55 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+const AGENT_IDS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto", "iris"] as const;
 const DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
+const LOOP_INTERVAL_MS = 200;
+const MISSION_STORE_DIR = "noctis-missions";
+const SESSION_NAME = "ff15";
+const STALE_LEASE_MS = 5_000;
+
+type AgentId = (typeof AGENT_IDS)[number];
+type PrimaryAgentOutboxStatus = "pending" | "leased" | "submitted";
+
+type PrimaryAgentOutboxItem = {
+  createdAt: string;
+  id: string;
+  lease?: {
+    attempt: number;
+    leasedAt: string;
+    owner: string;
+    staleAfterMs: number;
+    recoveredFrom?: {
+      attempt: number;
+      leasedAt: string;
+      owner: string;
+      staleAfterMs: number;
+    };
+  };
+  missionId: string;
+  payload: {
+    agent: AgentId;
+    model?: {
+      modelID: string;
+      providerID: string;
+    };
+    parts: Array<{
+      text: string;
+      type: "text";
+    }>;
+    sessionId: string;
+    system?: string;
+    variant?: string;
+  };
+  status: PrimaryAgentOutboxStatus;
+  submission?: {
+    dispatcherPid?: number;
+    submittedAt: string;
+    submittedBy: string;
+  };
+  updatedAt: string;
+};
 
 function parseRoot(argv: string[]): string {
   const rootIndex = argv.indexOf("--root");
@@ -16,7 +64,28 @@ function getDispatcherStatePath(root: string): string {
   return join(root, "runtime", DISPATCHER_STATE_FILE);
 }
 
-function writeState(root: string): void {
+function getMissionStorePath(root: string): string {
+  return join(root, "runtime", MISSION_STORE_DIR);
+}
+
+function getOutboxStateDir(
+  root: string,
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+): string {
+  return join(getMissionStorePath(root), missionId, "transport", "primary-agent-outbox", status);
+}
+
+function getOutboxItemPath(
+  root: string,
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+  itemId: string,
+): string {
+  return join(getOutboxStateDir(root, missionId, status), `${itemId}.json`);
+}
+
+function writeState(root: string, extra: Record<string, unknown> = {}): void {
   mkdirSync(join(root, "runtime"), { recursive: true });
   writeFileSync(
     getDispatcherStatePath(root),
@@ -27,6 +96,7 @@ function writeState(root: string): void {
         mode: "tmux-resident",
         pid: process.pid,
         startedAt: new Date().toISOString(),
+        ...extra,
       },
       null,
       2,
@@ -39,10 +109,310 @@ function cleanup(root: string): void {
   rmSync(getDispatcherStatePath(root), { force: true });
 }
 
+function isOutboxStatus(value: unknown): value is PrimaryAgentOutboxStatus {
+  return value === "pending" || value === "leased" || value === "submitted";
+}
+
+function isAgentId(value: unknown): value is AgentId {
+  return AGENT_IDS.some((agentId) => agentId === value);
+}
+
+function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.id !== "string" ||
+    typeof record.missionId !== "string" ||
+    typeof record.createdAt !== "string" ||
+    typeof record.updatedAt !== "string" ||
+    !isOutboxStatus(record.status)
+  ) {
+    return null;
+  }
+
+  const payload = record.payload;
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const payloadRecord = payload as Record<string, unknown>;
+  if (
+    !isAgentId(payloadRecord.agent) ||
+    typeof payloadRecord.sessionId !== "string" ||
+    !Array.isArray(payloadRecord.parts) ||
+    payloadRecord.parts.some(
+      (part) =>
+        !part ||
+        typeof part !== "object" ||
+        (part as Record<string, unknown>).type !== "text" ||
+        typeof (part as Record<string, unknown>).text !== "string",
+    )
+  ) {
+    return null;
+  }
+
+  return record as PrimaryAgentOutboxItem;
+}
+
+function listMissionIds(root: string): string[] {
+  const missionStorePath = getMissionStorePath(root);
+  if (!existsSync(missionStorePath)) {
+    return [];
+  }
+
+  return readdirSync(missionStorePath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function readItemsForStatus(
+  root: string,
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+): PrimaryAgentOutboxItem[] {
+  const dir = getOutboxStateDir(root, missionId, status);
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => {
+      try {
+        return normalizeItem(JSON.parse(readFileSync(join(dir, entry), "utf-8")));
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is PrimaryAgentOutboxItem => item !== null);
+}
+
+function compareItems(left: PrimaryAgentOutboxItem, right: PrimaryAgentOutboxItem): number {
+  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+}
+
+function isStale(item: PrimaryAgentOutboxItem, now: string): boolean {
+  if (!item.lease) {
+    return false;
+  }
+
+  const leasedAt = Date.parse(item.lease.leasedAt);
+  const checkedAt = Date.parse(now);
+  if (Number.isNaN(leasedAt) || Number.isNaN(checkedAt)) {
+    return false;
+  }
+
+  return checkedAt - leasedAt > item.lease.staleAfterMs;
+}
+
+function writeItem(root: string, item: PrimaryAgentOutboxItem): void {
+  for (const status of ["pending", "leased", "submitted"] as const) {
+    mkdirSync(getOutboxStateDir(root, item.missionId, status), { recursive: true });
+    rmSync(getOutboxItemPath(root, item.missionId, status, item.id), { force: true });
+  }
+
+  writeFileSync(
+    getOutboxItemPath(root, item.missionId, item.status, item.id),
+    `${JSON.stringify(item, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+function claimNextItem(root: string, now: string): PrimaryAgentOutboxItem | null {
+  const candidates = listMissionIds(root).flatMap((missionId) => {
+    const pending = readItemsForStatus(root, missionId, "pending");
+    const staleLeased = readItemsForStatus(root, missionId, "leased").filter((item) => isStale(item, now));
+    return [...pending, ...staleLeased];
+  });
+  const candidate = candidates.sort(compareItems)[0] ?? null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  const claimed: PrimaryAgentOutboxItem = {
+    ...candidate,
+    status: "leased",
+    updatedAt: now,
+    lease: {
+      attempt: (candidate.lease?.attempt ?? 0) + 1,
+      leasedAt: now,
+      owner: `dispatcher:${process.pid}`,
+      staleAfterMs: candidate.lease?.staleAfterMs ?? STALE_LEASE_MS,
+      ...(candidate.lease
+        ? {
+            recoveredFrom: {
+              attempt: candidate.lease.attempt,
+              leasedAt: candidate.lease.leasedAt,
+              owner: candidate.lease.owner,
+              staleAfterMs: candidate.lease.staleAfterMs,
+            },
+          }
+        : {}),
+    },
+  };
+
+  writeItem(root, claimed);
+  return claimed;
+}
+
+function runTmux(root: string, args: string[]): { code: number; stderr: string; stdout: string } {
+  const result = spawnSync("tmux", args, {
+    cwd: root,
+    encoding: "utf-8",
+  });
+
+  return {
+    code: result.status ?? 1,
+    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? "",
+  };
+}
+
+function buildDispatchText(item: PrimaryAgentOutboxItem): string {
+  const header = [
+    `[primary-agent-dispatch] mission=${item.missionId}`,
+    `session=${item.payload.sessionId}`,
+    `agent=${item.payload.agent}`,
+  ].join(" ");
+
+  return [
+    header,
+    item.payload.model
+      ? `model=${item.payload.model.providerID}/${item.payload.model.modelID}`
+      : null,
+    item.payload.variant ? `variant=${item.payload.variant}` : null,
+    item.payload.system ?? null,
+    ...item.payload.parts.map((part) => part.text),
+  ]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join("\n\n");
+}
+
+function applyModelSelection(root: string, target: string, item: PrimaryAgentOutboxItem): void {
+  if (!item.payload.model) {
+    return;
+  }
+
+  const openModelPicker = runTmux(root, ["send-keys", "-t", target, "/models"]);
+  if (openModelPicker.code !== 0) {
+    throw new Error(openModelPicker.stderr || `Failed to open model picker for ${target}`);
+  }
+
+  const submitModelPicker = runTmux(root, ["send-keys", "-t", target, "Enter"]);
+  if (submitModelPicker.code !== 0) {
+    throw new Error(submitModelPicker.stderr || `Failed to confirm model picker for ${target}`);
+  }
+
+  const modelRef = `${item.payload.model.providerID}/${item.payload.model.modelID}`;
+  const sendModel = runTmux(root, ["send-keys", "-t", target, modelRef]);
+  if (sendModel.code !== 0) {
+    throw new Error(sendModel.stderr || `Failed to select model ${modelRef} for ${target}`);
+  }
+
+  const submitModel = runTmux(root, ["send-keys", "-t", target, "Enter"]);
+  if (submitModel.code !== 0) {
+    throw new Error(submitModel.stderr || `Failed to confirm model ${modelRef} for ${target}`);
+  }
+
+  if (!item.payload.variant) {
+    return;
+  }
+
+  const sendVariant = runTmux(root, ["send-keys", "-t", target, item.payload.variant]);
+  if (sendVariant.code !== 0) {
+    throw new Error(sendVariant.stderr || `Failed to select variant ${item.payload.variant} for ${target}`);
+  }
+
+  const submitVariant = runTmux(root, ["send-keys", "-t", target, "Enter"]);
+  if (submitVariant.code !== 0) {
+    throw new Error(
+      submitVariant.stderr || `Failed to confirm variant ${item.payload.variant} for ${target}`,
+    );
+  }
+}
+
+function submitClaimedItem(root: string, item: PrimaryAgentOutboxItem): void {
+  const paneIndex = AGENT_IDS.indexOf(item.payload.agent);
+  if (paneIndex === -1) {
+    throw new Error(`Unsupported primary-agent outbox target: ${item.payload.agent}`);
+  }
+
+  const target = `${SESSION_NAME}:main.${paneIndex}`;
+  const payload = buildDispatchText(item);
+  applyModelSelection(root, target, item);
+  const sendPayload = runTmux(root, ["send-keys", "-t", target, "-l", payload]);
+  if (sendPayload.code !== 0) {
+    throw new Error(sendPayload.stderr || `Failed to send outbox payload to ${target}`);
+  }
+
+  const sendEnter = runTmux(root, ["send-keys", "-t", target, "Enter"]);
+  if (sendEnter.code !== 0) {
+    throw new Error(sendEnter.stderr || `Failed to submit outbox payload to ${target}`);
+  }
+
+  writeItem(root, {
+    ...item,
+    status: "submitted",
+    updatedAt: new Date().toISOString(),
+    submission: {
+      dispatcherPid: process.pid,
+      submittedAt: new Date().toISOString(),
+      submittedBy: `dispatcher:${process.pid}`,
+    },
+  });
+}
+
+function countQueuedItems(root: string): number {
+  return listMissionIds(root).reduce((total, missionId) => {
+    return total + readItemsForStatus(root, missionId, "pending").length + readItemsForStatus(root, missionId, "leased").length;
+  }, 0);
+}
+
 const root = parseRoot(process.argv.slice(2));
-writeState(root);
+let processedCount = 0;
+const dispatcherStartedAt = new Date().toISOString();
+
+const tick = () => {
+  try {
+    const now = new Date().toISOString();
+    const claimed = claimNextItem(root, now);
+    if (claimed) {
+      submitClaimedItem(root, claimed);
+      processedCount += 1;
+    }
+
+    writeState(root, {
+      lastActivityAt: now,
+      processedCount,
+      queuedCount: countQueuedItems(root),
+      startedAt: dispatcherStartedAt,
+    });
+  } catch (error) {
+    writeState(root, {
+      lastActivityAt: new Date().toISOString(),
+      lastError: error instanceof Error ? error.message : String(error),
+      processedCount,
+      queuedCount: countQueuedItems(root),
+      startedAt: dispatcherStartedAt,
+    });
+  }
+};
+
+writeState(root, {
+  processedCount,
+  queuedCount: countQueuedItems(root),
+  startedAt: dispatcherStartedAt,
+});
+tick();
+const interval = setInterval(tick, LOOP_INTERVAL_MS);
 
 const exitGracefully = () => {
+  clearInterval(interval);
   cleanup(root);
   process.exit(0);
 };
@@ -50,7 +420,6 @@ const exitGracefully = () => {
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
 process.on("exit", () => {
+  clearInterval(interval);
   cleanup(root);
 });
-
-setInterval(() => {}, 1_000);

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const AGENT_IDS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto", "iris"] as const;
+const AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto", "lunafreya", "iris"] as const;
 const DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
 const LOOP_INTERVAL_MS = 200;
 const MISSION_STORE_DIR = "noctis-missions";

--- a/scripts/tmux_transport_runtime.mts
+++ b/scripts/tmux_transport_runtime.mts
@@ -4,13 +4,13 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const AGENT_IDS = ["noctis", "lunafreya", "ignis", "gladiolus", "prompto", "iris"] as const;
+const AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto", "lunafreya", "iris"] as const;
 const DEFAULT_PORTS: Record<(typeof AGENT_IDS)[number], number> = {
   noctis: 4401,
-  lunafreya: 4402,
   ignis: 4403,
   gladiolus: 4404,
   prompto: 4405,
+  lunafreya: 4402,
   iris: 4406,
 };
 const DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
@@ -188,12 +188,11 @@ function ensureTmuxSession(root: string): void {
   }
 
   const layoutCommands = [
+    ["split-window", "-h", "-f", "-l", "66%", "-t", `${SESSION_NAME}:main.0`],
+    ["split-window", "-h", "-l", "50%", "-t", `${SESSION_NAME}:main.1`],
     ["split-window", "-v", "-l", "50%", "-t", `${SESSION_NAME}:main.0`],
-    ["split-window", "-h", "-l", "50%", "-t", `${SESSION_NAME}:main.0`],
-    ["split-window", "-h", "-l", "75%", "-t", `${SESSION_NAME}:main.2`],
-    ["split-window", "-h", "-l", "66%", "-t", `${SESSION_NAME}:main.3`],
-    ["split-window", "-h", "-l", "50%", "-t", `${SESSION_NAME}:main.4`],
-    ["select-layout", "-t", `${SESSION_NAME}:main`, "tiled"],
+    ["split-window", "-v", "-l", "50%", "-t", `${SESSION_NAME}:main.2`],
+    ["split-window", "-v", "-l", "50%", "-t", `${SESSION_NAME}:main.4`],
   ];
 
   for (const command of layoutCommands) {

--- a/scripts/tmux_transport_runtime.mts
+++ b/scripts/tmux_transport_runtime.mts
@@ -18,6 +18,7 @@ const ENDPOINT_MANIFEST_FILE = "opencode-endpoints.json";
 const PORT_RANGE_START = 4401;
 const PORT_RANGE_END = 4499;
 const SESSION_NAME = "ff15";
+const AGENT_LAUNCH_DELAY_MS = 1_000;
 const SCRIPT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
 type AgentEndpointRecord = {
@@ -74,6 +75,10 @@ function runTmux(root: string, args: string[]): { code: number; stderr: string; 
     stderr: result.stderr ?? "",
     stdout: result.stdout ?? "",
   };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -224,7 +229,7 @@ function writeEndpointManifest(root: string, assignedPorts: Record<(typeof AGENT
   return agents;
 }
 
-function launchAgentRoster(root: string, agents: AgentEndpointRecord[]): void {
+async function launchAgentRoster(root: string, agents: AgentEndpointRecord[]): Promise<void> {
   for (const [index, agent] of agents.entries()) {
     const target = `${SESSION_NAME}:main.${index}`;
     const launchCommand = [
@@ -242,6 +247,10 @@ function launchAgentRoster(root: string, agents: AgentEndpointRecord[]): void {
     const sendEnter = runTmux(root, ["send-keys", "-t", target, "Enter"]);
     if (sendEnter.code !== 0) {
       throw new Error(sendEnter.stderr || `Failed to confirm roster launch command for ${agent.agentId}`);
+    }
+
+    if (index < agents.length - 1) {
+      await sleep(AGENT_LAUNCH_DELAY_MS);
     }
   }
 }
@@ -298,7 +307,7 @@ async function start(root: string): Promise<void> {
   ensureTmuxSession(root);
   const assignedPorts = await allocateAgentPorts();
   const agents = writeEndpointManifest(root, assignedPorts);
-  launchAgentRoster(root, agents);
+  await launchAgentRoster(root, agents);
   const dispatcher = await ensureDispatcher(root);
 
   process.stdout.write(

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -127,7 +127,7 @@ function seedPrimaryAgentOutbox(root, missionId) {
         updatedAt: "2026-04-28T00:00:00.000Z",
         status: "pending",
         payload: {
-          agent: "noctis",
+          agent: "lunafreya",
           sessionId: "session-dispatch-1",
           parts: [{ type: "text", text: "queued prompt body" }],
           system: "queued system body",
@@ -219,6 +219,10 @@ test("starts a tmux agent roster, endpoint manifest, and dispatcher daemon", asy
   assert.match(tmuxLog, /new-session/);
   assert.equal((tmuxLog.match(/send-keys -t/g) ?? []).length >= 6, true);
   assert.equal((tmuxLog.match(/opencode --agent/g) ?? []).length, 6);
+  assert.match(
+    tmuxLog,
+    /send-keys -t ff15:main\.0 .*opencode --agent noctis[\s\S]*send-keys -t ff15:main\.1 .*opencode --agent ignis[\s\S]*send-keys -t ff15:main\.2 .*opencode --agent gladiolus[\s\S]*send-keys -t ff15:main\.3 .*opencode --agent prompto[\s\S]*send-keys -t ff15:main\.4 .*opencode --agent lunafreya[\s\S]*send-keys -t ff15:main\.5 .*opencode --agent iris/,
+  );
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);
@@ -252,6 +256,7 @@ test("dispatcher submits queued primary-agent outbox items and retains submitted
   const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
   assert.match(tmuxLog, /queued prompt body/);
   assert.match(tmuxLog, /queued system body/);
+  assert.match(tmuxLog, /send-keys -t ff15:main\.4 -l/);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -93,6 +93,92 @@ function isProcessAlive(pid) {
   }
 }
 
+async function waitFor(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  return predicate();
+}
+
+function seedPrimaryAgentOutbox(root, missionId) {
+  const pendingDir = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    missionId,
+    "transport",
+    "primary-agent-outbox",
+    "pending",
+  );
+  mkdirSync(pendingDir, { recursive: true });
+  writeFileSync(
+    join(pendingDir, "item-dispatch-1.json"),
+    `${JSON.stringify(
+      {
+        id: "item-dispatch-1",
+        missionId,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        updatedAt: "2026-04-28T00:00:00.000Z",
+        status: "pending",
+        payload: {
+          agent: "noctis",
+          sessionId: "session-dispatch-1",
+          parts: [{ type: "text", text: "queued prompt body" }],
+          system: "queued system body",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+function seedStaleLeasedPrimaryAgentOutbox(root, missionId) {
+  const leasedDir = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    missionId,
+    "transport",
+    "primary-agent-outbox",
+    "leased",
+  );
+  mkdirSync(leasedDir, { recursive: true });
+  writeFileSync(
+    join(leasedDir, "item-stale-1.json"),
+    `${JSON.stringify(
+      {
+        id: "item-stale-1",
+        missionId,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        updatedAt: "2026-04-28T00:00:01.000Z",
+        status: "leased",
+        lease: {
+          attempt: 1,
+          leasedAt: "2026-04-28T00:00:01.000Z",
+          owner: "dispatcher:old",
+          staleAfterMs: 1,
+        },
+        payload: {
+          agent: "noctis",
+          sessionId: "session-stale-1",
+          parts: [{ type: "text", text: "recovered stale prompt" }],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
 test.afterEach(() => {
   while (tempRoots.length > 0) {
     const root = tempRoots.pop();
@@ -106,7 +192,9 @@ test("starts a tmux agent roster, endpoint manifest, and dispatcher daemon", asy
   const root = createTempRoot();
   installFakeTmux(root);
 
+  const startedAt = Date.now();
   const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  const elapsedMs = Date.now() - startedAt;
   assert.equal(startResult.code, 0, startResult.stderr);
 
   const manifestPath = join(root, "runtime", "opencode-endpoints.json");
@@ -118,6 +206,7 @@ test("starts a tmux agent roster, endpoint manifest, and dispatcher daemon", asy
   assert.equal(manifest.version, 1);
   assert.equal(Array.isArray(manifest.agents), true);
   assert.equal(manifest.agents.length, 6);
+  assert.ok(elapsedMs >= (manifest.agents.length - 1) * 900, `expected staggered startup, got ${elapsedMs}ms`);
 
   const dispatcherState = JSON.parse(readFileSync(dispatcherStatePath, "utf-8"));
   assert.equal(dispatcherState.version, 1);
@@ -130,6 +219,69 @@ test("starts a tmux agent roster, endpoint manifest, and dispatcher daemon", asy
   assert.match(tmuxLog, /new-session/);
   assert.equal((tmuxLog.match(/send-keys -t/g) ?? []).length >= 6, true);
   assert.equal((tmuxLog.match(/opencode --agent/g) ?? []).length, 6);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher submits queued primary-agent outbox items and retains submitted artifacts", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedPrimaryAgentOutbox(root, "mission-dispatch");
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const submittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-1.json",
+  );
+  assert.equal(await waitFor(() => existsSync(submittedPath), 3_000), true);
+
+  const submitted = JSON.parse(readFileSync(submittedPath, "utf-8"));
+  assert.equal(submitted.status, "submitted");
+  assert.equal(typeof submitted.submission.dispatcherPid, "number");
+  assert.equal(submitted.submission.submittedBy.startsWith("dispatcher:"), true);
+
+  const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
+  assert.match(tmuxLog, /queued prompt body/);
+  assert.match(tmuxLog, /queued system body/);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher reclaims stale leases before submitting retained artifacts", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedStaleLeasedPrimaryAgentOutbox(root, "mission-stale");
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const submittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-stale",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-stale-1.json",
+  );
+  assert.equal(await waitFor(() => existsSync(submittedPath), 3_000), true);
+
+  const submitted = JSON.parse(readFileSync(submittedPath, "utf-8"));
+  assert.equal(submitted.status, "submitted");
+  assert.equal(submitted.lease.attempt, 2);
+  assert.equal(submitted.lease.recoveredFrom.owner, "dispatcher:old");
+  assert.equal(submitted.submission.submittedBy.startsWith("dispatcher:"), true);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/standby.sh
+++ b/standby.sh
@@ -14,6 +14,7 @@ APP_CONFIG_CONTROL_SCRIPT="scripts/app_config_control.mts"
 TMUX_TRANSPORT_CONTROL_SCRIPT="scripts/tmux_transport_runtime.mts"
 ACTION="start"
 RUN_BUILD=false
+ATTACH_SESSION=false
 SERVER_STATE="stopped"
 SERVER_PID=""
 SERVER_CMD=""
@@ -40,14 +41,16 @@ show_help() {
     echo ""
     echo "Options:"
     echo "  -b, --build    Build the web app before launch"
+    echo "      --attach   Attach to ff15 after startup (tmux-resident only)"
     echo "      --set-transport <mode>"
     echo "                 Persist transport_mode in config/settings.yaml"
     echo "      --stop     Stop the managed web server and app-owned OpenCode server"
-    echo "      --status   Print managed web and OpenCode server status"
+    echo "      --status   Print managed web, OpenCode, and dispatcher status"
     echo "  -h, --help     Show this help"
     echo ""
     echo "Examples:"
     echo "  ./standby.sh"
+    echo "  ./standby.sh --attach"
     echo "  ./standby.sh --build"
     echo "  ./standby.sh --set-transport tmux-resident"
     echo "  ./standby.sh --set-transport app-owned"
@@ -202,6 +205,10 @@ parse_args() {
                 RUN_BUILD=true
                 shift
                 ;;
+            --attach)
+                ATTACH_SESSION=true
+                shift
+                ;;
             --stop)
                 set_action "stop"
                 shift
@@ -234,6 +241,12 @@ parse_args() {
 
     if [ "$RUN_BUILD" = true ] && [ "$ACTION" != "start" ]; then
         log_warn "--build can only be used when starting the web app."
+        show_help
+        exit 1
+    fi
+
+    if [ "$ATTACH_SESSION" = true ] && [ "$ACTION" != "start" ]; then
+        log_warn "--attach can only be used when starting the web app."
         show_help
         exit 1
     fi
@@ -463,6 +476,7 @@ print_tmux_transport_status() {
 print_managed_status() {
     local web_status
     local opencode_status
+    local tmux_status
 
     if print_server_status; then
         web_status=0
@@ -475,17 +489,33 @@ print_managed_status() {
     if [ "$TRANSPORT_MODE" = "tmux-resident" ]; then
         if print_tmux_transport_status; then
             opencode_status=0
+            tmux_status=0
+        else
+            opencode_status=$?
+            tmux_status=$opencode_status
+        fi
+    else
+        if print_opencode_status; then
+            opencode_status=0
         else
             opencode_status=$?
         fi
-    elif print_opencode_status; then
-        opencode_status=0
-    else
-        opencode_status=$?
+
+        echo ""
+
+        if print_tmux_transport_status; then
+            tmux_status=0
+        else
+            tmux_status=$?
+        fi
     fi
 
-    if [ "$web_status" -eq 2 ] || [ "$opencode_status" -eq 2 ]; then
+    if [ "$web_status" -eq 2 ] || [ "$opencode_status" -eq 2 ] || [ "$tmux_status" -eq 2 ]; then
         return 2
+    fi
+
+    if [ "$TRANSPORT_MODE" = "tmux-resident" ] && [ "$tmux_status" -ne 0 ]; then
+        return 1
     fi
 
     if [ "$web_status" -ne 0 ] || [ "$opencode_status" -ne 0 ]; then
@@ -700,6 +730,46 @@ open_browser() {
     return 1
 }
 
+attach_tmux_session() {
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        log_warn "Cannot attach tmux session without an interactive terminal."
+        return 1
+    fi
+
+    if [ -n "${TMUX:-}" ]; then
+        log_info "Switching tmux client to session ff15..."
+        tmux switch-client -t ff15
+        return $?
+    fi
+
+    log_info "Attaching to tmux session ff15..."
+    tmux attach-session -t ff15
+}
+
+ensure_tmux_transport_ready() {
+    local status_json
+    local state
+
+    if [ "$ATTACH_SESSION" = true ]; then
+        if status_json="$(run_tmux_transport_control status 2>/dev/null)"; then
+            state="$(json_get "$status_json" "state" 2>/dev/null || true)"
+            if [ "$state" = "running" ]; then
+                log_info "Reusing existing tmux transport runtime."
+                return 0
+            fi
+        fi
+    fi
+
+    log_info "Bootstrapping tmux-resident OpenCode transport..."
+    if run_tmux_transport_control start >/dev/null; then
+        log_success "Tmux transport runtime is ready."
+        return 0
+    fi
+
+    log_warn "Failed to start tmux transport runtime."
+    return 1
+}
+
 start_server() {
     local start_command
 
@@ -717,6 +787,11 @@ start_server() {
 require_command node
 parse_args "$@"
 TRANSPORT_MODE="$(read_transport_mode)"
+
+if [ "$ATTACH_SESSION" = true ] && [ "$TRANSPORT_MODE" != "tmux-resident" ]; then
+    log_warn "--attach requires transport_mode=tmux-resident."
+    exit 1
+fi
 
 case "$ACTION" in
     set-transport)
@@ -759,11 +834,7 @@ log_info "Selected transport mode: ${TRANSPORT_MODE}"
 
 if [ "$TRANSPORT_MODE" = "tmux-resident" ]; then
     require_command tmux
-    log_info "Bootstrapping tmux-resident OpenCode transport..."
-    if run_tmux_transport_control start >/dev/null; then
-        log_success "Tmux transport runtime is ready."
-    else
-        log_warn "Failed to start tmux transport runtime."
+    if ! ensure_tmux_transport_ready; then
         exit 1
     fi
 fi
@@ -800,3 +871,12 @@ else
 fi
 
 log_success "Standby complete. Web server PID: ${WEB_PID}"
+
+if [ "$ATTACH_SESSION" = true ]; then
+    if attach_tmux_session; then
+        exit 0
+    fi
+
+    log_warn "Failed to attach to tmux session ff15."
+    exit 1
+fi

--- a/web/app/lib/mission-api.server.ts
+++ b/web/app/lib/mission-api.server.ts
@@ -1,5 +1,6 @@
 import { buildMissionBanterTimeline } from "@/lib/banter/timeline";
 import { getMissionResumeBlock } from "@/lib/mission-runtime-compatibility.server";
+import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
 import { getOpencodeClient } from "@/lib/opencode-client";
 import { readSessionContextUsage } from "@/lib/session-context.server";
 import type { SessionStatus } from "@/lib/session-status";
@@ -97,6 +98,7 @@ export function buildMissionResumePayload(mission: Mission) {
     operationState: mission.operationState ?? null,
     workflowProgress: buildMissionWorkflowProgress(mission.operationState),
     lunafreyaFacetSelection: mission.lunafreyaFacetSelection ?? null,
+    primaryAgentOutbox: listPrimaryAgentOutboxItems(mission.id),
     activityLog: mission.activityLog,
   };
 }

--- a/web/app/lib/mission-primary-agent-outbox.server.test.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.test.ts
@@ -1,0 +1,198 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMission, deleteMission, getMissionDir } from "./mission-store";
+import {
+  enqueuePrimaryAgentOutboxItem,
+  leasePrimaryAgentOutboxItem,
+  listPrimaryAgentOutboxItems,
+  markPrimaryAgentOutboxItemSubmitted,
+} from "./mission-primary-agent-outbox.server";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-outbox-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+afterEach(() => {
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("mission primary-agent outbox", () => {
+  it("enqueues a pending outbox item under the mission transport directory", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-pending", "session-primary-1", {
+      title: "Pending Outbox Mission",
+      objective: "Verify pending artifact persistence",
+    });
+    missionIds.push(mission.id);
+
+    const item = enqueuePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      itemId: "item-pending-1",
+      createdAt: "2026-04-28T00:00:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-primary-1",
+        parts: [{ type: "text", text: "queued prompt" }],
+        system: "{\"missionId\":\"mission-outbox-pending\"}",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5.4",
+        },
+        variant: "fast",
+      },
+    });
+
+    expect(item.status).toBe("pending");
+    expect(item.payload.parts).toEqual([{ type: "text", text: "queued prompt" }]);
+
+    const pendingPath = join(
+      getMissionDir(mission.id),
+      "transport",
+      "primary-agent-outbox",
+      "pending",
+      "item-pending-1.json",
+    );
+    expect(existsSync(pendingPath)).toBe(true);
+
+    const persisted = JSON.parse(readFileSync(pendingPath, "utf-8")) as { status: string };
+    expect(persisted.status).toBe("pending");
+    expect(listPrimaryAgentOutboxItems(mission.id)).toEqual([item]);
+  });
+
+  it("retains submitted artifacts after a leased item is submitted", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-submitted", "session-primary-2", {
+      title: "Submitted Outbox Mission",
+      objective: "Verify submitted artifact retention",
+    });
+    missionIds.push(mission.id);
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      itemId: "item-submitted-1",
+      createdAt: "2026-04-28T00:01:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-primary-2",
+        parts: [{ type: "text", text: "submitted prompt" }],
+      },
+    });
+
+    const leased = leasePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-a",
+      leasedAt: "2026-04-28T00:02:00.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    expect(leased?.status).toBe("leased");
+
+    const submitted = markPrimaryAgentOutboxItemSubmitted({
+      missionId: mission.id,
+      itemId: "item-submitted-1",
+      submittedAt: "2026-04-28T00:03:00.000Z",
+      submittedBy: "dispatcher-a",
+      dispatcherPid: 4242,
+    });
+
+    expect(submitted.status).toBe("submitted");
+    expect(submitted.submission).toEqual({
+      dispatcherPid: 4242,
+      submittedAt: "2026-04-28T00:03:00.000Z",
+      submittedBy: "dispatcher-a",
+    });
+
+    const submittedPath = join(
+      getMissionDir(mission.id),
+      "transport",
+      "primary-agent-outbox",
+      "submitted",
+      "item-submitted-1.json",
+    );
+    expect(existsSync(submittedPath)).toBe(true);
+    expect(listPrimaryAgentOutboxItems(mission.id)).toEqual([submitted]);
+  });
+
+  it("reclaims stale leased items with recovery metadata", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-stale-lease", "session-primary-3", {
+      title: "Stale Lease Mission",
+      objective: "Verify stale lease recovery",
+    });
+    missionIds.push(mission.id);
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      itemId: "item-stale-1",
+      createdAt: "2026-04-28T00:10:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-primary-3",
+        parts: [{ type: "text", text: "recover me" }],
+      },
+    });
+
+    const initialLease = leasePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-a",
+      leasedAt: "2026-04-28T00:10:05.000Z",
+      staleAfterMs: 1_000,
+    });
+
+    expect(initialLease?.lease).toEqual({
+      attempt: 1,
+      leasedAt: "2026-04-28T00:10:05.000Z",
+      owner: "dispatcher-a",
+      staleAfterMs: 1_000,
+    });
+
+    const reclaimedLease = leasePrimaryAgentOutboxItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-b",
+      leasedAt: "2026-04-28T00:10:07.500Z",
+      staleAfterMs: 1_000,
+    });
+
+    expect(reclaimedLease?.lease).toEqual({
+      attempt: 2,
+      leasedAt: "2026-04-28T00:10:07.500Z",
+      owner: "dispatcher-b",
+      recoveredFrom: {
+        attempt: 1,
+        leasedAt: "2026-04-28T00:10:05.000Z",
+        owner: "dispatcher-a",
+        staleAfterMs: 1_000,
+      },
+      staleAfterMs: 1_000,
+    });
+  });
+});

--- a/web/app/lib/mission-primary-agent-outbox.server.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.ts
@@ -1,0 +1,413 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getMissionDir } from "./mission-store";
+import type { TextPromptPart } from "./prompt-parts";
+import type { AgentId, ModelSelection } from "./types/mission";
+
+const PRIMARY_AGENT_OUTBOX_DIR = "primary-agent-outbox";
+const OUTBOX_STATUSES = ["pending", "leased", "submitted"] as const;
+
+export type PrimaryAgentOutboxStatus = (typeof OUTBOX_STATUSES)[number];
+
+export interface PrimaryAgentOutboxRecoveredLease {
+  attempt: number;
+  leasedAt: string;
+  owner: string;
+  staleAfterMs: number;
+}
+
+export interface PrimaryAgentOutboxLease {
+  attempt: number;
+  leasedAt: string;
+  owner: string;
+  staleAfterMs: number;
+  recoveredFrom?: PrimaryAgentOutboxRecoveredLease;
+}
+
+export interface PrimaryAgentOutboxSubmission {
+  dispatcherPid?: number;
+  submittedAt: string;
+  submittedBy: string;
+}
+
+export interface PrimaryAgentOutboxPayload {
+  agent: AgentId;
+  sessionId: string;
+  parts: TextPromptPart[];
+  system?: string;
+  model?: Pick<ModelSelection, "providerID" | "modelID">;
+  variant?: string;
+}
+
+export interface PrimaryAgentOutboxItem {
+  id: string;
+  missionId: string;
+  createdAt: string;
+  updatedAt: string;
+  status: PrimaryAgentOutboxStatus;
+  payload: PrimaryAgentOutboxPayload;
+  lease?: PrimaryAgentOutboxLease;
+  submission?: PrimaryAgentOutboxSubmission;
+}
+
+function isOutboxStatus(value: unknown): value is PrimaryAgentOutboxStatus {
+  return OUTBOX_STATUSES.some((status) => status === value);
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function normalizePromptParts(value: unknown): TextPromptPart[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const parts = value
+    .map((part) => {
+      if (!part || typeof part !== "object") {
+        return null;
+      }
+
+      const record = part as Record<string, unknown>;
+      if (record.type !== "text" || typeof record.text !== "string") {
+        return null;
+      }
+
+      return {
+        type: "text" as const,
+        text: record.text,
+      };
+    })
+    .filter((part): part is TextPromptPart => part !== null);
+
+  return parts.length === value.length ? parts : null;
+}
+
+function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const agent = normalizeString(record.agent);
+  const sessionId = normalizeString(record.sessionId);
+  const parts = normalizePromptParts(record.parts);
+
+  if (!agent || !sessionId || !parts) {
+    return null;
+  }
+
+  return {
+    agent: agent as AgentId,
+    sessionId,
+    parts,
+    ...(normalizeString(record.system) ? { system: normalizeString(record.system) } : {}),
+    ...(record.model && typeof record.model === "object"
+      ? {
+          model: {
+            providerID: (record.model as Record<string, unknown>).providerID as string,
+            modelID: (record.model as Record<string, unknown>).modelID as string,
+          },
+        }
+      : {}),
+    ...(normalizeString(record.variant) ? { variant: normalizeString(record.variant) } : {}),
+  };
+}
+
+function normalizeRecoveredLease(value: unknown): PrimaryAgentOutboxRecoveredLease | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.attempt !== "number" ||
+    typeof record.leasedAt !== "string" ||
+    typeof record.owner !== "string" ||
+    typeof record.staleAfterMs !== "number"
+  ) {
+    return undefined;
+  }
+
+  return {
+    attempt: record.attempt,
+    leasedAt: record.leasedAt,
+    owner: record.owner,
+    staleAfterMs: record.staleAfterMs,
+  };
+}
+
+function normalizeLease(value: unknown): PrimaryAgentOutboxLease | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.attempt !== "number" ||
+    typeof record.leasedAt !== "string" ||
+    typeof record.owner !== "string" ||
+    typeof record.staleAfterMs !== "number"
+  ) {
+    return undefined;
+  }
+
+  return {
+    attempt: record.attempt,
+    leasedAt: record.leasedAt,
+    owner: record.owner,
+    staleAfterMs: record.staleAfterMs,
+    ...(normalizeRecoveredLease(record.recoveredFrom)
+      ? { recoveredFrom: normalizeRecoveredLease(record.recoveredFrom) }
+      : {}),
+  };
+}
+
+function normalizeSubmission(value: unknown): PrimaryAgentOutboxSubmission | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.submittedAt !== "string" || typeof record.submittedBy !== "string") {
+    return undefined;
+  }
+
+  return {
+    submittedAt: record.submittedAt,
+    submittedBy: record.submittedBy,
+    ...(typeof record.dispatcherPid === "number" ? { dispatcherPid: record.dispatcherPid } : {}),
+  };
+}
+
+function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const id = normalizeString(record.id);
+  const missionId = normalizeString(record.missionId);
+  const createdAt = normalizeString(record.createdAt);
+  const updatedAt = normalizeString(record.updatedAt);
+  const payload = normalizePayload(record.payload);
+
+  if (!id || !missionId || !createdAt || !updatedAt || !isOutboxStatus(record.status) || !payload) {
+    return null;
+  }
+
+  return {
+    id,
+    missionId,
+    createdAt,
+    updatedAt,
+    status: record.status,
+    payload,
+    ...(normalizeLease(record.lease) ? { lease: normalizeLease(record.lease) } : {}),
+    ...(normalizeSubmission(record.submission)
+      ? { submission: normalizeSubmission(record.submission) }
+      : {}),
+  };
+}
+
+function compareItems(left: PrimaryAgentOutboxItem, right: PrimaryAgentOutboxItem): number {
+  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+}
+
+function ensurePrimaryAgentOutboxDirs(missionId: string): void {
+  for (const status of OUTBOX_STATUSES) {
+    mkdirSync(getMissionPrimaryAgentOutboxStateDir(missionId, status), { recursive: true });
+  }
+}
+
+function getPrimaryAgentOutboxItemPath(
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+  itemId: string,
+): string {
+  return join(getMissionPrimaryAgentOutboxStateDir(missionId, status), `${itemId}.json`);
+}
+
+function writeItem(item: PrimaryAgentOutboxItem, previousStatus?: PrimaryAgentOutboxStatus): void {
+  ensurePrimaryAgentOutboxDirs(item.missionId);
+
+  for (const status of OUTBOX_STATUSES) {
+    if (status === item.status || status === previousStatus) {
+      rmSync(getPrimaryAgentOutboxItemPath(item.missionId, status, item.id), { force: true });
+    }
+  }
+
+  writeFileSync(
+    getPrimaryAgentOutboxItemPath(item.missionId, item.status, item.id),
+    `${JSON.stringify(item, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+function readItemsForStatus(
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+): PrimaryAgentOutboxItem[] {
+  const dir = getMissionPrimaryAgentOutboxStateDir(missionId, status);
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => {
+      try {
+        return normalizeItem(JSON.parse(readFileSync(join(dir, entry), "utf-8")));
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is PrimaryAgentOutboxItem => item !== null)
+    .sort(compareItems);
+}
+
+function findItem(
+  missionId: string,
+  itemId: string,
+): { item: PrimaryAgentOutboxItem; status: PrimaryAgentOutboxStatus } | null {
+  for (const status of OUTBOX_STATUSES) {
+    const path = getPrimaryAgentOutboxItemPath(missionId, status, itemId);
+    if (!existsSync(path)) {
+      continue;
+    }
+
+    try {
+      const item = normalizeItem(JSON.parse(readFileSync(path, "utf-8")));
+      if (item) {
+        return { item, status };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isStaleLease(item: PrimaryAgentOutboxItem, leasedAt: string): boolean {
+  if (item.status !== "leased" || !item.lease) {
+    return false;
+  }
+
+  const leaseStartedAt = Date.parse(item.lease.leasedAt);
+  const leaseCheckedAt = Date.parse(leasedAt);
+  if (Number.isNaN(leaseStartedAt) || Number.isNaN(leaseCheckedAt)) {
+    return false;
+  }
+
+  return leaseCheckedAt - leaseStartedAt > item.lease.staleAfterMs;
+}
+
+export function getMissionPrimaryAgentOutboxDir(missionId: string): string {
+  return join(getMissionDir(missionId), "transport", PRIMARY_AGENT_OUTBOX_DIR);
+}
+
+export function getMissionPrimaryAgentOutboxStateDir(
+  missionId: string,
+  status: PrimaryAgentOutboxStatus,
+): string {
+  return join(getMissionPrimaryAgentOutboxDir(missionId), status);
+}
+
+export function enqueuePrimaryAgentOutboxItem(input: {
+  missionId: string;
+  itemId?: string;
+  createdAt?: string;
+  payload: PrimaryAgentOutboxPayload;
+}): PrimaryAgentOutboxItem {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const item: PrimaryAgentOutboxItem = {
+    id: input.itemId ?? randomUUID(),
+    missionId: input.missionId,
+    createdAt,
+    updatedAt: createdAt,
+    status: "pending",
+    payload: input.payload,
+  };
+
+  writeItem(item);
+  return item;
+}
+
+export function listPrimaryAgentOutboxItems(missionId: string): PrimaryAgentOutboxItem[] {
+  return OUTBOX_STATUSES.flatMap((status) => readItemsForStatus(missionId, status)).sort(compareItems);
+}
+
+export function leasePrimaryAgentOutboxItem(input: {
+  missionId: string;
+  leaseOwner: string;
+  leasedAt?: string;
+  staleAfterMs: number;
+}): PrimaryAgentOutboxItem | null {
+  const leasedAt = input.leasedAt ?? new Date().toISOString();
+  const pending = readItemsForStatus(input.missionId, "pending");
+  const staleLeased = readItemsForStatus(input.missionId, "leased").filter((item) =>
+    isStaleLease(item, leasedAt),
+  );
+  const candidate = [...pending, ...staleLeased].sort(compareItems)[0] ?? null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  const nextItem: PrimaryAgentOutboxItem = {
+    ...candidate,
+    status: "leased",
+    updatedAt: leasedAt,
+    lease: {
+      attempt: (candidate.lease?.attempt ?? 0) + 1,
+      leasedAt,
+      owner: input.leaseOwner,
+      staleAfterMs: input.staleAfterMs,
+      ...(candidate.lease
+        ? {
+            recoveredFrom: {
+              attempt: candidate.lease.attempt,
+              leasedAt: candidate.lease.leasedAt,
+              owner: candidate.lease.owner,
+              staleAfterMs: candidate.lease.staleAfterMs,
+            },
+          }
+        : {}),
+    },
+  };
+
+  writeItem(nextItem, candidate.status);
+  return nextItem;
+}
+
+export function markPrimaryAgentOutboxItemSubmitted(input: {
+  missionId: string;
+  itemId: string;
+  submittedAt?: string;
+  submittedBy: string;
+  dispatcherPid?: number;
+}): PrimaryAgentOutboxItem {
+  const record = findItem(input.missionId, input.itemId);
+  if (!record) {
+    throw new Error(`Primary-agent outbox item not found: ${input.itemId}`);
+  }
+
+  const submittedAt = input.submittedAt ?? new Date().toISOString();
+  const item: PrimaryAgentOutboxItem = {
+    ...record.item,
+    status: "submitted",
+    updatedAt: submittedAt,
+    submission: {
+      submittedAt,
+      submittedBy: input.submittedBy,
+      ...(typeof input.dispatcherPid === "number" ? { dispatcherPid: input.dispatcherPid } : {}),
+    },
+  };
+
+  writeItem(item, record.status);
+  return item;
+}

--- a/web/app/lib/primary-agent-outbox-dispatch.server.ts
+++ b/web/app/lib/primary-agent-outbox-dispatch.server.ts
@@ -1,0 +1,47 @@
+import { appendMissionActivity } from "./mission-store";
+import {
+  enqueuePrimaryAgentOutboxItem,
+  type PrimaryAgentOutboxItem,
+} from "./mission-primary-agent-outbox.server";
+import type { TextPromptPart } from "./prompt-parts";
+import type { AgentId, ModelSelection } from "./types/mission";
+
+export function queuePrimaryAgentTmuxDispatch(input: {
+  agent: AgentId;
+  missionId: string;
+  model?: Pick<ModelSelection, "providerID" | "modelID">;
+  parts: TextPromptPart[];
+  queuedAt?: string;
+  sessionId: string;
+  system?: string;
+  variant?: string;
+}): PrimaryAgentOutboxItem {
+  const queuedAt = input.queuedAt ?? new Date().toISOString();
+  const item = enqueuePrimaryAgentOutboxItem({
+    missionId: input.missionId,
+    createdAt: queuedAt,
+    payload: {
+      agent: input.agent,
+      sessionId: input.sessionId,
+      parts: input.parts,
+      ...(input.system ? { system: input.system } : {}),
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.variant ? { variant: input.variant } : {}),
+    },
+  });
+
+  appendMissionActivity(input.missionId, {
+    id: `activity_${item.id}`,
+    actor: "system",
+    speaker: "system",
+    kind: "system_event",
+    body: "Queued primary-agent tmux delivery.",
+    createdAt: queuedAt,
+    source: {
+      type: "system",
+      sessionId: input.sessionId,
+    },
+  });
+
+  return item;
+}

--- a/web/app/lib/tmux-transport-bootstrap.server.test.ts
+++ b/web/app/lib/tmux-transport-bootstrap.server.test.ts
@@ -66,4 +66,57 @@ describe("tmux-transport-bootstrap.server", () => {
       isReady: false,
     });
   });
+
+  it("accepts a healthy dispatcher state file that includes runtime queue metadata", async () => {
+    const root = createTempRoot();
+
+    writeFileSync(
+      join(root, "runtime", "opencode-endpoints.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          startedAt: "2026-04-27T00:00:00.000Z",
+          agents: [
+            {
+              agentId: "noctis",
+              port: 4401,
+              url: "http://127.0.0.1:4401",
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    writeFileSync(
+      join(root, "runtime", "tmux-transport-dispatcher.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          owner: "standby",
+          mode: "tmux-resident",
+          pid: process.pid,
+          startedAt: "2026-04-27T00:00:00.000Z",
+          processedCount: 2,
+          queuedCount: 1,
+          lastActivityAt: "2026-04-27T00:01:00.000Z",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    const status = await getTmuxTransportBootstrapStatus(root);
+
+    expect(status).toMatchObject({
+      agentCount: 1,
+      dispatcherPid: process.pid,
+      dispatcherState: "valid",
+      endpointManifestState: "valid",
+      error: null,
+      isReady: true,
+    });
+  });
 });

--- a/web/app/routes/api.noctis.mission.continue.ts
+++ b/web/app/routes/api.noctis.mission.continue.ts
@@ -14,6 +14,7 @@ import {
   getNoctisExecutionMode,
 } from "@/lib/noctis-working-party";
 import { getOpencodeClient } from "@/lib/opencode-client";
+import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
@@ -172,6 +173,38 @@ export const action = async ({ request }: Route.ActionArgs) => {
       sessionId,
       isNewMission: false,
     });
+
+    if (transportStatus.transportMode === "tmux-resident") {
+      appendSessionPromptDebugLog({
+        route: "api.noctis.mission.continue",
+        stage: "prompt-dispatched",
+        requestId,
+        sessionId,
+        payload: {
+          sessionID: sessionId,
+          model: model ?? null,
+          variant: variant ?? null,
+          agent: noctisAgentProfile,
+          parts: composed.payloadParts,
+          mission: {
+            missionId,
+            sessionRecreated,
+            ...missionDebugContext,
+          },
+        },
+      });
+
+      queuePrimaryAgentTmuxDispatch({
+        missionId,
+        sessionId,
+        agent: noctisAgentProfile,
+        parts: composed.payloadParts,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      return Response.json({ noctisSessionId: sessionId });
+    }
 
     appendSessionPromptDebugLog({
       route: "api.noctis.mission.continue",

--- a/web/app/routes/api.noctis.mission.execution-workspace.test.ts
+++ b/web/app/routes/api.noctis.mission.execution-workspace.test.ts
@@ -8,9 +8,11 @@ import {
   createMission,
   deleteMission,
   getMission,
+  getMissionPrimarySessionId,
   setWorkerSession,
 } from "@/lib/mission-store";
 import { getProjectRoot } from "@/lib/get-project-root.server";
+import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
 
 const { promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
   promptAsyncMock: vi.fn(),
@@ -100,6 +102,44 @@ function createTempRoot(options?: {
   );
 
   return root;
+}
+
+function writeHealthyTmuxTransportBootstrapArtifacts(root: string): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  writeFileSync(
+    join(root, "runtime", "opencode-endpoints.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        startedAt: "2026-04-28T00:00:00.000Z",
+        agents: [
+          {
+            agentId: "noctis",
+            port: 4401,
+            url: "http://127.0.0.1:4401",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(root, "runtime", "tmux-transport-dispatcher.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        owner: "standby",
+        mode: "tmux-resident",
+        pid: process.pid,
+        startedAt: "2026-04-28T00:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
 }
 
 async function readJson<T>(response: Response): Promise<T> {
@@ -208,6 +248,59 @@ describe("Noctis mission execution workspace lifecycle", () => {
       error: expect.stringContaining("Missing tmux transport endpoint manifest"),
     });
     expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues tmux-resident mission start payloads instead of dispatching them inline", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    sessionCreateMock.mockResolvedValue({ data: { id: "session-tmux-start" } });
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/noctis/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Start through tmux transport.",
+          executionProjectId: "alpha",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{ missionId: string; noctisSessionId: string }>(response);
+    missionIds.push(data.missionId);
+
+    expect(data.noctisSessionId).toBe("session-tmux-start");
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+
+    const queuedItems = listPrimaryAgentOutboxItems(data.missionId);
+    expect(queuedItems).toHaveLength(1);
+    expect(queuedItems[0]).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-tmux-start",
+        parts: [
+          {
+            type: "text",
+            text: expect.stringContaining("<user-request from=\"user\" to=\"noctis\">") as never,
+          },
+        ],
+      },
+    });
+
+    const mission = getMission(data.missionId);
+    expect(mission?.activityLog).toContainEqual(
+      expect.objectContaining({
+        kind: "system_event",
+        body: "Queued primary-agent tmux delivery.",
+      }),
+    );
+    expect(mission?.activityLog.map((entry) => entry.body).join("\n") ?? "").not.toContain(
+      "Start through tmux transport.",
+    );
   });
 
   it("defaults new missions to the execution project root when executionTargetMode is omitted", async () => {
@@ -561,6 +654,53 @@ describe("Noctis mission execution workspace lifecycle", () => {
       noctisSessionId: "session-app-owned",
     });
     expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues tmux-resident mission continue payloads instead of dispatching them inline", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    const mission = createMission(`mission-tmux-enqueue-${crypto.randomUUID()}`, "session-tmux-existing", {
+      title: "Tmux queued mission",
+      objective: "Resume through tmux outbox",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Resume through tmux transport.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await readJson<{ noctisSessionId: string }>(response)).toEqual({
+      noctisSessionId: "session-tmux-existing",
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+
+    const queuedItems = listPrimaryAgentOutboxItems(mission.id);
+    expect(queuedItems).toHaveLength(1);
+    expect(queuedItems[0]).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "noctis",
+        sessionId: getMissionPrimarySessionId(getMission(mission.id)) ?? "session-tmux-existing",
+      },
+    });
+
+    const activityBody = getMission(mission.id)?.activityLog.map((entry) => entry.body).join("\n") ?? "";
+    expect(activityBody).toContain("Queued primary-agent tmux delivery.");
+    expect(activityBody).not.toContain("Resume through tmux transport.");
   });
 
   it("refuses mission continue when tmux transport bootstrap is unhealthy", async () => {

--- a/web/app/routes/api.noctis.mission.start.ts
+++ b/web/app/routes/api.noctis.mission.start.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/operation-definition/operation-catalog";
 import { readOperationLanguage } from "@/lib/operation-definition/language";
 import { getOperationState } from "@/lib/operation-runtime/state";
+import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
@@ -217,6 +218,24 @@ export const action = async ({ request }: Route.ActionArgs) => {
       isNewMission: true,
       selectedOperation,
     });
+
+    if (transportStatus.transportMode === "tmux-resident") {
+      queuePrimaryAgentTmuxDispatch({
+        missionId,
+        sessionId,
+        agent: noctisAgentProfile,
+        parts: composed.payloadParts,
+        system: ledger,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      return Response.json({
+        missionId,
+        noctisSessionId: sessionId,
+        operationState: getOperationState(missionId) ?? null,
+      });
+    }
 
     const promptResult = await client.session.promptAsync({
       sessionID: sessionId,

--- a/web/app/routes/api.noctis.missions.$missionId.test.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createMission, deleteMission } from "@/lib/mission-store";
+import { enqueuePrimaryAgentOutboxItem } from "@/lib/mission-primary-agent-outbox.server";
 import { createOperationState, saveOperationState } from "@/lib/operation-runtime/state";
 import {
   REVIEW_CYCLE_TEST_OPERATION_NAME,
@@ -173,6 +174,54 @@ describe("api.noctis.missions.$missionId", () => {
       expect.objectContaining({
         missionId,
         transportMode: "tmux-resident",
+      }),
+    );
+  });
+
+  it("returns retained primary-agent outbox artifacts in the mission detail payload", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-outbox-detail-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", {
+      title: "Outbox detail mission",
+      objective: "Inspect retained transport artifacts",
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-detail-1",
+      createdAt: "2026-04-28T00:00:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "Inspect this queued payload." }],
+      },
+    });
+
+    const response = await loader({ params: { missionId } } as never);
+    expect(response.status).toBe(200);
+
+    await expect(
+      readJson<{
+        primaryAgentOutbox: Array<{
+          id: string;
+          payload: { sessionId: string };
+          status: string;
+        }>;
+      }>(response),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        primaryAgentOutbox: [
+          expect.objectContaining({
+            id: "item-detail-1",
+            status: "pending",
+            payload: expect.objectContaining({
+              sessionId: "session-noctis",
+            }),
+          }),
+        ],
       }),
     );
   });


### PR DESCRIPTION
## 📝 Summary

- add tmux-resident primary-agent outbox storage and enqueue helpers for mission start and continue flows
- submit queued primary-agent payloads through the dispatcher with lease recovery and submitted-artifact retention
- route session reads and transport inspection through owning agent endpoints so tmux-managed sessions stay consistent end to end
- tighten standby and tmux runtime behavior with dispatcher visibility, attach handling, staggered startup, and deterministic pane layout

## 🎯 Motivation

This PR lands the main tmux-resident transport wiring needed to move primary-agent prompt delivery off the request path and into a durable dispatcher flow. It also includes the supporting session-owner routing and runtime/bootstrap changes required to keep reads, writes, and operational tooling pointed at the same owning agent endpoint.

## 🔧 Changes Overview

- added mission-scoped primary-agent outbox models, storage helpers, and mission inspection payload exposure
- updated Noctis and Lunafreya tmux-managed start/continue routes to enqueue fully materialized payloads instead of dispatching inline
- extended the tmux dispatcher/runtime to lease, submit, reclaim stale work, and retain submitted audit artifacts
- added owner-aware session routing for transcript reads, status aggregation, abort, and open-terminal flows
- updated standby and tmux runtime behavior for dispatcher status, safe attach reuse, staggered launches, and the requested pane ordering/layout
- refreshed focused tests across web routes, mission storage, dispatcher/runtime control, and standby transport behavior

## ✅ Testing

- `bash .opencode/skills/pr-assistant/scripts/quality_checks.sh`
- `node --test scripts/tmux_transport_runtime.test.mjs`
- `node --test scripts/standby_transport_mode.test.mjs`
- `npm --prefix web run test -- app/lib/mission-primary-agent-outbox.server.test.ts app/routes/api.noctis.mission.execution-workspace.test.ts`
- `./node_modules/.bin/vitest run app/routes/api.noctis.missions.*.test.ts`

- [x] Tested locally
- [x] Manual testing completed
- [x] Edge cases considered

## 📸 Screenshots

No screenshots attached. The user-facing impact in this branch is limited to mission transport/runtime behavior rather than a visual redesign.

## 🔗 Related Issues

- Closes #58
- Related to #54
- Related to #65

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots added if useful
- [x] Documentation updated or confirmed unnecessary
- [x] Config, CI, or deployment impact reviewed

## 📌 Notes

- This branch includes the transport groundwork that issue #58 depends on, including the session-owner routing and mission transport snapshot/runtime pieces already developed alongside this slice.
- Follow-up work to render tmux-managed primary-agent responses in mission transcripts remains tracked separately in #65 and is not part of the auto-close scope for this PR.
