### PR TITLE
Implement polling-first mission sync for tmux-managed active missions

### DIFF
--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -40,6 +40,7 @@ type PrimaryAgentOutboxItem = {
       type: "text";
     }>;
     sessionId: string;
+    sessionTitle?: string;
     system?: string;
     variant?: string;
   };
@@ -347,6 +348,46 @@ function buildDispatchText(item: PrimaryAgentOutboxItem): string {
     .join("\n\n");
 }
 
+function resolveManagedSessionTitle(item: PrimaryAgentOutboxItem): string {
+  if (typeof item.payload.sessionTitle === "string" && item.payload.sessionTitle.length > 0) {
+    return item.payload.sessionTitle;
+  }
+
+  return `mission:${item.missionId}`;
+}
+
+function activateManagedSession(
+  root: string,
+  target: string,
+  item: PrimaryAgentOutboxItem,
+  interactionState: { hasSentInput: boolean },
+): void {
+  const sessionTitle = resolveManagedSessionTitle(item);
+  sendTmuxKeys(root, target, ["C-p"], `Failed to open command palette for ${target}`, interactionState);
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", "Switch session"],
+    `Failed to queue session switch command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(root, target, ["Enter"], `Failed to submit session switch command for ${target}`, interactionState);
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", sessionTitle],
+    `Failed to select session ${sessionTitle} for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    target,
+    ["Enter"],
+    `Failed to confirm session ${sessionTitle} for ${target}`,
+    interactionState,
+  );
+}
+
 function applyModelSelection(
   root: string,
   target: string,
@@ -427,6 +468,7 @@ function submitClaimedItem(root: string, item: PrimaryAgentOutboxItem): void {
   const target = `${SESSION_NAME}:main.${paneIndex}`;
   const payload = buildDispatchText(item);
   const interactionState = { hasSentInput: false };
+  activateManagedSession(root, target, item, interactionState);
   applyModelSelection(root, target, item, interactionState);
   sendTmuxKeys(root, target, ["-l", payload], `Failed to send outbox payload to ${target}`, interactionState);
   sendTmuxKeys(root, target, ["Enter"], `Failed to submit outbox payload to ${target}`, interactionState);

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -8,6 +8,7 @@ const LOOP_INTERVAL_MS = 200;
 const MISSION_STORE_DIR = "noctis-missions";
 const SESSION_NAME = "ff15";
 const STALE_LEASE_MS = 5_000;
+const TMUX_INTERACTION_DELAY_SECONDS = "0.5";
 
 type AgentId = (typeof AGENT_IDS)[number];
 type PrimaryAgentOutboxStatus = "pending" | "leased" | "submitted";
@@ -273,6 +274,59 @@ function runTmux(root: string, args: string[]): { code: number; stderr: string; 
   };
 }
 
+function waitForTmuxInteraction(root: string): void {
+  const result = spawnSync("sleep", [TMUX_INTERACTION_DELAY_SECONDS], {
+    cwd: root,
+    encoding: "utf-8",
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      result.stderr ?? `Failed to wait ${TMUX_INTERACTION_DELAY_SECONDS}s between tmux inputs`,
+    );
+  }
+}
+
+function sendTmuxKeys(
+  root: string,
+  target: string,
+  args: string[],
+  errorMessage: string,
+  interactionState: { hasSentInput: boolean },
+): void {
+  if (interactionState.hasSentInput) {
+    waitForTmuxInteraction(root);
+  }
+
+  const result = runTmux(root, ["send-keys", "-t", target, ...args]);
+  if (result.code !== 0) {
+    throw new Error(result.stderr || errorMessage);
+  }
+
+  interactionState.hasSentInput = true;
+}
+
+function readCatalogModelSelectionText(
+  root: string,
+  model: NonNullable<PrimaryAgentOutboxItem["payload"]["model"]>,
+): string | null {
+  const modelKey = `${model.providerID}/${model.modelID}`;
+  const catalogPath = join(root, "runtime", "opencode-model-catalog.json");
+  if (!existsSync(catalogPath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(catalogPath, "utf-8")) as {
+      namesByModel?: Record<string, unknown>;
+    };
+    const displayName = parsed.namesByModel?.[modelKey];
+    return typeof displayName === "string" && displayName.length > 0 ? displayName : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildDispatchText(item: PrimaryAgentOutboxItem): string {
   const header = [
     `[primary-agent-dispatch] mission=${item.missionId}`,
@@ -293,47 +347,75 @@ function buildDispatchText(item: PrimaryAgentOutboxItem): string {
     .join("\n\n");
 }
 
-function applyModelSelection(root: string, target: string, item: PrimaryAgentOutboxItem): void {
+function applyModelSelection(
+  root: string,
+  target: string,
+  item: PrimaryAgentOutboxItem,
+  interactionState: { hasSentInput: boolean },
+): void {
   if (!item.payload.model) {
     return;
   }
 
-  const openModelPicker = runTmux(root, ["send-keys", "-t", target, "/models"]);
-  if (openModelPicker.code !== 0) {
-    throw new Error(openModelPicker.stderr || `Failed to open model picker for ${target}`);
-  }
-
-  const submitModelPicker = runTmux(root, ["send-keys", "-t", target, "Enter"]);
-  if (submitModelPicker.code !== 0) {
-    throw new Error(submitModelPicker.stderr || `Failed to confirm model picker for ${target}`);
-  }
-
   const modelRef = `${item.payload.model.providerID}/${item.payload.model.modelID}`;
-  const sendModel = runTmux(root, ["send-keys", "-t", target, modelRef]);
-  if (sendModel.code !== 0) {
-    throw new Error(sendModel.stderr || `Failed to select model ${modelRef} for ${target}`);
-  }
-
-  const submitModel = runTmux(root, ["send-keys", "-t", target, "Enter"]);
-  if (submitModel.code !== 0) {
-    throw new Error(submitModel.stderr || `Failed to confirm model ${modelRef} for ${target}`);
-  }
+  const selectionText = readCatalogModelSelectionText(root, item.payload.model) ?? modelRef;
+  sendTmuxKeys(root, target, ["C-p"], `Failed to open command palette for ${target}`, interactionState);
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", "Switch model"],
+    `Failed to queue model command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(root, target, ["Enter"], `Failed to submit model command for ${target}`, interactionState);
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", selectionText],
+    `Failed to select model ${selectionText} for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    target,
+    ["Enter"],
+    `Failed to confirm model ${selectionText} for ${target}`,
+    interactionState,
+  );
 
   if (!item.payload.variant) {
     return;
   }
 
-  const sendVariant = runTmux(root, ["send-keys", "-t", target, item.payload.variant]);
-  if (sendVariant.code !== 0) {
-    throw new Error(sendVariant.stderr || `Failed to select variant ${item.payload.variant} for ${target}`);
-  }
-
-  const submitVariant = runTmux(root, ["send-keys", "-t", target, "Enter"]);
-  if (submitVariant.code !== 0) {
-    throw new Error(
-      submitVariant.stderr || `Failed to confirm variant ${item.payload.variant} for ${target}`,
-    );
-  }
+  sendTmuxKeys(root, target, ["C-p"], `Failed to reopen command palette for ${target}`, interactionState);
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", "Switch model variant"],
+    `Failed to queue model variant command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    target,
+    ["Enter"],
+    `Failed to submit model variant command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    target,
+    ["-l", item.payload.variant],
+    `Failed to select variant ${item.payload.variant} for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    target,
+    ["Enter"],
+    `Failed to confirm variant ${item.payload.variant} for ${target}`,
+    interactionState,
+  );
 }
 
 function submitClaimedItem(root: string, item: PrimaryAgentOutboxItem): void {
@@ -344,16 +426,10 @@ function submitClaimedItem(root: string, item: PrimaryAgentOutboxItem): void {
 
   const target = `${SESSION_NAME}:main.${paneIndex}`;
   const payload = buildDispatchText(item);
-  applyModelSelection(root, target, item);
-  const sendPayload = runTmux(root, ["send-keys", "-t", target, "-l", payload]);
-  if (sendPayload.code !== 0) {
-    throw new Error(sendPayload.stderr || `Failed to send outbox payload to ${target}`);
-  }
-
-  const sendEnter = runTmux(root, ["send-keys", "-t", target, "Enter"]);
-  if (sendEnter.code !== 0) {
-    throw new Error(sendEnter.stderr || `Failed to submit outbox payload to ${target}`);
-  }
+  const interactionState = { hasSentInput: false };
+  applyModelSelection(root, target, item, interactionState);
+  sendTmuxKeys(root, target, ["-l", payload], `Failed to send outbox payload to ${target}`, interactionState);
+  sendTmuxKeys(root, target, ["Enter"], `Failed to submit outbox payload to ${target}`, interactionState);
 
   writeItem(root, {
     ...item,

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -140,6 +140,7 @@ function seedPrimaryAgentOutbox(root, missionId, options = {}) {
         payload: {
           agent: "lunafreya",
           sessionId: "session-dispatch-1",
+          ...(options.sessionTitle ? { sessionTitle: options.sessionTitle } : {}),
           parts: [{ type: "text", text: "queued prompt body" }],
           ...(options.model ? { model: options.model } : {}),
           system: "queued system body",
@@ -331,6 +332,7 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
     "github-copilot/gpt-5-mini": "GPT-5-mini",
   });
   seedPrimaryAgentOutbox(root, "mission-display-name", {
+    sessionTitle: "mission:mission-display-name:lunafreya",
     model: {
       providerID: "github-copilot",
       modelID: "gpt-5-mini",
@@ -354,6 +356,10 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
   assert.equal(await waitFor(() => existsSync(submittedPath), 3_000), true);
 
   const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
+  const switchSessionCommandIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l Switch session");
+  const sessionTitleIndex = tmuxLog.indexOf(
+    "send-keys -t ff15:main.4 -l mission:mission-display-name:lunafreya",
+  );
   const switchModelCommandIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l Switch model");
   const displayNameIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l GPT-5-mini");
   const switchVariantCommandIndex = tmuxLog.indexOf(
@@ -363,18 +369,22 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
   const payloadIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l [primary-agent-dispatch]");
 
   assert.match(tmuxLog, /send-keys -t ff15:main\.4 C-p/);
+  assert.equal(switchSessionCommandIndex >= 0, true, tmuxLog);
+  assert.equal(sessionTitleIndex >= 0, true, tmuxLog);
   assert.equal(switchModelCommandIndex >= 0, true, tmuxLog);
   assert.equal(displayNameIndex >= 0, true, tmuxLog);
   assert.equal(switchVariantCommandIndex >= 0, true, tmuxLog);
   assert.equal(variantIndex >= 0, true, tmuxLog);
   assert.equal(payloadIndex >= 0, true, tmuxLog);
+  assert.equal(switchSessionCommandIndex < sessionTitleIndex, true, tmuxLog);
+  assert.equal(sessionTitleIndex < switchModelCommandIndex, true, tmuxLog);
   assert.equal(switchModelCommandIndex < displayNameIndex, true, tmuxLog);
   assert.equal(displayNameIndex < switchVariantCommandIndex, true, tmuxLog);
   assert.equal(switchVariantCommandIndex < variantIndex, true, tmuxLog);
   assert.equal(variantIndex < payloadIndex, true, tmuxLog);
   assert.match(
     tmuxLog,
-    /send-keys -t ff15:main\.4 C-p\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l Switch model/,
+    /send-keys -t ff15:main\.4 C-p\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l Switch session\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l mission:mission-display-name:lunafreya\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 C-p\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l Switch model/,
   );
   assert.match(
     tmuxLog,
@@ -384,9 +394,37 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
     tmuxLog,
     /send-keys -t ff15:main\.4 -l high\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l \[primary-agent-dispatch\]/,
   );
-  assert.equal((tmuxLog.match(/^sleep 0\.5$/gm) ?? []).length, 11, tmuxLog);
+  assert.equal((tmuxLog.match(/^sleep 0\.5$/gm) ?? []).length, 16, tmuxLog);
   assert.doesNotMatch(tmuxLog, /send-keys -t ff15:main\.4 \/models/);
   assert.doesNotMatch(tmuxLog, /send-keys -t ff15:main\.4 github-copilot\/gpt-5-mini/);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher falls back to the legacy raw primary-session title when queued items omit sessionTitle", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedPrimaryAgentOutbox(root, "mission-legacy-title");
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const submittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-legacy-title",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-1.json",
+  );
+  assert.equal(await waitFor(() => existsSync(submittedPath), 3_000), true);
+
+  const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
+  assert.match(tmuxLog, /send-keys -t ff15:main\.4 -l Switch session/);
+  assert.match(tmuxLog, /send-keys -t ff15:main\.4 -l mission:mission-legacy-title/);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -23,6 +23,7 @@ function writeExecutable(path, content) {
 
 function installFakeTmux(root) {
   const tmuxPath = join(root, "bin", "tmux");
+  const sleepPath = join(root, "bin", "sleep");
   writeExecutable(
     tmuxPath,
     `#!/usr/bin/env bash
@@ -52,6 +53,16 @@ case "\${1:-}" in
     ;;
 esac
 
+exit 0
+`,
+  );
+  writeExecutable(
+    sleepPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+ROOT="\${TMUX_STUB_ROOT:?}"
+LOG="\${ROOT}/tmux.log"
+printf '%s\n' "sleep \$*" >> "\$LOG"
 exit 0
 `,
   );
@@ -106,7 +117,7 @@ async function waitFor(predicate, timeoutMs) {
   return predicate();
 }
 
-function seedPrimaryAgentOutbox(root, missionId) {
+function seedPrimaryAgentOutbox(root, missionId, options = {}) {
   const pendingDir = join(
     root,
     "runtime",
@@ -130,8 +141,29 @@ function seedPrimaryAgentOutbox(root, missionId) {
           agent: "lunafreya",
           sessionId: "session-dispatch-1",
           parts: [{ type: "text", text: "queued prompt body" }],
+          ...(options.model ? { model: options.model } : {}),
           system: "queued system body",
+          ...(options.variant ? { variant: options.variant } : {}),
         },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+function seedModelCatalog(root, namesByModel = {}) {
+  writeFileSync(
+    join(root, "runtime", "opencode-model-catalog.json"),
+    `${JSON.stringify(
+      {
+        generatedAt: "2026-04-28T00:00:00.000Z",
+        models: Object.keys(namesByModel),
+        namesByModel,
+        opencodeVersion: "1.3.17",
+        sourceCommand: "opencode models --verbose",
+        variantsByModel: {},
       },
       null,
       2,
@@ -287,6 +319,74 @@ test("dispatcher reclaims stale leases before submitting retained artifacts", as
   assert.equal(submitted.lease.attempt, 2);
   assert.equal(submitted.lease.recoveredFrom.owner, "dispatcher:old");
   assert.equal(submitted.submission.submittedBy.startsWith("dispatcher:"), true);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher uses command palette flow for tmux model and variant selection", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedModelCatalog(root, {
+    "github-copilot/gpt-5-mini": "GPT-5-mini",
+  });
+  seedPrimaryAgentOutbox(root, "mission-display-name", {
+    model: {
+      providerID: "github-copilot",
+      modelID: "gpt-5-mini",
+    },
+    variant: "high",
+  });
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const submittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-display-name",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-1.json",
+  );
+  assert.equal(await waitFor(() => existsSync(submittedPath), 3_000), true);
+
+  const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
+  const switchModelCommandIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l Switch model");
+  const displayNameIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l GPT-5-mini");
+  const switchVariantCommandIndex = tmuxLog.indexOf(
+    "send-keys -t ff15:main.4 -l Switch model variant",
+  );
+  const variantIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l high");
+  const payloadIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l [primary-agent-dispatch]");
+
+  assert.match(tmuxLog, /send-keys -t ff15:main\.4 C-p/);
+  assert.equal(switchModelCommandIndex >= 0, true, tmuxLog);
+  assert.equal(displayNameIndex >= 0, true, tmuxLog);
+  assert.equal(switchVariantCommandIndex >= 0, true, tmuxLog);
+  assert.equal(variantIndex >= 0, true, tmuxLog);
+  assert.equal(payloadIndex >= 0, true, tmuxLog);
+  assert.equal(switchModelCommandIndex < displayNameIndex, true, tmuxLog);
+  assert.equal(displayNameIndex < switchVariantCommandIndex, true, tmuxLog);
+  assert.equal(switchVariantCommandIndex < variantIndex, true, tmuxLog);
+  assert.equal(variantIndex < payloadIndex, true, tmuxLog);
+  assert.match(
+    tmuxLog,
+    /send-keys -t ff15:main\.4 C-p\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l Switch model/,
+  );
+  assert.match(
+    tmuxLog,
+    /send-keys -t ff15:main\.4 -l GPT-5-mini\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 C-p/,
+  );
+  assert.match(
+    tmuxLog,
+    /send-keys -t ff15:main\.4 -l high\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l \[primary-agent-dispatch\]/,
+  );
+  assert.equal((tmuxLog.match(/^sleep 0\.5$/gm) ?? []).length, 11, tmuxLog);
+  assert.doesNotMatch(tmuxLog, /send-keys -t ff15:main\.4 \/models/);
+  assert.doesNotMatch(tmuxLog, /send-keys -t ff15:main\.4 github-copilot\/gpt-5-mini/);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/standby.sh
+++ b/standby.sh
@@ -832,21 +832,22 @@ show_party_roll_call
 
 log_info "Selected transport mode: ${TRANSPORT_MODE}"
 
-if [ "$TRANSPORT_MODE" = "tmux-resident" ]; then
-    require_command tmux
-    if ! ensure_tmux_transport_ready; then
-        exit 1
-    fi
-fi
-
 log_info "Preparing production web app..."
 ensure_dependencies
 
 if [ "$RUN_BUILD" = true ]; then
     log_info "Building web app..."
     npm run web:build
+    ensure_build_artifact
 else
     ensure_build_artifact
+fi
+
+if [ "$TRANSPORT_MODE" = "tmux-resident" ]; then
+    require_command tmux
+    if ! ensure_tmux_transport_ready; then
+        exit 1
+    fi
 fi
 
 stop_existing_server

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -786,6 +786,209 @@ describe("useAgentSession", () => {
     });
   });
 
+  it("settles a pending transcript when runtime polling reports the same primary session idle", async () => {
+    vi.useFakeTimers();
+
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    let runtimeStatus: "busy" | "idle" = "busy";
+    let sessionLoadCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse({
+          ...createRuntimePayload(mission),
+          sessionStatuses: { "session-1": runtimeStatus },
+        });
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        sessionLoadCount += 1;
+
+        if (sessionLoadCount < 3) {
+          return createJsonResponse({ messages: [] });
+        }
+
+        return createJsonResponse({
+          messages: [createAssistantMessage("message-2", "Mission one follow-up reply")],
+        });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+    await waitFor(
+      () =>
+        MockEventSource.instances.some(
+          (instance) => instance.url === "/api/session/session-1/events",
+        ),
+    );
+
+    const sessionEventSource = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/session/session-1/events",
+    );
+    await waitFor(() => typeof sessionEventSource?.onopen === "function");
+
+    await act(async () => {
+      sessionEventSource?.onopen?.call(
+        sessionEventSource as unknown as EventSource,
+        new Event("open"),
+      );
+    });
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
+    expect(sessionLoadCount).toBe(2);
+
+    runtimeStatus = "idle";
+
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    expect(sessionLoadCount).toBe(3);
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "ready",
+      isLoadingHistory: false,
+      messages: ["Mission one follow-up reply"],
+      streamingContent: "",
+    });
+  });
+
+  it("settles a pending transcript when runtime polling settles the same primary session without a status", async () => {
+    vi.useFakeTimers();
+
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    let sessionLoadCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse({
+          ...createRuntimePayload(mission),
+          sessionStatuses: {},
+        });
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        sessionLoadCount += 1;
+
+        if (sessionLoadCount < 3) {
+          return createJsonResponse({ messages: [] });
+        }
+
+        return createJsonResponse({
+          messages: [createAssistantMessage("message-2", "Mission one follow-up reply")],
+        });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+    await waitFor(
+      () =>
+        MockEventSource.instances.some(
+          (instance) => instance.url === "/api/session/session-1/events",
+        ),
+    );
+
+    const sessionEventSource = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/session/session-1/events",
+    );
+    await waitFor(() => typeof sessionEventSource?.onopen === "function");
+
+    await act(async () => {
+      sessionEventSource?.onopen?.call(
+        sessionEventSource as unknown as EventSource,
+        new Event("open"),
+      );
+    });
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
+    expect(sessionLoadCount).toBe(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    expect(sessionLoadCount).toBe(3);
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "ready",
+      isLoadingHistory: false,
+      messages: ["Mission one follow-up reply"],
+      streamingContent: "",
+    });
+  });
+
   it("clears a stale pending transcript when the same mission switches to a new primary session", async () => {
     const initialMission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
     let runtimeMission = initialMission;

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MessageInfo } from "@/lib/opencode-session-types";
 import { useChatStore } from "@/stores/chat-store";
 import {
+  getMissionRuntimePollInterval,
   type MissionResumePayload,
   useAgentSession,
   withMissionStartPending,
@@ -20,6 +21,7 @@ type HookProbeSnapshot = {
     sessionId: string | null;
   } | null;
   historyPhase: string;
+  isSessionActive: boolean;
   isLoadingHistory: boolean;
   isStreaming: boolean;
   abortSettlementPhase: string;
@@ -218,6 +220,7 @@ function HookProbe({
     onSnapshot({
       liveDraft: state.liveDraft,
       historyPhase: state.historyPhase,
+      isSessionActive: state.isSessionActive,
       isLoadingHistory: state.isLoadingHistory,
       isStreaming: state.isStreaming,
       abortSettlementPhase: state.abortSettlementPhase,
@@ -231,6 +234,7 @@ function HookProbe({
     state.abort,
     state.abortSettlementPhase,
     state.historyPhase,
+    state.isSessionActive,
     state.isLoadingHistory,
     state.isStreaming,
     state.liveDraft,
@@ -288,6 +292,20 @@ describe("useAgentSession", () => {
     container.remove();
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it("uses a fast runtime polling cadence while a visible mission transcript is pending", () => {
+    expect(
+      getMissionRuntimePollInterval({
+        abortSettlementPhase: "idle",
+        hasActiveDelegation: false,
+        hasPendingTranscript: true,
+        isDocumentVisible: true,
+        isPrimaryStreamConnected: true,
+        isSessionActive: false,
+        isStreaming: false,
+      }),
+    ).toBe(3000);
   });
 
   it("suppresses the previous mission transcript while the next mission transcript is still loading", async () => {
@@ -727,7 +745,6 @@ describe("useAgentSession", () => {
 
   it("keeps a session-bound pending transcript state when a dispatched reply has not persisted yet", async () => {
     const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
-    let sessionLoadCount = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
 
@@ -746,7 +763,6 @@ describe("useAgentSession", () => {
       }
 
       if (url === "/api/session/session-1") {
-        sessionLoadCount += 1;
         return createJsonResponse({ messages: [] });
       }
 
@@ -782,6 +798,75 @@ describe("useAgentSession", () => {
       historyPhase: "pending",
       isLoadingHistory: false,
       messages: ["Continue mission"],
+      streamingContent: "",
+    });
+  });
+
+  it("keeps an existing transcript pending and active while a follow-up reply has not persisted yet", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const persistedMessages = [createAssistantMessage("message-1", "Mission one reply")];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse({
+          ...createRuntimePayload(mission),
+          sessionStatuses: {},
+        });
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        return createJsonResponse({ messages: persistedMessages });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: persistedMessages,
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await flushEffects();
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
+
+    await act(async () => {
+      useChatStore.getState().setOptimisticSessionState("session-1", "idle", 60_000);
+    });
+
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "pending",
+      isLoadingHistory: false,
+      isSessionActive: true,
+      messages: ["Mission one reply", "Continue mission"],
       streamingContent: "",
     });
   });
@@ -975,6 +1060,95 @@ describe("useAgentSession", () => {
 
     await act(async () => {
       vi.advanceTimersByTime(20_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    expect(sessionLoadCount).toBe(3);
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "ready",
+      isLoadingHistory: false,
+      messages: ["Mission one follow-up reply"],
+      streamingContent: "",
+    });
+  });
+
+  it("settles a pending transcript when runtime freshness advances without a live session event", async () => {
+    vi.useFakeTimers();
+
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    let sessionLoadCount = 0;
+    let latestPrimaryMessageId: string | null = null;
+    let latestPrimaryMessageCreatedAt: string | null = null;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse({
+          ...createRuntimePayload(mission),
+          latestPrimaryMessageId,
+          latestPrimaryMessageCreatedAt,
+          sessionStatuses: { "session-1": "busy" },
+        });
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        sessionLoadCount += 1;
+
+        if (sessionLoadCount < 3) {
+          return createJsonResponse({ messages: [] });
+        }
+
+        return createJsonResponse({
+          messages: [createAssistantMessage("message-2", "Mission one follow-up reply")],
+        });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
+    expect(sessionLoadCount).toBe(2);
+
+    latestPrimaryMessageId = "message-2";
+    latestPrimaryMessageCreatedAt = "2026-04-19T00:02:00.000Z";
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
       await Promise.resolve();
     });
 
@@ -1415,6 +1589,9 @@ describe("useAgentSession", () => {
 
     const missionId = await missionIdPromise;
     expect(missionId).toBe("mission-1");
+    expect(
+      fetchMock.mock.calls.filter(([input]) => String(input) === "/api/session/session-1"),
+    ).toHaveLength(0);
 
     await act(async () => {
       root?.render(
@@ -1525,78 +1702,6 @@ describe("useAgentSession", () => {
       historyPhase: "ready",
       isLoadingHistory: false,
       messages: ["Mission one reply"],
-    });
-  });
-
-  it("accumulates a reasoning part into the mission live draft", async () => {
-    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-
-      if (url.startsWith("/api/noctis/operations")) {
-        return createJsonResponse({ operations: [] });
-      }
-
-      if (url === "/api/noctis/missions/mission-1/runtime") {
-        return createJsonResponse(createRuntimePayload(mission));
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    let latestSnapshot: HookProbeSnapshot | null = null;
-
-    root = createRoot(container);
-    await act(async () => {
-      root?.render(
-        createElement(HookProbe, {
-          activeMissionId: "mission-1",
-          initialMessageInfos: [createAssistantMessage("message-0", "Mission one reply")],
-          initialMissionData: mission,
-          onSnapshot: (snapshot: HookProbeSnapshot) => {
-            latestSnapshot = snapshot;
-          },
-        }),
-      );
-    });
-    await waitFor(() => latestSnapshot?.historyPhase === "ready");
-    await waitFor(
-      () => MockEventSource.instances.some((instance) => instance.url === "/api/session/session-1/events"),
-    );
-
-    const sessionEventSource = [...MockEventSource.instances]
-      .reverse()
-      .find((instance) => instance.url === "/api/session/session-1/events" && !instance.closed);
-    await waitFor(() => typeof sessionEventSource?.onmessage === "function");
-
-    await act(async () => {
-      sessionEventSource?.onmessage?.call(sessionEventSource as unknown as EventSource, {
-        data: JSON.stringify({
-          properties: {
-            part: {
-              messageID: "message-1",
-              sessionID: "session-1",
-              text: "Thinking through the next step",
-              time: { start: 1 },
-              type: "reasoning",
-            },
-          },
-          type: "message.part.updated",
-        }),
-      } as MessageEvent<string>);
-    });
-
-    await waitFor(() => latestSnapshot?.liveDraft?.messageId === "message-1");
-
-    expect(latestSnapshot).toMatchObject({
-      liveDraft: {
-        messageId: "message-1",
-        parts: [{ text: "Thinking through the next step", type: "reasoning" }],
-        sessionId: "session-1",
-      },
-      messages: ["Mission one reply"],
-      streamingContent: "",
     });
   });
 

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -770,13 +770,13 @@ describe("useAgentSession", () => {
       );
     });
 
-    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+    await flushEffects();
 
     await act(async () => {
       await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
     });
 
-    await waitFor(() => sessionLoadCount >= 2);
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
 
     expect(latestSnapshot).toMatchObject({
       historyPhase: "pending",
@@ -1938,6 +1938,69 @@ describe("useAgentSession", () => {
     expect(
       fetchMock.mock.calls.some(([input]) => String(input) === "/api/noctis/mission/continue"),
     ).toBe(true);
+  });
+
+  it("surfaces tmux activation-block errors from mission continue responses", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      if (url === "/api/session/session-1") {
+        return createJsonResponse({ messages: [] });
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse(
+          { error: "Tmux write focus is still held by mission mission-2." },
+          { ok: false, status: 409 },
+        );
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [createAssistantMessage("message-1", "Mission one reply")],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await flushEffects();
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Retry request" }]);
+    });
+
+    await flushEffects();
+
+    expect(requireSnapshot(latestSnapshot, "Expected post-send snapshot.").messages).toContain(
+      "Something went wrong. Tmux write focus is still held by mission mission-2.",
+    );
+
+    expect(fetchMock.mock.calls.some(([input]) => String(input) === "/api/noctis/mission/continue")).toBe(
+      true,
+    );
   });
 
   it("backs off idle runtime polling after the primary stream is healthy", async () => {

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -165,6 +165,14 @@ async function waitFor(predicate: () => boolean, attempts = 10): Promise<void> {
   throw new Error("Condition was not met before timeout.");
 }
 
+function requireSnapshot(snapshot: HookProbeSnapshot | null, message: string): HookProbeSnapshot {
+  if (!snapshot) {
+    throw new Error(message);
+  }
+
+  return snapshot;
+}
+
 function resetChatStore(): void {
   useChatStore.setState({
     agentModels: {},
@@ -715,6 +723,155 @@ describe("useAgentSession", () => {
     });
 
     expect(sessionLoadCount).toBe(1);
+  });
+
+  it("keeps a session-bound pending transcript state when a dispatched reply has not persisted yet", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    let sessionLoadCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        sessionLoadCount += 1;
+        return createJsonResponse({ messages: [] });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => sessionLoadCount >= 2);
+
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "pending",
+      isLoadingHistory: false,
+      messages: ["Continue mission"],
+      streamingContent: "",
+    });
+  });
+
+  it("clears a stale pending transcript when the same mission switches to a new primary session", async () => {
+    const initialMission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    let runtimeMission = initialMission;
+    const deferredSessionTwo = createDeferredResponse();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(runtimeMission));
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ noctisSessionId: "session-1" });
+      }
+
+      if (url === "/api/session/session-1") {
+        return createJsonResponse({ messages: [] });
+      }
+
+      if (url === "/api/session/session-2") {
+        return deferredSessionTwo.promise;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [],
+          initialMissionData: initialMission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "empty");
+    await waitFor(
+      () =>
+        MockEventSource.instances.some(
+          (instance) => instance.url === "/api/session/session-1/events",
+        ),
+    );
+
+    const sessionEventSource = MockEventSource.instances.find(
+      (instance) => instance.url === "/api/session/session-1/events",
+    );
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Continue mission" }]);
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "pending");
+    const pendingSnapshot = requireSnapshot(latestSnapshot, "Expected a pending hook snapshot.");
+    expect(pendingSnapshot.messages).toEqual(["Continue mission"]);
+
+    runtimeMission = createMission({ missionId: "mission-1", primarySessionId: "session-2" });
+
+    await act(async () => {
+      sessionEventSource?.onerror?.call(sessionEventSource as unknown as EventSource, new Event("error"));
+    });
+
+    await waitFor(
+      () =>
+        fetchMock.mock.calls.some(([input]) => String(input) === "/api/session/session-2"),
+    );
+
+    expect(latestSnapshot).toMatchObject({
+      historyPhase: "loading",
+      isLoadingHistory: true,
+      messages: [],
+      streamingContent: "",
+    });
   });
 
   it("runs one queued history sync after the in-flight sync finishes", async () => {

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -408,24 +408,27 @@ function normalizeDelegationLedger(
   };
 }
 
-export type MissionTranscriptPhase = "idle" | "loading" | "ready" | "empty" | "error";
+export type MissionTranscriptPhase = "idle" | "loading" | "pending" | "ready" | "empty" | "error";
 export type AbortSettlementPhase = "idle" | "settling" | "delayed";
 
 type MissionTranscriptState = {
   errorMessage: string | null;
   missionId: string | null;
   phase: MissionTranscriptPhase;
+  sessionId: string | null;
 };
 
 function createMissionTranscriptState(
   missionId: string | null,
   phase: MissionTranscriptPhase,
   errorMessage: string | null = null,
+  sessionId: string | null = null,
 ): MissionTranscriptState {
   return {
     errorMessage,
     missionId,
     phase,
+    sessionId,
   };
 }
 
@@ -717,7 +720,10 @@ function getVisibleMissionMessages(
     return [];
   }
 
-  if (transcriptState.phase === "loading" && sessionMessages.length > 0) {
+  if (
+    (transcriptState.phase === "loading" || transcriptState.phase === "pending") &&
+    sessionMessages.length > 0
+  ) {
     return sessionMessages;
   }
 
@@ -934,6 +940,7 @@ export function useAgentSession({
   const runtimeRefreshQueuedRef = useRef(false);
   const applyMissionRuntimeSnapshotRef = useRef<((runtime: MissionRuntimeSnapshot) => void) | null>(null);
   const refreshMissionRuntimeRef = useRef<(() => Promise<void>) | null>(null);
+  const transcriptStateRef = useRef<MissionTranscriptState>(transcriptState);
 
   const sessionStates = useChatStore((state) => state.sessionStates);
   const setServerSessionState = useChatStore((state) => state.setServerSessionState);
@@ -981,6 +988,10 @@ export function useAgentSession({
       },
     });
   }
+
+  useEffect(() => {
+    transcriptStateRef.current = transcriptState;
+  }, [transcriptState]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1373,7 +1384,9 @@ export function useAgentSession({
 
         setSessionMessages((current) => {
           if (nextMessages.length === 0) {
-            return options?.preserveStreaming ? current : initialMessages;
+            return options?.preserveStreaming || options?.trackStreamingMessage
+              ? current
+              : (transcriptMissionId ? [] : initialMessages);
           }
 
           return options?.preserveStreaming
@@ -1382,10 +1395,12 @@ export function useAgentSession({
         });
 
         setTranscriptState(
-          createMissionTranscriptState(
-            transcriptMissionId,
-            resolveMissionTranscriptPhase(nextMessages),
-          )
+          nextMessages.length === 0 && options?.trackStreamingMessage
+            ? createMissionTranscriptState(transcriptMissionId, "pending", null, sessionId)
+            : createMissionTranscriptState(
+                transcriptMissionId,
+                resolveMissionTranscriptPhase(nextMessages),
+              )
         );
 
         if (shouldClearSyncedLiveTail) {
@@ -1891,10 +1906,16 @@ export function useAgentSession({
 
       if (noctisSessionIdRef.current !== nextPrimarySessionId) {
         const transcriptMissionId = runtime.missionId ?? activeMissionIdRef.current;
+        const shouldClearVisibleTranscriptOnSessionSwitch =
+          transcriptStateRef.current.missionId === transcriptMissionId &&
+          transcriptStateRef.current.phase !== "ready";
         noctisSessionIdRef.current = nextPrimarySessionId;
         setNoctisSessionId(nextPrimarySessionId);
         clearStreamingState();
         if (nextPrimarySessionId) {
+          if (shouldClearVisibleTranscriptOnSessionSwitch) {
+            setSessionMessages([]);
+          }
           setTranscriptState(createMissionTranscriptState(transcriptMissionId, "loading"));
           subscribeToSession(nextPrimarySessionId);
           void syncSessionMessages(nextPrimarySessionId, {
@@ -2485,6 +2506,7 @@ export function useAgentSession({
 
             handleAgentEvent({ type: "session.created" });
             subscribeToSession(sessionId);
+            setTranscriptState(createMissionTranscriptState(data.missionId, "pending", null, sessionId));
             await waitForActiveStatus(sessionId);
             requestSessionHistorySync(sessionId, {
               trackStreamingMessage: true,
@@ -2540,6 +2562,14 @@ export function useAgentSession({
 
           const sessionId = responseSessionId ?? noctisSessionIdRef.current;
           if (sessionId) {
+            setTranscriptState(
+              createMissionTranscriptState(
+                activeMissionIdRef.current ?? missionIdRef.current,
+                "pending",
+                null,
+                sessionId,
+              ),
+            );
             requestSessionHistorySync(sessionId, {
               trackStreamingMessage: true,
               reason: "mission-continue-response",

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -1849,6 +1849,7 @@ export function useAgentSession({
         return current === nextSelectedOperation ? current : nextSelectedOperation;
       });
 
+      const currentPrimarySessionId = noctisSessionIdRef.current;
       const nextPrimarySessionId = getMissionPrimarySessionIdFromPayload(runtime);
       const runtimePrimaryStatus = nextPrimarySessionId
         ? (runtime.sessionStatuses[nextPrimarySessionId] ?? null)
@@ -1904,6 +1905,15 @@ export function useAgentSession({
 
       clearPendingMissionSession(runtime.missionId);
 
+      const shouldResyncPendingTranscriptFromRuntime = Boolean(
+        nextPrimarySessionId &&
+          currentPrimarySessionId === nextPrimarySessionId &&
+          isPrimarySettled &&
+          transcriptStateRef.current.phase === "pending" &&
+          transcriptStateRef.current.missionId === runtime.missionId &&
+          transcriptStateRef.current.sessionId === nextPrimarySessionId,
+      );
+
       if (noctisSessionIdRef.current !== nextPrimarySessionId) {
         const transcriptMissionId = runtime.missionId ?? activeMissionIdRef.current;
         const shouldClearVisibleTranscriptOnSessionSwitch =
@@ -1943,6 +1953,13 @@ export function useAgentSession({
         if (nextPrimarySessionId && !eventSourceRef.current) {
           subscribeToSession(nextPrimarySessionId);
         }
+      }
+
+      if (shouldResyncPendingTranscriptFromRuntime && nextPrimarySessionId) {
+        requestSessionHistorySync(nextPrimarySessionId, {
+          missionId: runtime.missionId,
+          reason: "runtime-primary-settled-sync",
+        });
       }
 
       setWorkerSessionIds((current) => {
@@ -2034,6 +2051,7 @@ export function useAgentSession({
       pendingMissionSessionId,
       persistAmbientBanter,
       primaryAgentId,
+      requestSessionHistorySync,
       setServerSessionState,
       subscribeToSession,
       syncSessionMessages,

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -60,7 +60,7 @@ const PROGRESS_BANTER_DELAYS = {
 const ABORT_SETTLEMENT_DELAY_MS = 10000;
 const MISSION_RUNTIME_RECOVERY_POLL_MS = 2000;
 const MISSION_RUNTIME_SETTLING_POLL_MS = 4000;
-const MISSION_RUNTIME_ACTIVE_POLL_MS = 10000;
+const MISSION_RUNTIME_ACTIVE_POLL_MS = 3000;
 const MISSION_RUNTIME_IDLE_POLL_MS = 15000;
 const MISSION_RUNTIME_HIDDEN_POLL_MS = 30000;
 const MISSION_SETTLED_BANTER_COOLDOWN_MS = 30000;
@@ -301,9 +301,22 @@ function areContextUsageByAgentEqual(
   );
 }
 
-function getMissionRuntimePollInterval({
+function getRuntimePrimaryFreshnessKey(payload: {
+  latestPrimaryMessageCreatedAt?: string | null;
+  latestPrimaryMessageId?: string | null;
+  primarySessionId?: string | null;
+}): string | null {
+  if (!payload.primarySessionId) {
+    return null;
+  }
+
+  return `${payload.primarySessionId}:${payload.latestPrimaryMessageId ?? ""}:${payload.latestPrimaryMessageCreatedAt ?? ""}`;
+}
+
+export function getMissionRuntimePollInterval({
   abortSettlementPhase,
   hasActiveDelegation,
+  hasPendingTranscript,
   isDocumentVisible,
   isPrimaryStreamConnected,
   isSessionActive,
@@ -311,6 +324,7 @@ function getMissionRuntimePollInterval({
 }: {
   abortSettlementPhase: AbortSettlementPhase;
   hasActiveDelegation: boolean;
+  hasPendingTranscript: boolean;
   isDocumentVisible: boolean;
   isPrimaryStreamConnected: boolean;
   isSessionActive: boolean;
@@ -324,12 +338,12 @@ function getMissionRuntimePollInterval({
     return MISSION_RUNTIME_RECOVERY_POLL_MS;
   }
 
-  if (abortSettlementPhase !== "idle") {
-    return MISSION_RUNTIME_SETTLING_POLL_MS;
+  if (hasPendingTranscript || isStreaming || isSessionActive || hasActiveDelegation) {
+    return MISSION_RUNTIME_ACTIVE_POLL_MS;
   }
 
-  if (isStreaming || isSessionActive || hasActiveDelegation) {
-    return MISSION_RUNTIME_ACTIVE_POLL_MS;
+  if (abortSettlementPhase !== "idle") {
+    return MISSION_RUNTIME_SETTLING_POLL_MS;
   }
 
   return MISSION_RUNTIME_IDLE_POLL_MS;
@@ -364,6 +378,8 @@ export type MissionResumePayload = {
   objective?: string;
   createdAt: string;
   updatedAt: string;
+  latestPrimaryMessageCreatedAt?: string | null;
+  latestPrimaryMessageId?: string | null;
   archivedAt?: string | null;
   status: "active" | "completed" | "archived";
   executionProjectId?: string | null;
@@ -516,6 +532,7 @@ type SessionHistorySyncOptions = {
   missionId?: string | null;
   preserveStreaming?: boolean;
   trackStreamingMessage?: boolean;
+  expectedLatestAssistantMessageId?: string | null;
   reason?: string;
 };
 
@@ -555,6 +572,8 @@ function mergeSessionHistorySyncOptions(
     missionId: next?.missionId ?? current?.missionId,
     preserveStreaming: Boolean(current?.preserveStreaming || next?.preserveStreaming),
     trackStreamingMessage: Boolean(current?.trackStreamingMessage || next?.trackStreamingMessage),
+    expectedLatestAssistantMessageId:
+      next?.expectedLatestAssistantMessageId ?? current?.expectedLatestAssistantMessageId ?? null,
     reason: next?.reason ?? current?.reason,
   };
 }
@@ -640,6 +659,17 @@ function toSessionChatMessages(
       source: message.source,
     };
   });
+}
+
+function getLatestAssistantMessageId(
+  messages: ChatMessage[],
+  primaryAgentId: MissionPrimaryAgentId,
+): string | null {
+  const latestAssistantMessage = [...messages]
+    .reverse()
+    .find((message) => message.sender === primaryAgentId);
+
+  return latestAssistantMessage?.id ?? null;
 }
 
 async function loadSessionMessages(
@@ -926,7 +956,6 @@ export function useAgentSession({
     visibleTranscriptState.phase === "loading" &&
     messages.length === 0;
   const sessionStatusRef = useRef<SessionStatus | null>(null);
-  const pendingActiveResolversRef = useRef<Map<string, Array<() => void>>>(new Map());
   const progressTimersRef = useRef<
     Partial<Record<string, Partial<Record<"early" | "late", ReturnType<typeof setTimeout>>>>>
   >({});
@@ -938,6 +967,7 @@ export function useAgentSession({
   const loadMissionInvocationIdRef = useRef(0);
   const runtimeRefreshInFlightRef = useRef(false);
   const runtimeRefreshQueuedRef = useRef(false);
+  const runtimePrimaryFreshnessKeyRef = useRef<string | null>(null);
   const applyMissionRuntimeSnapshotRef = useRef<((runtime: MissionRuntimeSnapshot) => void) | null>(null);
   const refreshMissionRuntimeRef = useRef<(() => Promise<void>) | null>(null);
   const transcriptStateRef = useRef<MissionTranscriptState>(transcriptState);
@@ -1050,7 +1080,11 @@ export function useAgentSession({
   }, [activeMissionId]);
 
   const sessionStatus = noctisSessionId ? (sessionStates[noctisSessionId] ?? null) : null;
-  const isSessionActive = isSessionStatusActive(sessionStatus);
+  const hasPendingPrimaryTranscript =
+    activeMissionId !== null &&
+    visibleTranscriptState.phase === "pending" &&
+    (visibleTranscriptState.sessionId === null || visibleTranscriptState.sessionId === noctisSessionId);
+  const isSessionActive = isSessionStatusActive(sessionStatus) || hasPendingPrimaryTranscript;
   const partyMembers = useMemo<PartyMember[]>(
     () =>
       PARTY_MEMBER_META.map((member) => {
@@ -1151,47 +1185,6 @@ export function useAgentSession({
     setNoctisSessionId((current) => current ?? initialNoctisSessionId);
     noctisSessionIdRef.current = noctisSessionIdRef.current ?? initialNoctisSessionId;
   }, [initialNoctisSessionId]);
-
-  const resolvePendingActive = useCallback((sessionId: string, status: SessionStatus) => {
-    if (!isSessionStatusActive(status)) {
-      return;
-    }
-
-    const resolvers = pendingActiveResolversRef.current.get(sessionId);
-    if (!resolvers || resolvers.length === 0) {
-      return;
-    }
-
-    pendingActiveResolversRef.current.delete(sessionId);
-    for (const resolve of resolvers) {
-      resolve();
-    }
-  }, []);
-
-  const waitForActiveStatus = useCallback(async (sessionId: string, timeoutMs = 1200) => {
-    const currentStatus = useChatStore.getState().sessionStates[sessionId] ?? null;
-    if (isSessionStatusActive(currentStatus)) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      const finish = () => {
-        window.clearTimeout(timeout);
-        const resolvers = pendingActiveResolversRef.current.get(sessionId) ?? [];
-        const nextResolvers = resolvers.filter((entry) => entry !== finish);
-        if (nextResolvers.length === 0) {
-          pendingActiveResolversRef.current.delete(sessionId);
-        } else {
-          pendingActiveResolversRef.current.set(sessionId, nextResolvers);
-        }
-        resolve();
-      };
-
-      const timeout = window.setTimeout(finish, timeoutMs);
-      const resolvers = pendingActiveResolversRef.current.get(sessionId) ?? [];
-      pendingActiveResolversRef.current.set(sessionId, [...resolvers, finish]);
-    });
-  }, []);
 
   const clearBanterEntries = useCallback(() => {
     banterFeedPresenterRef.current?.clear();
@@ -1323,6 +1316,7 @@ export function useAgentSession({
     hasHydratedNoctisSettledRef.current = false;
     lastNoctisSettledRef.current = false;
     lastNoctisSettledEmitAtRef.current = null;
+    runtimePrimaryFreshnessKeyRef.current = null;
     sessionHistorySyncInFlightRef.current.clear();
     sessionHistorySyncQueuedRef.current.clear();
     loadMissionHydrationInFlightRef.current.clear();
@@ -1372,6 +1366,12 @@ export function useAgentSession({
         const latestAssistant = [...nextMessages]
           .reverse()
           .find((message) => message.sender === primaryAgentId);
+        const shouldKeepPendingTrackedReply = Boolean(
+          options?.trackStreamingMessage &&
+            !currentStreamingMessageId &&
+            ((latestAssistant?.id ?? null) === (options.expectedLatestAssistantMessageId ?? null) ||
+              nextMessages.length === 0),
+        );
         const containsStreamingMessageId = Boolean(
           currentStreamingMessageId &&
             nextMessages.some((message) => message.id === currentStreamingMessageId)
@@ -1389,13 +1389,17 @@ export function useAgentSession({
               : (transcriptMissionId ? [] : initialMessages);
           }
 
+          if (shouldKeepPendingTrackedReply) {
+            return current;
+          }
+
           return options?.preserveStreaming
             ? mergeRuntimeSessionMessages(current, nextMessages, primaryAgentId)
             : nextMessages;
         });
 
         setTranscriptState(
-          nextMessages.length === 0 && options?.trackStreamingMessage
+          shouldKeepPendingTrackedReply
             ? createMissionTranscriptState(transcriptMissionId, "pending", null, sessionId)
             : createMissionTranscriptState(
                 transcriptMissionId,
@@ -1422,6 +1426,8 @@ export function useAgentSession({
           payload: {
             durationMs: Date.now() - syncStartedAt,
             effectiveSessionStatus,
+            expectedLatestAssistantMessageId: options?.expectedLatestAssistantMessageId ?? null,
+            keptPendingTrackedReply: shouldKeepPendingTrackedReply,
             messageCount: nextMessages.length,
             preserveStreaming: Boolean(options?.preserveStreaming),
             reason: options?.reason ?? "unspecified",
@@ -1433,7 +1439,7 @@ export function useAgentSession({
           return;
         }
 
-        streamingMessageIdRef.current = latestAssistant?.id ?? null;
+        streamingMessageIdRef.current = shouldKeepPendingTrackedReply ? null : (latestAssistant?.id ?? null);
       } catch (error) {
         appendMissionClientDebugLog({
           event: "session-history-sync",
@@ -1693,7 +1699,6 @@ export function useAgentSession({
           handleAgentEvent({
             type: "message.part.updated",
             messageId: liveEvent.messageId ?? undefined,
-            part: liveEvent.part,
             sessionId: liveEvent.sessionId ?? undefined,
             text: liveEvent.part.type === "text" ? liveEvent.part.text : undefined,
           });
@@ -1736,7 +1741,6 @@ export function useAgentSession({
             if (nextStatus === "idle") {
               clearAbortSettlement();
             }
-            resolvePendingActive(activeSessionId, nextStatus);
             if (nextStatus === "retry" && lastSessionStateRef.current !== "retry") {
               clearProgressBanter(primaryAgentId);
               handleAgentEvent({ type: "task.retrying", agentId: primaryAgentId });
@@ -1760,7 +1764,6 @@ export function useAgentSession({
       handleAgentEvent,
       missionRouteBase,
       primaryAgentId,
-      resolvePendingActive,
       requestSessionHistorySync,
       setServerSessionState,
     ]
@@ -1851,6 +1854,12 @@ export function useAgentSession({
 
       const currentPrimarySessionId = noctisSessionIdRef.current;
       const nextPrimarySessionId = getMissionPrimarySessionIdFromPayload(runtime);
+      const previousPrimaryFreshnessKey = runtimePrimaryFreshnessKeyRef.current;
+      const nextPrimaryFreshnessKey = getRuntimePrimaryFreshnessKey({
+        latestPrimaryMessageCreatedAt: runtime.latestPrimaryMessageCreatedAt,
+        latestPrimaryMessageId: runtime.latestPrimaryMessageId,
+        primarySessionId: nextPrimarySessionId,
+      });
       const runtimePrimaryStatus = nextPrimarySessionId
         ? (runtime.sessionStatuses[nextPrimarySessionId] ?? null)
         : null;
@@ -1913,6 +1922,15 @@ export function useAgentSession({
           transcriptStateRef.current.missionId === runtime.missionId &&
           transcriptStateRef.current.sessionId === nextPrimarySessionId,
       );
+      const shouldResyncTranscriptFromRuntimeFreshness = Boolean(
+        nextPrimarySessionId &&
+          currentPrimarySessionId === nextPrimarySessionId &&
+          previousPrimaryFreshnessKey !== null &&
+          previousPrimaryFreshnessKey !== nextPrimaryFreshnessKey &&
+          transcriptStateRef.current.missionId === runtime.missionId,
+      );
+
+      runtimePrimaryFreshnessKeyRef.current = nextPrimaryFreshnessKey;
 
       if (noctisSessionIdRef.current !== nextPrimarySessionId) {
         const transcriptMissionId = runtime.missionId ?? activeMissionIdRef.current;
@@ -1958,7 +1976,16 @@ export function useAgentSession({
       if (shouldResyncPendingTranscriptFromRuntime && nextPrimarySessionId) {
         requestSessionHistorySync(nextPrimarySessionId, {
           missionId: runtime.missionId,
+          preserveStreaming: true,
           reason: "runtime-primary-settled-sync",
+        });
+      }
+
+      if (shouldResyncTranscriptFromRuntimeFreshness && nextPrimarySessionId) {
+        requestSessionHistorySync(nextPrimarySessionId, {
+          missionId: runtime.missionId,
+          preserveStreaming: true,
+          reason: "runtime-primary-freshness-sync",
         });
       }
 
@@ -2164,6 +2191,7 @@ export function useAgentSession({
       getMissionRuntimePollInterval({
         abortSettlementPhase,
         hasActiveDelegation,
+        hasPendingTranscript: transcriptStateRef.current.phase === "pending",
         isDocumentVisible,
         isPrimaryStreamConnected,
         isSessionActive,
@@ -2434,6 +2462,10 @@ export function useAgentSession({
   const send = useCallback(
     async (parts: PromptPart[]) => {
       const text = stringifyPromptParts(parts);
+      const expectedLatestAssistantMessageId = getLatestAssistantMessageId(
+        sessionMessages,
+        primaryAgentId,
+      );
       if (
         activeMissionId &&
         visibleTranscriptState.phase === "loading"
@@ -2525,11 +2557,6 @@ export function useAgentSession({
             handleAgentEvent({ type: "session.created" });
             subscribeToSession(sessionId);
             setTranscriptState(createMissionTranscriptState(data.missionId, "pending", null, sessionId));
-            await waitForActiveStatus(sessionId);
-            requestSessionHistorySync(sessionId, {
-              trackStreamingMessage: true,
-              reason: "mission-start-session-created",
-            });
             return data.missionId;
           });
         } else {
@@ -2589,6 +2616,7 @@ export function useAgentSession({
               ),
             );
             requestSessionHistorySync(sessionId, {
+              expectedLatestAssistantMessageId,
               trackStreamingMessage: true,
               reason: "mission-continue-response",
             });
@@ -2629,6 +2657,7 @@ export function useAgentSession({
       missionContinueEndpoint,
       missionStartEndpoint,
       primaryAgentId,
+      sessionMessages,
       visibleTranscriptState,
       selectedOperation,
       selectedLunafreyaJobId,
@@ -2637,7 +2666,6 @@ export function useAgentSession({
       setOptimisticSessionState,
       subscribeToSession,
       requestSessionHistorySync,
-      waitForActiveStatus,
       clearStreamingState,
       selectedContextProjectIds,
       selectedExecutionProjectId,

--- a/web/app/lib/execution-workspace-sessions.test.ts
+++ b/web/app/lib/execution-workspace-sessions.test.ts
@@ -13,11 +13,13 @@ import {
   setWorkerSession,
 } from "@/lib/mission-store";
 import { dispatchTaskToWorker } from "@/lib/task-dispatch.server";
+import { writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 import { sendSimpleMessage, sendWorkerReport } from "@/lib/team-message.server";
 
-const { promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+const { promptAsyncMock, sessionCreateMock, sessionStatusMock } = vi.hoisted(() => ({
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
+  sessionStatusMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
@@ -25,6 +27,7 @@ vi.mock("@/lib/opencode-client", () => ({
     session: {
       create: sessionCreateMock,
       promptAsync: promptAsyncMock,
+      status: sessionStatusMock,
     },
   }),
 }));
@@ -44,7 +47,7 @@ function initializeGitProject(projectRoot: string): void {
   execSync('git commit -m "init"', { cwd: projectRoot, stdio: "ignore" });
 }
 
-function createTempRoot(): string {
+function createTempRoot(options?: { transportMode?: "app-owned" | "tmux-resident" }): string {
   const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-execution-sessions-"));
   tempRoots.push(root);
   cpSync(join(repoRoot, "builtins"), join(root, "builtins"), { recursive: true });
@@ -58,7 +61,12 @@ function createTempRoot(): string {
 
   writeFileSync(
     join(root, "config", "settings.yaml"),
-    ['language: ja', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+    [
+      'language: ja',
+      `transport_mode: "${options?.transportMode ?? "app-owned"}"`,
+      'execution_workspace_root: ".worktrees"',
+      '',
+    ].join("\n"),
     "utf-8",
   );
   writeFileSync(
@@ -249,6 +257,34 @@ describe("execution workspace sessions", () => {
     );
   });
 
+  it("blocks worker dispatch when another tmux mission still owns writable focus", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const activeMission = createExecutionMission(root);
+    const targetMission = createExecutionMission(root);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.missionId,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-noctis": "busy",
+      },
+      error: null,
+    });
+
+    await expect(
+      dispatchTaskToWorker({
+        missionId: targetMission.missionId,
+        agentId: "ignis",
+        message: "Do not steal focus from the busy mission.",
+      }),
+    ).rejects.toThrow(activeMission.missionId);
+
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+  });
+
   it("uses the mission execution workspace for team-message worker sessions", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;
@@ -328,6 +364,35 @@ describe("execution workspace sessions", () => {
         title: `mission:${missionId}:ignis`,
       }),
     );
+  });
+
+  it("blocks team-message delivery when another tmux mission still owns writable focus", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const activeMission = createExecutionMission(root);
+    const targetMission = createExecutionMission(root);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.missionId,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-noctis": "busy",
+      },
+      error: null,
+    });
+
+    await expect(
+      sendSimpleMessage({
+        missionId: targetMission.missionId,
+        toAgent: "ignis",
+        body: "Do not steal focus from the busy mission.",
+        fromActor: "user",
+      }),
+    ).rejects.toThrow(activeMission.missionId);
+
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
   });
 
   it("records report-return banter when a worker sends a report back to Noctis", async () => {

--- a/web/app/lib/managed-session-activation.server.ts
+++ b/web/app/lib/managed-session-activation.server.ts
@@ -1,0 +1,38 @@
+import { getManagedSessionTitle, getManagedSessionTitleCandidates } from "@/lib/managed-session-titles";
+import type { AgentId } from "@/lib/types/mission";
+
+type SessionListClient = {
+  session: {
+    list?: () => Promise<{
+      data?: Array<{ id?: unknown; title?: unknown }>;
+      error?: unknown;
+    }>;
+  };
+};
+
+export async function resolveManagedSessionActivationTitle(input: {
+  client: SessionListClient;
+  missionId: string;
+  agentId: AgentId;
+  sessionId: string;
+}): Promise<string> {
+  const canonicalTitle = getManagedSessionTitle(input.missionId, input.agentId);
+  const sessionList = input.client.session.list;
+  if (typeof sessionList !== "function") {
+    return canonicalTitle;
+  }
+
+  try {
+    const result = await sessionList();
+    if (!result.error && Array.isArray(result.data)) {
+      const match = result.data.find((session) => session?.id === input.sessionId);
+      if (typeof match?.title === "string" && match.title.trim().length > 0) {
+        return match.title;
+      }
+    }
+  } catch {
+    // Fall back to the canonical title when the runtime session list is unavailable.
+  }
+
+  return getManagedSessionTitleCandidates(input.missionId, input.agentId)[0] ?? canonicalTitle;
+}

--- a/web/app/lib/managed-session-titles.ts
+++ b/web/app/lib/managed-session-titles.ts
@@ -1,0 +1,18 @@
+import type { AgentId } from "@/lib/types/mission";
+
+function isPrimaryAgentId(agentId: AgentId): agentId is "noctis" | "lunafreya" {
+  return agentId === "noctis" || agentId === "lunafreya";
+}
+
+export function getManagedSessionTitle(missionId: string, agentId: AgentId): string {
+  return `mission:${missionId}:${agentId}`;
+}
+
+export function getManagedSessionTitleCandidates(missionId: string, agentId: AgentId): string[] {
+  const canonicalTitle = getManagedSessionTitle(missionId, agentId);
+  if (!isPrimaryAgentId(agentId)) {
+    return [canonicalTitle];
+  }
+
+  return [canonicalTitle, `mission:${missionId}`];
+}

--- a/web/app/lib/mission-list-running-state.test.ts
+++ b/web/app/lib/mission-list-running-state.test.ts
@@ -14,6 +14,22 @@ function createMissionSummary(activitySessionIds: string[]): MissionSummary {
 }
 
 describe("mission-list-running-state", () => {
+  it("prefers summary agent statuses when they are available", () => {
+    expect(
+      isMissionSummaryRunning(
+        {
+          ...createMissionSummary(["session-primary"]),
+          agentStatuses: {
+            noctis: "busy",
+          },
+        },
+        {
+          "session-primary": "idle",
+        },
+      ),
+    ).toBe(true);
+  });
+
   it("returns true when the primary mission session is active", () => {
     expect(
       isMissionSummaryRunning(createMissionSummary(["session-primary"]), {

--- a/web/app/lib/mission-list-running-state.ts
+++ b/web/app/lib/mission-list-running-state.ts
@@ -2,9 +2,14 @@ import { isSessionStatusActive, type SessionStatus } from "@/lib/session-status"
 import type { MissionSummary } from "@/lib/types/mission";
 
 export function isMissionSummaryRunning(
-  mission: Pick<MissionSummary, "activitySessionIds">,
+  mission: Pick<MissionSummary, "activitySessionIds" | "agentStatuses">,
   sessionStates: Record<string, SessionStatus | null | undefined>,
 ): boolean {
+  const summaryStatuses = Object.values(mission.agentStatuses ?? {});
+  if (summaryStatuses.length > 0) {
+    return summaryStatuses.some((status) => isSessionStatusActive(status));
+  }
+
   return mission.activitySessionIds.some((sessionId) =>
     isSessionStatusActive(sessionStates[sessionId] ?? null),
   );

--- a/web/app/lib/mission-primary-agent-outbox.server.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.ts
@@ -35,6 +35,7 @@ export interface PrimaryAgentOutboxSubmission {
 export interface PrimaryAgentOutboxPayload {
   agent: AgentId;
   sessionId: string;
+  sessionTitle?: string;
   parts: TextPromptPart[];
   system?: string;
   model?: Pick<ModelSelection, "providerID" | "modelID">;
@@ -103,6 +104,9 @@ function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
   return {
     agent: agent as AgentId,
     sessionId,
+    ...(normalizeString(record.sessionTitle)
+      ? { sessionTitle: normalizeString(record.sessionTitle) }
+      : {}),
     parts,
     ...(normalizeString(record.system) ? { system: normalizeString(record.system) } : {}),
     ...(record.model && typeof record.model === "object"

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -345,6 +345,10 @@ function readMissionFromDisk(id: string): Mission | null {
             item === "ignis" || item === "gladiolus" || item === "prompto",
         )
       : [];
+    parsed.latestPrimaryMessageId = normalizeOptionalString(parsed.latestPrimaryMessageId);
+    parsed.latestPrimaryMessageCreatedAt = normalizeOptionalString(
+      parsed.latestPrimaryMessageCreatedAt,
+    );
     parsed.archivedAt = typeof parsed.archivedAt === "string" ? parsed.archivedAt : undefined;
     if (parsed.operationState && "previousResponse" in parsed.operationState) {
       delete (parsed.operationState as { previousResponse?: string | null }).previousResponse;
@@ -408,6 +412,9 @@ function toMissionSummary(mission: Mission): MissionSummary {
     archivedAt: mission.archivedAt,
     status: mission.status,
     activitySessionIds,
+    primarySessionId: getMissionPrimarySessionId(mission),
+    latestPrimaryMessageId: mission.latestPrimaryMessageId ?? null,
+    latestPrimaryMessageCreatedAt: mission.latestPrimaryMessageCreatedAt ?? null,
   };
 }
 
@@ -522,7 +529,7 @@ export function listMissionSummaries(options?: {
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);
   const missions = missionIds
-    .map((missionId) => readMissionFromDisk(missionId))
+    .map((missionId) => getMission(missionId))
     .filter((mission): mission is Mission => mission !== null)
     .filter((mission) => {
       if (view === "all") {
@@ -542,6 +549,39 @@ export function listMissionSummaries(options?: {
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
 
   return missions.map(toMissionSummary);
+}
+
+export function listMissionSummariesWithCounts(options?: {
+  view?: "active" | "archived" | "all";
+  surfaceId?: MissionSurfaceId;
+}): {
+  missions: MissionSummary[];
+  counts: { active: number; archived: number };
+} {
+  const allMissions = listMissionSummaries({ view: "all", surfaceId: options?.surfaceId });
+  const counts = allMissions.reduce(
+    (result, mission) => {
+      if (mission.status === "archived") {
+        result.archived += 1;
+      } else {
+        result.active += 1;
+      }
+
+      return result;
+    },
+    { active: 0, archived: 0 },
+  );
+  const view = options?.view ?? "active";
+
+  return {
+    counts,
+    missions:
+      view === "all"
+        ? allMissions
+        : allMissions.filter((mission) =>
+            view === "archived" ? mission.status === "archived" : mission.status !== "archived",
+          ),
+  };
 }
 
 export function archiveMission(missionId: string): Mission | undefined {
@@ -601,6 +641,10 @@ export function setMissionPrimarySession(
     mission.noctisSessionId = normalizedSessionId;
   }
   if (getMissionPrimaryAgentId(mission) === agentId) {
+    if (mission.primarySessionId !== normalizedSessionId) {
+      mission.latestPrimaryMessageId = undefined;
+      mission.latestPrimaryMessageCreatedAt = undefined;
+    }
     mission.primarySessionId = normalizedSessionId;
   }
   setMissionSessionOwner(mission, normalizedSessionId, agentId, previousSessionId);
@@ -842,6 +886,30 @@ export function updateMissionMetadata(
     mission.objective = patch.objective.trim() || undefined;
   }
   touchMission(mission, patch.status);
+}
+
+export function updateMissionPrimaryMessageMetadata(
+  missionId: string,
+  metadata: {
+    latestPrimaryMessageId: string | null;
+    latestPrimaryMessageCreatedAt: string | null;
+  },
+): void {
+  const mission = getMission(missionId);
+  if (!mission) return;
+
+  const nextMessageId = normalizeOptionalString(metadata.latestPrimaryMessageId);
+  const nextCreatedAt = normalizeOptionalString(metadata.latestPrimaryMessageCreatedAt);
+  const currentMessageId = normalizeOptionalString(mission.latestPrimaryMessageId);
+  const currentCreatedAt = normalizeOptionalString(mission.latestPrimaryMessageCreatedAt);
+
+  if (currentMessageId === nextMessageId && currentCreatedAt === nextCreatedAt) {
+    return;
+  }
+
+  mission.latestPrimaryMessageId = nextMessageId;
+  mission.latestPrimaryMessageCreatedAt = nextCreatedAt;
+  touchMission(mission);
 }
 
 export function appendMissionMessage(missionId: string, message: MissionMessageLogEntry): void {

--- a/web/app/lib/mission-surface-hydration.server.test.ts
+++ b/web/app/lib/mission-surface-hydration.server.test.ts
@@ -1,9 +1,16 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { sessionMessagesMock, sessionStatusMock } = vi.hoisted(() => ({
+const {
+  listSessionStatusTargetsMock,
+  resolveSessionRouteTargetMock,
+  sessionMessagesMock,
+  sessionStatusMock,
+} = vi.hoisted(() => ({
+  listSessionStatusTargetsMock: vi.fn(),
+  resolveSessionRouteTargetMock: vi.fn(),
   sessionMessagesMock: vi.fn(),
   sessionStatusMock: vi.fn(),
 }));
@@ -17,11 +24,17 @@ vi.mock("@/lib/opencode-client", () => ({
   }),
 }));
 
+vi.mock("./session-owner-routing.server", () => ({
+  listSessionStatusTargets: listSessionStatusTargetsMock,
+  resolveSessionRouteTarget: resolveSessionRouteTargetMock,
+}));
+
 import {
   appendAmbientBanter,
   appendConversationLogEntry,
   createMission,
   deleteMission,
+  getMission,
   setWorkerSession,
 } from "@/lib/mission-store";
 import { buildMissionSurfaceHydrationPayload } from "./mission-surface-hydration.server";
@@ -70,6 +83,8 @@ function writeContextSnapshot(root: string, sessionId: string): void {
 }
 
 afterEach(() => {
+  listSessionStatusTargetsMock.mockReset();
+  resolveSessionRouteTargetMock.mockReset();
   sessionMessagesMock.mockReset();
   sessionStatusMock.mockReset();
 
@@ -89,6 +104,22 @@ afterEach(() => {
       rmSync(root, { recursive: true, force: true });
     }
   }
+});
+
+beforeEach(() => {
+  listSessionStatusTargetsMock.mockReturnValue([]);
+  resolveSessionRouteTargetMock.mockImplementation((sessionId: string) => ({
+    client: {
+      session: {
+        messages: sessionMessagesMock,
+      },
+    },
+    endpointUrl: null,
+    managedSession: null,
+    mode: "default",
+    ownerAgent: null,
+    sessionId,
+  }));
 });
 
 describe("mission-surface-hydration.server", () => {
@@ -139,11 +170,25 @@ describe("mission-surface-hydration.server", () => {
         "session-prompto": "idle",
       },
     });
+    sessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "message-1",
+            role: "assistant",
+            time: { created: Date.parse("2026-04-29T00:00:00.000Z") },
+          },
+          parts: [{ type: "text", text: "Primary reply" }],
+        },
+      ],
+    });
 
     const payload = await buildMissionSurfaceHydrationPayload(mission);
 
     expect(payload).not.toHaveProperty("primaryMessages");
     expect(payload).not.toHaveProperty("noctisMessages");
+    expect(payload.latestPrimaryMessageId).toBe("message-1");
+    expect(payload.latestPrimaryMessageCreatedAt).toBe("2026-04-29T00:00:00.000Z");
     expect(payload.banterTimeline).toHaveLength(2);
     expect(Object.keys(payload.contextUsageByAgent).sort()).toEqual([
       "ignis",
@@ -156,7 +201,11 @@ describe("mission-surface-hydration.server", () => {
       "session-ignis": "retry",
       "session-prompto": "idle",
     });
-    expect(sessionMessagesMock).not.toHaveBeenCalled();
+    expect(getMission(missionId)).toMatchObject({
+      latestPrimaryMessageId: "message-1",
+      latestPrimaryMessageCreatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    expect(sessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-noctis" });
   });
 
   it("omits team-only runtime fields for Lunafreya", async () => {
@@ -191,16 +240,92 @@ describe("mission-surface-hydration.server", () => {
         "session-ignis": "busy",
       },
     });
+    sessionMessagesMock.mockResolvedValue({ data: [] });
 
     const payload = await buildMissionSurfaceHydrationPayload(mission);
 
     expect(payload).not.toHaveProperty("primaryMessages");
     expect(payload).not.toHaveProperty("noctisMessages");
     expect(payload).not.toHaveProperty("banterTimeline");
+    expect(payload.latestPrimaryMessageId).toBeNull();
+    expect(payload.latestPrimaryMessageCreatedAt).toBeNull();
     expect(Object.keys(payload.contextUsageByAgent)).toEqual(["lunafreya"]);
     expect(payload.sessionStatuses).toEqual({
       "session-lunafreya": "busy",
     });
+    expect(sessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-lunafreya" });
+  });
+
+  it("routes managed primary session hydration through the owning agent endpoint", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-managed-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    const mission = createMission(missionId, "session-noctis", {
+      title: "Managed Noctis mission",
+      objective: "Verify owner-aware hydration",
+    });
+    writeContextSnapshot(root, "session-noctis");
+
+    const managedMessagesMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "message-managed-1",
+            role: "assistant",
+            time: { created: Date.parse("2026-04-29T00:00:00.000Z") },
+          },
+          parts: [{ type: "text", text: "Managed primary reply" }],
+        },
+      ],
+    });
+    const managedStatusMock = vi.fn().mockResolvedValue({
+      data: {
+        "session-noctis": "busy",
+      },
+    });
+
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-noctis": "idle",
+      },
+    });
+    sessionMessagesMock.mockResolvedValue({ data: [] });
+    listSessionStatusTargetsMock.mockReturnValue([
+      {
+        agentId: "noctis",
+        client: {
+          session: {
+            status: managedStatusMock,
+          },
+        },
+        endpointUrl: "http://127.0.0.1:4401",
+      },
+    ]);
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          messages: managedMessagesMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4401",
+      managedSession: {
+        missionId,
+        ownerAgent: "noctis",
+      },
+      mode: "managed",
+      ownerAgent: "noctis",
+    });
+
+    const payload = await buildMissionSurfaceHydrationPayload(mission);
+
+    expect(resolveSessionRouteTargetMock).toHaveBeenCalledWith("session-noctis");
+    expect(managedMessagesMock).toHaveBeenCalledWith({ sessionID: "session-noctis" });
     expect(sessionMessagesMock).not.toHaveBeenCalled();
+    expect(payload.latestPrimaryMessageId).toBe("message-managed-1");
+    expect(payload.sessionStatuses).toEqual({
+      "session-noctis": "busy",
+    });
   });
 });

--- a/web/app/lib/mission-surface-hydration.server.ts
+++ b/web/app/lib/mission-surface-hydration.server.ts
@@ -1,5 +1,6 @@
 import { buildMissionBanterTimeline } from "@/lib/banter/timeline";
 import { getOpencodeClient } from "@/lib/opencode-client";
+import type { MessageInfo } from "@/lib/opencode-session-types";
 import { readSessionContextUsage } from "@/lib/session-context.server";
 import type { SessionStatus } from "@/lib/session-status";
 import { coerceSessionStatus } from "@/lib/session-status";
@@ -10,14 +11,38 @@ import type {
   Mission,
 } from "@/lib/types/mission";
 import { buildMissionResumePayload } from "./mission-api.server";
-import { getMissionPrimaryAgentId, getMissionPrimarySessionId } from "./mission-store";
+import {
+  getMissionPrimaryAgentId,
+  getMissionPrimarySessionId,
+  updateMissionPrimaryMessageMetadata,
+} from "./mission-store";
 import { getMissionSurfaceForMission } from "./mission-surface";
+import {
+  listSessionStatusTargets,
+  resolveSessionRouteTarget,
+} from "./session-owner-routing.server";
 
 export type MissionSurfaceHydrationPayload = ReturnType<typeof buildMissionResumePayload> & {
   banterTimeline?: BanterTimelineEntry[];
   contextUsageByAgent: Partial<Record<AgentId, AgentContextUsage | null>>;
+  latestPrimaryMessageCreatedAt: string | null;
+  latestPrimaryMessageId: string | null;
   sessionStatuses: Record<string, SessionStatus>;
 };
+
+function getLatestPrimaryMessageMetadata(messages: MessageInfo[] | null | undefined): {
+  latestPrimaryMessageCreatedAt: string | null;
+  latestPrimaryMessageId: string | null;
+} {
+  const latestMessage = Array.isArray(messages) && messages.length > 0 ? messages.at(-1) ?? null : null;
+  const createdAt = latestMessage?.info.time.created;
+
+  return {
+    latestPrimaryMessageId: latestMessage?.info.id ?? null,
+    latestPrimaryMessageCreatedAt:
+      typeof createdAt === "number" ? new Date(createdAt).toISOString() : null,
+  };
+}
 
 function getRelevantContextUsageByAgent(
   mission: Mission,
@@ -90,18 +115,61 @@ function getRelevantSessionStatuses(
   return nextStatuses;
 }
 
+async function loadMissionSessionStatuses(): Promise<Record<string, unknown>> {
+  const targets = listSessionStatusTargets();
+  if (targets.length === 0) {
+    const statusResult = await getOpencodeClient().session.status();
+    if (statusResult.error) {
+      throw new Error(String(statusResult.error));
+    }
+
+    return statusResult.data ?? {};
+  }
+
+  const statuses: Record<string, unknown> = {};
+  let successCount = 0;
+
+  for (const target of targets) {
+    try {
+      const result = await target.client.session.status();
+      if (result.error) {
+        continue;
+      }
+
+      Object.assign(statuses, result.data ?? {});
+      successCount += 1;
+    } catch {}
+  }
+
+  if (successCount === 0) {
+    throw new Error("No OpenCode status endpoints responded.");
+  }
+
+  return statuses;
+}
+
 export async function buildMissionSurfaceHydrationPayload(
   mission: Mission,
 ): Promise<MissionSurfaceHydrationPayload> {
   const primaryAgentId = getMissionPrimaryAgentId(mission) ?? "noctis";
   const primarySessionId = getMissionPrimarySessionId(mission);
   const surface = getMissionSurfaceForMission(mission);
-  const client = getOpencodeClient();
-  const statusResult = await client.session.status();
-
-  if (statusResult.error) {
-    throw new Error(String(statusResult.error));
-  }
+  const primarySessionClient = primarySessionId
+    ? resolveSessionRouteTarget(primarySessionId).client
+    : getOpencodeClient();
+  const [rawStatuses, messagesResult] = await Promise.all([
+    loadMissionSessionStatuses(),
+    primarySessionId
+      ? primarySessionClient.session.messages({ sessionID: primarySessionId })
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  const latestPrimaryMessage = messagesResult?.error
+    ? {
+        latestPrimaryMessageCreatedAt: null,
+        latestPrimaryMessageId: null,
+      }
+    : getLatestPrimaryMessageMetadata((messagesResult?.data ?? []) as MessageInfo[]);
+  updateMissionPrimaryMessageMetadata(mission.id, latestPrimaryMessage);
 
   const relevantSessionIds = getRelevantSessionIds(mission, primaryAgentId);
 
@@ -117,6 +185,8 @@ export async function buildMissionSurfaceHydrationPayload(
       primaryAgentId,
       primarySessionId,
     ),
-    sessionStatuses: getRelevantSessionStatuses(statusResult.data ?? {}, relevantSessionIds),
+    latestPrimaryMessageCreatedAt: latestPrimaryMessage.latestPrimaryMessageCreatedAt,
+    latestPrimaryMessageId: latestPrimaryMessage.latestPrimaryMessageId,
+    sessionStatuses: getRelevantSessionStatuses(rawStatuses, relevantSessionIds),
   };
 }

--- a/web/app/lib/opencode-model-catalog.server.test.ts
+++ b/web/app/lib/opencode-model-catalog.server.test.ts
@@ -25,6 +25,7 @@ function verboseOutput(): string {
     "github-copilot/gpt-5.4",
     "{",
     '  "id": "gpt-5.4",',
+    '  "name": "GPT-5.4",',
     '  "variants": {',
     '    "medium": {},',
     '    "high": {}',
@@ -32,7 +33,8 @@ function verboseOutput(): string {
     "}",
     "github-copilot/claude-haiku-4.5",
     "{",
-    '  "id": "claude-haiku-4.5"',
+    '  "id": "claude-haiku-4.5",',
+    '  "name": "Claude Haiku 4.5"',
     "}",
     "",
   ].join("\n");
@@ -91,6 +93,10 @@ describe("opencode-model-catalog.server", () => {
 
     expect(parseOpencodeModelsVerboseOutput(verboseOutput())).toEqual({
       models: ["github-copilot/gpt-5.4", "github-copilot/claude-haiku-4.5"],
+      namesByModel: {
+        "github-copilot/claude-haiku-4.5": "Claude Haiku 4.5",
+        "github-copilot/gpt-5.4": "GPT-5.4",
+      },
       variantsByModel: {
         "github-copilot/claude-haiku-4.5": [],
         "github-copilot/gpt-5.4": ["medium", "high"],
@@ -110,6 +116,10 @@ describe("opencode-model-catalog.server", () => {
     expect(existsSync(filePath)).toBe(true);
     expect(JSON.parse(readFileSync(filePath, "utf-8"))).toMatchObject({
       models: ["github-copilot/gpt-5.4", "github-copilot/claude-haiku-4.5"],
+      namesByModel: {
+        "github-copilot/claude-haiku-4.5": "Claude Haiku 4.5",
+        "github-copilot/gpt-5.4": "GPT-5.4",
+      },
       opencodeVersion: "1.2.3",
       sourceCommand: "opencode models --verbose",
       variantsByModel: {

--- a/web/app/lib/opencode-model-catalog.server.ts
+++ b/web/app/lib/opencode-model-catalog.server.ts
@@ -8,6 +8,7 @@ const SOURCE_COMMAND = "opencode models --verbose";
 export interface OpencodeModelCatalogSnapshot {
   generatedAt: string;
   models: string[];
+  namesByModel: Record<string, string>;
   opencodeVersion: string;
   sourceCommand: string;
   variantsByModel: Record<string, string[]>;
@@ -118,9 +119,10 @@ function readJsonObject(input: string, index: number): { json: string; nextIndex
 
 export function parseOpencodeModelsVerboseOutput(stdout: string): Pick<
   OpencodeModelCatalogSnapshot,
-  "models" | "variantsByModel"
+  "models" | "namesByModel" | "variantsByModel"
 > {
   const models: string[] = [];
+  const namesByModel: Record<string, string> = {};
   const variantsByModel: Record<string, string[]> = {};
 
   let index = 0;
@@ -142,14 +144,20 @@ export function parseOpencodeModelsVerboseOutput(stdout: string): Pick<
     }
 
     const { json, nextIndex: afterJson } = readJsonObject(stdout, jsonStart);
-    const parsed = JSON.parse(json) as { variants?: Record<string, unknown> };
+    const parsed = JSON.parse(json) as {
+      name?: unknown;
+      variants?: Record<string, unknown>;
+    };
 
     models.push(line);
+    if (typeof parsed.name === "string" && parsed.name.length > 0) {
+      namesByModel[line] = parsed.name;
+    }
     variantsByModel[line] = Object.keys(parsed.variants ?? {});
     index = afterJson;
   }
 
-  return { models, variantsByModel };
+  return { models, namesByModel, variantsByModel };
 }
 
 function readSnapshot(root: string): OpencodeModelCatalogSnapshot | null {
@@ -159,7 +167,15 @@ function readSnapshot(root: string): OpencodeModelCatalogSnapshot | null {
   }
 
   try {
-    return JSON.parse(readFileSync(filePath, "utf-8")) as OpencodeModelCatalogSnapshot;
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<OpencodeModelCatalogSnapshot>;
+    return {
+      generatedAt: parsed.generatedAt ?? "",
+      models: parsed.models ?? [],
+      namesByModel: parsed.namesByModel ?? {},
+      opencodeVersion: parsed.opencodeVersion ?? "unknown",
+      sourceCommand: parsed.sourceCommand ?? SOURCE_COMMAND,
+      variantsByModel: parsed.variantsByModel ?? {},
+    };
   } catch {
     return null;
   }
@@ -199,6 +215,7 @@ async function createSnapshot(root: string): Promise<OpencodeModelCatalogSnapsho
   return {
     generatedAt: new Date().toISOString(),
     models: parsed.models,
+    namesByModel: parsed.namesByModel,
     opencodeVersion: version,
     sourceCommand: SOURCE_COMMAND,
     variantsByModel: parsed.variantsByModel,

--- a/web/app/lib/primary-agent-outbox-dispatch.server.ts
+++ b/web/app/lib/primary-agent-outbox-dispatch.server.ts
@@ -13,6 +13,7 @@ export function queuePrimaryAgentTmuxDispatch(input: {
   parts: TextPromptPart[];
   queuedAt?: string;
   sessionId: string;
+  sessionTitle?: string;
   system?: string;
   variant?: string;
 }): PrimaryAgentOutboxItem {
@@ -23,6 +24,7 @@ export function queuePrimaryAgentTmuxDispatch(input: {
     payload: {
       agent: input.agent,
       sessionId: input.sessionId,
+      ...(input.sessionTitle ? { sessionTitle: input.sessionTitle } : {}),
       parts: input.parts,
       ...(input.system ? { system: input.system } : {}),
       ...(input.model ? { model: input.model } : {}),

--- a/web/app/lib/session-chat-rendering-orchestration.test.ts
+++ b/web/app/lib/session-chat-rendering-orchestration.test.ts
@@ -352,6 +352,42 @@ Implemented the requested change.
     expect(textSnapshot.showPendingIndicator).toBe(true);
   });
 
+  it("replaces a pending-only tail with authoritative assistant history without leaving duplicate tail state", () => {
+    const pendingSnapshot = buildSessionChatRenderSnapshot({
+      assistantPending: true,
+      messages: [],
+    });
+
+    const settledSnapshot = buildSessionChatRenderSnapshot({
+      assistantPending: false,
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          sender: "noctis",
+          senderLabel: "Noctis",
+          kind: "assistant_message",
+          content: "Mission reply settled.",
+          detailContent: "Mission reply settled.",
+          rawText: "Mission reply settled.",
+          parts: [{ type: "text", text: "Mission reply settled." }],
+          timestamp: new Date("2026-04-28T10:00:05.000Z"),
+          source: "session",
+        },
+      ],
+      previousSnapshot: pendingSnapshot,
+    });
+
+    expect(pendingSnapshot.showPendingIndicator).toBe(true);
+    expect(settledSnapshot.showPendingIndicator).toBe(false);
+    expect(settledSnapshot.streamingMessage).toBeNull();
+    expect(settledSnapshot.renderedMessages).toHaveLength(1);
+    expect(settledSnapshot.renderedMessages[0]?.messageDisplay.displayContent).toBe(
+      "Mission reply settled.",
+    );
+    expectRefreshKind(settledSnapshot.refreshKind, "tail-append");
+  });
+
   it("derives follow keys from reasoning-only live draft growth", () => {
     const initial = buildSessionChatRenderSnapshot({
       liveDraft: {

--- a/web/app/lib/session-stream.test.ts
+++ b/web/app/lib/session-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSessionLiveEvent } from "./session-stream";
+import { mergeSessionLiveDraft, parseSessionLiveEvent } from "./session-stream";
 
 describe("parseSessionLiveEvent", () => {
   it("normalizes a reasoning part update", () => {
@@ -94,6 +94,31 @@ describe("parseSessionLiveEvent", () => {
       }),
     ).toEqual({
       kind: "idle",
+      sessionId: "session-1",
+    });
+  });
+
+  it("appends a reasoning part onto an existing live draft", () => {
+    expect(
+      mergeSessionLiveDraft(
+        {
+          messageId: "message-1",
+          parts: [{ type: "text", text: "Drafting the next reply" }],
+          sessionId: "session-1",
+        },
+        {
+          kind: "part",
+          messageId: "message-1",
+          part: { type: "reasoning", text: "Thinking through the next step" },
+          sessionId: "session-1",
+        },
+      ),
+    ).toEqual({
+      messageId: "message-1",
+      parts: [
+        { type: "text", text: "Drafting the next reply" },
+        { type: "reasoning", text: "Thinking through the next step" },
+      ],
       sessionId: "session-1",
     });
   });

--- a/web/app/lib/task-dispatch.server.ts
+++ b/web/app/lib/task-dispatch.server.ts
@@ -12,6 +12,7 @@ import {
   updateMissionExecutionContext,
   updateTask,
 } from "@/lib/mission-store";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { splitModelSelection } from "@/lib/model-variant-selection";
 import { getOpencodeClient } from "@/lib/opencode-client";
 import { loadOperationByRef } from "@/lib/operation-definition/operation-catalog";
@@ -26,6 +27,10 @@ import {
 } from "@/lib/operation-runtime/state";
 import { composeWorkerTaskPrompt } from "@/lib/prompt-composition-engine";
 import { getRuntimeScriptPath } from "@/lib/runtime-script-path";
+import {
+  activateTmuxMissionWriteFocus,
+  getTmuxMissionWriteConflict,
+} from "@/lib/tmux-mission-activation.server";
 import type { AgentId, MissionMessageLogEntry, Task, WorkerAgentId } from "@/lib/types/mission";
 
 function createTaskId(): string {
@@ -171,6 +176,8 @@ export async function dispatchTaskToWorker(input: {
   if (!mission) {
     throw new Error("Mission not found");
   }
+  const projectRoot = getProjectRoot();
+  const client = getOpencodeClient();
 
   const handoffFromAgent = input.fromAgent ?? "noctis";
   const orchestratedBy = input.orchestratedBy ?? "noctis";
@@ -192,6 +199,19 @@ export async function dispatchTaskToWorker(input: {
     if (!effectiveWorkers.includes(input.agentId)) {
       throw new Error(`Delegation to ${input.agentId} is not allowed for the active step`);
     }
+  }
+
+  if (mission.transportMode === "tmux-resident") {
+    const conflict = await getTmuxMissionWriteConflict({
+      appRoot: projectRoot,
+      missionId: input.missionId,
+      client,
+    });
+    if (conflict) {
+      throw new Error(`Tmux write focus is still held by mission ${conflict.activeMissionId}.`);
+    }
+
+    activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId: input.missionId });
   }
 
   const reusableTask = explicitTaskId
@@ -249,8 +269,6 @@ export async function dispatchTaskToWorker(input: {
     agentId: input.agentId,
   });
 
-  const client = getOpencodeClient();
-  const projectRoot = getProjectRoot();
   const managedRoots = resolveManagedRootsForWorkerDispatch(input.missionId);
   const existingSessionId = mission.workerSessions[input.agentId];
 
@@ -354,7 +372,7 @@ export async function dispatchTaskToWorker(input: {
   const ledger = buildDelegationLedger(mission);
   const sessionResult = await client.session.create({
     directory: managedRoots.sessionHostRoot,
-    title: `mission:${input.missionId}:${input.agentId}`,
+    title: getManagedSessionTitle(input.missionId, input.agentId),
   });
 
   if (sessionResult.error) {

--- a/web/app/lib/team-message.server.ts
+++ b/web/app/lib/team-message.server.ts
@@ -14,11 +14,16 @@ import {
   setWorkerSession,
   updateMissionExecutionContext,
 } from "@/lib/mission-store";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { splitModelSelection } from "@/lib/model-variant-selection";
 import { getOpencodeClient } from "@/lib/opencode-client";
 import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeTeamMessagePrompt } from "@/lib/prompt-composition-engine";
 import { getActivityActorLabel } from "@/lib/team-message-format";
+import {
+  activateTmuxMissionWriteFocus,
+  getTmuxMissionWriteConflict,
+} from "@/lib/tmux-mission-activation.server";
 import type {
   ActivityActorId,
   AgentId,
@@ -112,8 +117,9 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
     throw new Error("Mission requires an execution workspace before team messages can be delivered.");
   }
 
+  const projectRoot = getProjectRoot();
   const executionRoot = resolveMissionExecutionRoot({
-    appRoot: getProjectRoot(),
+    appRoot: projectRoot,
     mission,
   });
   if (executionRoot.workspacePath && executionRoot.workspaceStatus) {
@@ -128,6 +134,18 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
   }
 
   const client = getOpencodeClient();
+  if (mission.transportMode === "tmux-resident") {
+    const conflict = await getTmuxMissionWriteConflict({
+      appRoot: projectRoot,
+      missionId,
+      client,
+    });
+    if (conflict) {
+      throw new Error(`Tmux write focus is still held by mission ${conflict.activeMissionId}.`);
+    }
+
+    activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId });
+  }
 
   if (!isWorkerAgentId(toAgent)) {
     const existingPrimarySessionId = mission.primarySessionId || mission.noctisSessionId;
@@ -137,7 +155,7 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
 
     const sessionResult = await client.session.create({
       directory: executionRoot.sessionHostRoot,
-      title: `mission:${missionId}`,
+      title: getManagedSessionTitle(missionId, toAgent),
     });
 
     const sessionId = sessionResult.data?.id;
@@ -156,7 +174,7 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
 
   const sessionResult = await client.session.create({
     directory: executionRoot.sessionHostRoot,
-    title: `mission:${missionId}:${toAgent}`,
+    title: getManagedSessionTitle(missionId, toAgent),
   });
 
   const sessionId = sessionResult.data?.id;

--- a/web/app/lib/tmux-active-mission.server.test.ts
+++ b/web/app/lib/tmux-active-mission.server.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  TMUX_ACTIVE_MISSION_STATE_FILE,
+  clearTmuxActiveMission,
+  readTmuxActiveMission,
+  writeTmuxActiveMission,
+} from "./tmux-active-mission.server";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-tmux-active-mission-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("tmux-active-mission.server", () => {
+  it("returns null when no writable tmux mission has been activated", () => {
+    const root = createTempRoot();
+
+    expect(readTmuxActiveMission(root)).toBeNull();
+  });
+
+  it("persists and reads back one writable active tmux mission", () => {
+    const root = createTempRoot();
+
+    writeTmuxActiveMission(root, {
+      missionId: "mission-alpha",
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+
+    expect(readTmuxActiveMission(root)).toEqual({
+      missionId: "mission-alpha",
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+
+    const filePath = join(root, "runtime", TMUX_ACTIVE_MISSION_STATE_FILE);
+    expect(existsSync(filePath)).toBe(true);
+    expect(JSON.parse(readFileSync(filePath, "utf-8"))).toMatchObject({
+      missionId: "mission-alpha",
+      updatedAt: "2026-04-29T00:00:00.000Z",
+      version: 1,
+    });
+  });
+
+  it("clears the writable active tmux mission state", () => {
+    const root = createTempRoot();
+
+    writeTmuxActiveMission(root, {
+      missionId: "mission-alpha",
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+
+    clearTmuxActiveMission(root);
+
+    expect(readTmuxActiveMission(root)).toBeNull();
+    expect(existsSync(join(root, "runtime", TMUX_ACTIVE_MISSION_STATE_FILE))).toBe(false);
+  });
+});

--- a/web/app/lib/tmux-active-mission.server.ts
+++ b/web/app/lib/tmux-active-mission.server.ts
@@ -1,0 +1,68 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const TMUX_ACTIVE_MISSION_STATE_FILE = "tmux-active-mission.json";
+
+export interface TmuxActiveMissionState {
+  missionId: string;
+  updatedAt: string;
+}
+
+type TmuxActiveMissionRecord = TmuxActiveMissionState & {
+  version: 1;
+};
+
+function getTmuxActiveMissionPath(root: string): string {
+  return join(root, "runtime", TMUX_ACTIVE_MISSION_STATE_FILE);
+}
+
+function parseTmuxActiveMissionRecord(value: unknown): TmuxActiveMissionRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1 || typeof record.missionId !== "string" || typeof record.updatedAt !== "string") {
+    return null;
+  }
+
+  return {
+    missionId: record.missionId,
+    updatedAt: record.updatedAt,
+    version: 1,
+  };
+}
+
+export function readTmuxActiveMission(root: string): TmuxActiveMissionState | null {
+  const path = getTmuxActiveMissionPath(root);
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const record = parseTmuxActiveMissionRecord(JSON.parse(readFileSync(path, "utf-8")));
+    if (!record) {
+      return null;
+    }
+
+    return {
+      missionId: record.missionId,
+      updatedAt: record.updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeTmuxActiveMission(root: string, state: TmuxActiveMissionState): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  writeFileSync(
+    getTmuxActiveMissionPath(root),
+    `${JSON.stringify({ ...state, version: 1 }, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+export function clearTmuxActiveMission(root: string): void {
+  rmSync(getTmuxActiveMissionPath(root), { force: true });
+}

--- a/web/app/lib/tmux-mission-activation.server.ts
+++ b/web/app/lib/tmux-mission-activation.server.ts
@@ -1,0 +1,113 @@
+import { getMission, getMissionPrimarySessionId } from "@/lib/mission-store";
+import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
+import { isSessionStatusActive, type SessionStatus } from "@/lib/session-status";
+import { readTmuxActiveMission, writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
+import type { Mission } from "@/lib/types/mission";
+
+type SessionStatusClient = {
+  session: {
+    status: () => Promise<{ data?: Record<string, unknown>; error?: unknown }>;
+  };
+};
+
+export interface TmuxMissionWriteConflict {
+  activeMissionId: string;
+}
+
+function getRelevantMissionSessionIds(mission: Mission): string[] {
+  return [
+    getMissionPrimarySessionId(mission),
+    mission.workerSessions.ignis,
+    mission.workerSessions.gladiolus,
+    mission.workerSessions.prompto,
+  ].filter((sessionId, index, values): sessionId is string => {
+    return typeof sessionId === "string" && sessionId.length > 0 && values.indexOf(sessionId) === index;
+  });
+}
+
+function hasActiveDelegationWork(mission: Mission): boolean {
+  if (mission.delegationLedger.activeTasks.length > 0) {
+    return true;
+  }
+
+  return (
+    mission.operationState?.delegatedTasks?.some(
+      (task: { status?: string }) => task.status === "dispatched",
+    ) ?? false
+  );
+}
+
+function hasPendingPrimaryOutboxWork(missionId: string): boolean {
+  return listPrimaryAgentOutboxItems(missionId).some(
+    (item) => item.status === "pending" || item.status === "leased",
+  );
+}
+
+function coerceStatusesById(result: Record<string, unknown> | undefined, sessionIds: string[]): Record<string, SessionStatus> {
+  const statuses: Record<string, SessionStatus> = {};
+
+  for (const sessionId of sessionIds) {
+    const value = result?.[sessionId];
+    if (value === "idle" || value === "busy" || value === "retry") {
+      statuses[sessionId] = value;
+      continue;
+    }
+
+    if (value && typeof value === "object") {
+      const type = (value as { type?: unknown }).type;
+      if (type === "idle" || type === "busy" || type === "retry") {
+        statuses[sessionId] = type;
+      }
+    }
+  }
+
+  return statuses;
+}
+
+export async function getTmuxMissionWriteConflict(input: {
+  appRoot: string;
+  missionId: string;
+  client: SessionStatusClient;
+}): Promise<TmuxMissionWriteConflict | null> {
+  const activeMission = readTmuxActiveMission(input.appRoot);
+  if (!activeMission || activeMission.missionId === input.missionId) {
+    return null;
+  }
+
+  const mission = getMission(activeMission.missionId);
+  if (!mission) {
+    return null;
+  }
+
+  if (hasPendingPrimaryOutboxWork(mission.id) || hasActiveDelegationWork(mission)) {
+    return { activeMissionId: mission.id };
+  }
+
+  const relevantSessionIds = getRelevantMissionSessionIds(mission);
+  if (relevantSessionIds.length === 0) {
+    return null;
+  }
+
+  try {
+    const result = await input.client.session.status();
+    if (result.error) {
+      return null;
+    }
+
+    const statuses = coerceStatusesById(result.data, relevantSessionIds);
+    const hasActiveSession = relevantSessionIds.some((sessionId) =>
+      isSessionStatusActive(statuses[sessionId] ?? null),
+    );
+
+    return hasActiveSession ? { activeMissionId: mission.id } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function activateTmuxMissionWriteFocus(input: { appRoot: string; missionId: string; updatedAt?: string }): void {
+  writeTmuxActiveMission(input.appRoot, {
+    missionId: input.missionId,
+    updatedAt: input.updatedAt ?? new Date().toISOString(),
+  });
+}

--- a/web/app/lib/types/mission.ts
+++ b/web/app/lib/types/mission.ts
@@ -129,6 +129,8 @@ export interface Mission {
   agentModels: Partial<Record<AgentId, ModelSelection>>;
   createdAt: string;
   updatedAt: string;
+  latestPrimaryMessageId?: string;
+  latestPrimaryMessageCreatedAt?: string;
   archivedAt?: string;
   title: string;
   objective?: string;
@@ -305,9 +307,13 @@ export interface MissionSummary {
   objective?: string;
   createdAt: string;
   updatedAt: string;
-  archivedAt?: string;
+  archivedAt?: string | null;
   status: MissionStatus;
   activitySessionIds: string[];
+  primarySessionId?: string | null;
+  agentStatuses?: Partial<Record<AgentId, import("@/lib/session-status").SessionStatus>>;
+  latestPrimaryMessageId?: string | null;
+  latestPrimaryMessageCreatedAt?: string | null;
 }
 
 export interface MissionOutputSummary {

--- a/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
@@ -470,6 +470,36 @@ describe("chat-area", () => {
     expect(markup).toContain("send-enabled");
   });
 
+  it("suppresses the empty transcript placeholder while a pending assistant tail is visible", () => {
+    sessionChatRenderSnapshotMock.mockReturnValueOnce(
+      buildSessionChatRenderSnapshot({
+        assistantPending: true,
+        messages: [],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(
+      <ChatArea
+        messages={[]}
+        historyPhase="empty"
+        isResponding={true}
+        isSessionActive={true}
+        missionExecutionLabel="Core Repo"
+        contextProjects={[]}
+        availableOperations={[]}
+        selectedOperation={null}
+        activeOperationState={null}
+        isOperationSelectionLocked={true}
+        onSelectedOperationChange={() => undefined}
+        onSend={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("animate-bounce");
+    expect(markup).not.toContain("No Session History Yet");
+    expect(markup).not.toContain("This mission has not produced a transcript yet.");
+  });
+
   it("shows abort-settlement feedback while resend is blocked", () => {
     const markup = renderToStaticMarkup(
       <ChatArea

--- a/web/app/routes/_layout.noctis-team/components/chat-area.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.tsx
@@ -966,7 +966,7 @@ export const ChatArea = ({
   );
   const historyEmptyCallout = useMemo(
     () =>
-      isTranscriptEmpty ? (
+      isTranscriptEmpty && !hasVisibleTranscriptContent ? (
         <div className="rounded-xl border border-border/60 bg-background/40 px-3 py-2.5" role="status">
           <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground/80">
             No Session History Yet
@@ -976,7 +976,7 @@ export const ChatArea = ({
           </p>
         </div>
       ) : null,
-    [isTranscriptEmpty],
+    [hasVisibleTranscriptContent, isTranscriptEmpty],
   );
   const historyErrorCallout = useMemo(
     () =>

--- a/web/app/routes/_layout.noctis-team/components/mission-history-item.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/mission-history-item.test.tsx
@@ -74,4 +74,27 @@ describe("MissionHistoryItem", () => {
     expect(markup).toContain("animate-spin");
     expect(markup).toContain("/lunafreya/mission/mission-luna");
   });
+
+  it("shows a fresh reply badge when polling detects a newer primary message", () => {
+    const markup = renderToStaticMarkup(
+      <MissionHistoryItem
+        mission={createMissionSummary()}
+        routeBase="/noctis-team"
+        isActive={false}
+        isArchivedView={false}
+        isEditing={false}
+        isArchivePending={false}
+        isArchiveDisabled={false}
+        isRenaming={false}
+        isRunning={false}
+        hasFreshPrimaryMessage={true}
+        onBeginRename={vi.fn()}
+        onArchiveAction={vi.fn()}
+        onCancelRename={vi.fn()}
+        onSubmitRename={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("New reply");
+  });
 });

--- a/web/app/routes/_layout.noctis-team/components/mission-history-item.tsx
+++ b/web/app/routes/_layout.noctis-team/components/mission-history-item.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useState } from "react";
 import { NavLink } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import type { MissionSummary } from "@/hooks/use-agent-session";
+import type { MissionSummary } from "@/lib/types/mission";
 import { cn } from "@/lib/utils";
 import { buildMissionPath } from "./output-detail-routing";
 
@@ -17,6 +17,7 @@ export type MissionHistoryItemProps = {
   isArchiveDisabled: boolean;
   isRenaming: boolean;
   isRunning: boolean;
+  hasFreshPrimaryMessage?: boolean;
   onBeginRename: (mission: MissionSummary) => void;
   onArchiveAction: (mission: MissionSummary, action: "archive" | "restore") => void;
   onCancelRename: () => void;
@@ -34,6 +35,7 @@ export const MissionHistoryItem = memo(
     isArchiveDisabled,
     isRenaming,
     isRunning,
+    hasFreshPrimaryMessage = false,
     onBeginRename,
     onArchiveAction,
     onCancelRename,
@@ -109,6 +111,11 @@ export const MissionHistoryItem = memo(
               <span className="max-w-24 shrink-0 truncate rounded-full border border-border/50 px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-muted-foreground/70">
                 {mission.status}
               </span>
+              {hasFreshPrimaryMessage ? (
+                <span className="shrink-0 rounded-full bg-primary/15 px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-primary">
+                  New reply
+                </span>
+              ) : null}
               <p className="min-w-0 flex-1 truncate text-right font-mono text-[9px] uppercase tracking-widest text-muted-foreground/40">
                 {new Date(mission.updatedAt).toLocaleString("en-US", {
                   year: "numeric",

--- a/web/app/routes/_layout.noctis-team/components/mission-summary-freshness.test.ts
+++ b/web/app/routes/_layout.noctis-team/components/mission-summary-freshness.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { MissionSummary } from "@/lib/types/mission";
+import { reconcileFreshMissionIds } from "./mission-summary-freshness";
+
+function createMissionSummary(overrides: Partial<MissionSummary> = {}): MissionSummary {
+  return {
+    missionId: "mission-1",
+    title: "Mission One",
+    createdAt: "2026-04-13T00:00:00.000Z",
+    updatedAt: "2026-04-13T00:00:00.000Z",
+    status: "active",
+    activitySessionIds: ["session-1"],
+    latestPrimaryMessageId: null,
+    latestPrimaryMessageCreatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("mission-summary-freshness", () => {
+  it("does not mark missions fresh on the first summary load", () => {
+    expect(
+      reconcileFreshMissionIds({
+        currentFreshMissionIds: [],
+        previousMissions: [],
+        nextMissions: [
+          createMissionSummary({
+            latestPrimaryMessageId: "message-1",
+            latestPrimaryMessageCreatedAt: "2026-04-13T00:01:00.000Z",
+          }),
+        ],
+        activeMissionId: null,
+      }),
+    ).toEqual([]);
+  });
+
+  it("marks a mission fresh when the latest primary message changes on a later poll", () => {
+    expect(
+      reconcileFreshMissionIds({
+        currentFreshMissionIds: [],
+        previousMissions: [
+          createMissionSummary({
+            latestPrimaryMessageId: "message-1",
+            latestPrimaryMessageCreatedAt: "2026-04-13T00:01:00.000Z",
+          }),
+        ],
+        nextMissions: [
+          createMissionSummary({
+            latestPrimaryMessageId: "message-2",
+            latestPrimaryMessageCreatedAt: "2026-04-13T00:02:00.000Z",
+          }),
+        ],
+        activeMissionId: null,
+      }),
+    ).toEqual(["mission-1"]);
+  });
+
+  it("retains fresh missions across unchanged polls until the mission becomes active", () => {
+    expect(
+      reconcileFreshMissionIds({
+        currentFreshMissionIds: ["mission-1"],
+        previousMissions: [
+          createMissionSummary({
+            latestPrimaryMessageId: "message-2",
+            latestPrimaryMessageCreatedAt: "2026-04-13T00:02:00.000Z",
+          }),
+        ],
+        nextMissions: [
+          createMissionSummary({
+            latestPrimaryMessageId: "message-2",
+            latestPrimaryMessageCreatedAt: "2026-04-13T00:02:00.000Z",
+          }),
+        ],
+        activeMissionId: "mission-1",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/mission-summary-freshness.ts
+++ b/web/app/routes/_layout.noctis-team/components/mission-summary-freshness.ts
@@ -1,0 +1,40 @@
+import type { MissionSummary } from "@/lib/types/mission";
+
+function getFreshnessKey(mission: MissionSummary): string {
+  return `${mission.latestPrimaryMessageId ?? ""}:${mission.latestPrimaryMessageCreatedAt ?? ""}`;
+}
+
+export function reconcileFreshMissionIds(input: {
+  currentFreshMissionIds: string[];
+  previousMissions: MissionSummary[];
+  nextMissions: MissionSummary[];
+  activeMissionId: string | null;
+}): string[] {
+  const { activeMissionId, currentFreshMissionIds, nextMissions, previousMissions } = input;
+  const nextMissionIds = new Set(nextMissions.map((mission) => mission.missionId));
+  const previousMissionById = new Map(
+    previousMissions.map((mission) => [mission.missionId, mission] as const),
+  );
+  const nextFreshMissionIds = new Set(
+    currentFreshMissionIds.filter(
+      (missionId) => missionId !== activeMissionId && nextMissionIds.has(missionId),
+    ),
+  );
+
+  for (const mission of nextMissions) {
+    if (mission.missionId === activeMissionId) {
+      continue;
+    }
+
+    const previousMission = previousMissionById.get(mission.missionId);
+    if (!previousMission) {
+      continue;
+    }
+
+    if (getFreshnessKey(previousMission) !== getFreshnessKey(mission)) {
+      nextFreshMissionIds.add(mission.missionId);
+    }
+  }
+
+  return Array.from(nextFreshMissionIds);
+}

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.polling.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.polling.test.tsx
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MissionSummary } from "@/lib/types/mission";
+
+vi.hoisted(() => {
+  const maybeWindow = globalThis as typeof globalThis & {
+    window?: typeof globalThis & { __vite_plugin_react_preamble_installed__?: boolean };
+    __vite_plugin_react_preamble_installed__?: boolean;
+    $RefreshReg$?: (type: unknown, id: string) => void;
+    $RefreshSig$?: () => <T>(type: T) => T;
+  };
+
+  if (maybeWindow.window) {
+    maybeWindow.window.__vite_plugin_react_preamble_installed__ = true;
+  }
+  maybeWindow.__vite_plugin_react_preamble_installed__ = true;
+  maybeWindow.$RefreshReg$ = () => undefined;
+  maybeWindow.$RefreshSig$ = () => (type) => type;
+});
+
+const {
+  agentSessionStateMock,
+  matchMock,
+  navigateMock,
+  paramsMock,
+  projectRegistryStateMock,
+  sessionStatusFeedMock,
+} = vi.hoisted(() => ({
+  agentSessionStateMock: vi.fn(),
+  matchMock: vi.fn(),
+  navigateMock: vi.fn(),
+  paramsMock: vi.fn(),
+  projectRegistryStateMock: vi.fn(),
+  sessionStatusFeedMock: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  NavLink: ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  useMatch: () => matchMock(),
+  useNavigate: () => navigateMock,
+  useParams: () => paramsMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/use-agent-session", () => ({
+  useAgentSession: () => agentSessionStateMock(),
+}));
+
+vi.mock("@/hooks/use-project-registry", () => ({
+  useProjectRegistry: () => projectRegistryStateMock(),
+}));
+
+vi.mock("@/hooks/use-session-status-feed", () => ({
+  useSessionStatusFeed: (...args: unknown[]) => sessionStatusFeedMock(...args),
+}));
+
+vi.mock("@/components/workspace-launch-actions", () => ({
+  WorkspaceLaunchActions: () => <div>workspace-launch-actions</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock("./banter-log", () => ({
+  BanterLog: () => <div>banter-log</div>,
+}));
+
+vi.mock("./chat-area", () => ({
+  ChatArea: () => <div>chat-area</div>,
+}));
+
+vi.mock("./lunafreya-status-panel", () => ({
+  LunafreyaStatusPanel: () => <div>lunafreya-status</div>,
+}));
+
+vi.mock("./mission-activity-log", () => ({
+  MissionActivityLog: () => <div>mission-activity-log</div>,
+}));
+
+vi.mock("./mission-history-item", () => ({
+  MissionHistoryItem: ({ mission }: { mission: MissionSummary }) => <div>{mission.title}</div>,
+}));
+
+vi.mock("./mission-output-browser", () => ({
+  MissionOutputBrowser: () => <div>mission-output-browser</div>,
+  getMissionOutputKey: ({ step, taskId, filename }: { step: string; taskId: string; filename: string }) =>
+    `${step}:${taskId}:${filename}`,
+}));
+
+vi.mock("./party-status-panel", () => ({
+  PartyStatusPanel: () => <div>party-status-panel</div>,
+}));
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+  fetch?: typeof fetch;
+};
+
+const testWindow = globalThis as typeof globalThis & {
+  __vite_plugin_react_preamble_installed__?: boolean;
+};
+
+function createMissionSummary(overrides: Partial<MissionSummary> = {}): MissionSummary {
+  return {
+    activitySessionIds: ["session-1"],
+    agentStatuses: {
+      gladiolus: "idle",
+      ignis: "idle",
+      noctis: "idle",
+      prompto: "idle",
+    },
+    archivedAt: null,
+    createdAt: "2026-04-29T00:00:00.000Z",
+    latestPrimaryMessageCreatedAt: null,
+    latestPrimaryMessageId: null,
+    missionId: "mission-1",
+    objective: undefined,
+    primarySessionId: "session-1",
+    status: "active",
+    title: "Mission One",
+    updatedAt: "2026-04-29T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+  });
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => undefined | boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await flushEffects();
+    try {
+      const result = assertion();
+      if (result === false) {
+        throw new Error("retry");
+      }
+      return;
+    } catch {
+      // retry
+    }
+  }
+
+  assertion();
+}
+
+describe("noctis-team-screen mission list refresh", () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    paramsMock.mockReturnValue({});
+    matchMock.mockReturnValue(null);
+    navigateMock.mockReset();
+    projectRegistryStateMock.mockReturnValue({
+      data: {
+        projects: [
+          {
+            displayName: "Core Repo",
+            id: "core-repo",
+            path: "/repos/core",
+          },
+        ],
+      },
+      error: null,
+      loading: false,
+    });
+    agentSessionStateMock.mockReturnValue({
+      messages: [],
+      streamingContent: "",
+      banterEntries: [],
+      latestBanterEntryId: null,
+      partyMembers: [],
+      speakingAgentId: null,
+      historyErrorMessage: null,
+      historyPhase: "idle",
+      abortSettlementPhase: "idle",
+      isStartingMission: false,
+      isSessionActive: false,
+      isStreaming: false,
+      isLoadingHistory: false,
+      availableOperations: [],
+      selectedOperation: null,
+      activeOperationState: null,
+      workflowProgress: null,
+      activityLog: [],
+      primaryContextUsage: null,
+      isOperationSelectionLocked: false,
+      setSelectedOperation: vi.fn(),
+      send: vi.fn(),
+      abort: vi.fn(),
+    });
+    sessionStatusFeedMock.mockReturnValue({});
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+      root = null;
+    }
+
+    container?.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the loaded mission list visible instead of re-entering loading on a timer refresh", async () => {
+    testWindow.__vite_plugin_react_preamble_installed__ = true;
+    const { NoctisTeamScreen } = await import("./noctis-team-screen");
+
+    let missionFetchCount = 0;
+    testGlobal.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url !== "/api/noctis/missions?view=active") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      missionFetchCount += 1;
+      if (missionFetchCount === 1) {
+        return createJsonResponse({
+          counts: { active: 1, archived: 1 },
+          missions: [createMissionSummary()],
+        });
+      }
+
+      return new Promise<Response>(() => undefined);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(
+        <NoctisTeamScreen activeMissionId={null} initialMissionData={null} language="other" />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(missionFetchCount).toBe(1);
+      expect(container.textContent).toContain("Active (1)");
+      expect(container.textContent).toContain("Archived (1)");
+      return true;
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(missionFetchCount).toBe(1);
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.start-mission.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.start-mission.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  const maybeWindow = globalThis as typeof globalThis & {
+    window?: typeof globalThis & { __vite_plugin_react_preamble_installed__?: boolean };
+    __vite_plugin_react_preamble_installed__?: boolean;
+    $RefreshReg$?: (type: unknown, id: string) => void;
+    $RefreshSig$?: () => <T>(type: T) => T;
+  };
+
+  if (maybeWindow.window) {
+    maybeWindow.window.__vite_plugin_react_preamble_installed__ = true;
+  }
+  maybeWindow.__vite_plugin_react_preamble_installed__ = true;
+  maybeWindow.$RefreshReg$ = () => undefined;
+  maybeWindow.$RefreshSig$ = () => (type) => type;
+});
+
+const {
+  agentSessionStateMock,
+  matchMock,
+  navigateMock,
+  paramsMock,
+  projectRegistryStateMock,
+  sendMock,
+  sessionStatusFeedMock,
+} = vi.hoisted(() => ({
+  agentSessionStateMock: vi.fn(),
+  matchMock: vi.fn(),
+  navigateMock: vi.fn(),
+  paramsMock: vi.fn(),
+  projectRegistryStateMock: vi.fn(),
+  sendMock: vi.fn(),
+  sessionStatusFeedMock: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  NavLink: ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  useMatch: () => matchMock(),
+  useNavigate: () => navigateMock,
+  useParams: () => paramsMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/use-agent-session", () => ({
+  useAgentSession: () => agentSessionStateMock(),
+}));
+
+vi.mock("@/hooks/use-project-registry", () => ({
+  useProjectRegistry: () => projectRegistryStateMock(),
+}));
+
+vi.mock("@/hooks/use-session-status-feed", () => ({
+  useSessionStatusFeed: (...args: unknown[]) => sessionStatusFeedMock(...args),
+}));
+
+vi.mock("@/components/workspace-launch-actions", () => ({
+  WorkspaceLaunchActions: () => <div>workspace-launch-actions</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock("./banter-log", () => ({
+  BanterLog: () => <div>banter-log</div>,
+}));
+
+vi.mock("./chat-area", () => ({
+  ChatArea: ({ onSend }: { onSend?: (parts: unknown[]) => Promise<void> | void }) => (
+    <button type="button" onClick={() => void onSend?.([])}>
+      start-mission
+    </button>
+  ),
+}));
+
+vi.mock("./lunafreya-status-panel", () => ({
+  LunafreyaStatusPanel: () => <div>lunafreya-status</div>,
+}));
+
+vi.mock("./mission-activity-log", () => ({
+  MissionActivityLog: () => <div>mission-activity-log</div>,
+}));
+
+vi.mock("./mission-history-item", () => ({
+  MissionHistoryItem: () => <div>mission-history-item</div>,
+}));
+
+vi.mock("./mission-output-browser", () => ({
+  MissionOutputBrowser: () => <div>mission-output-browser</div>,
+  getMissionOutputKey: ({ step, taskId, filename }: { step: string; taskId: string; filename: string }) =>
+    `${step}:${taskId}:${filename}`,
+}));
+
+vi.mock("./party-status-panel", () => ({
+  PartyStatusPanel: () => <div>party-status-panel</div>,
+}));
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+  fetch?: typeof fetch;
+};
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => undefined | boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await flushEffects();
+    try {
+      const result = assertion();
+      if (result === false) {
+        throw new Error("retry");
+      }
+      return;
+    } catch {
+      // retry
+    }
+  }
+
+  assertion();
+}
+
+describe("noctis-team-screen mission start navigation", () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    paramsMock.mockReturnValue({});
+    matchMock.mockReturnValue(null);
+    navigateMock.mockReset();
+    sendMock.mockReset();
+    sendMock.mockResolvedValue("mission-2");
+    projectRegistryStateMock.mockReturnValue({
+      data: {
+        projects: [
+          {
+            displayName: "Core Repo",
+            id: "core-repo",
+            path: "/repos/core",
+          },
+        ],
+      },
+      error: null,
+      loading: false,
+    });
+    agentSessionStateMock.mockReturnValue({
+      messages: [],
+      streamingContent: "",
+      banterEntries: [],
+      latestBanterEntryId: null,
+      partyMembers: [],
+      speakingAgentId: null,
+      historyErrorMessage: null,
+      historyPhase: "idle",
+      abortSettlementPhase: "idle",
+      isStartingMission: false,
+      isSessionActive: false,
+      isStreaming: false,
+      isLoadingHistory: false,
+      availableOperations: [],
+      selectedOperation: null,
+      activeOperationState: null,
+      workflowProgress: null,
+      activityLog: [],
+      primaryContextUsage: null,
+      isOperationSelectionLocked: false,
+      setSelectedOperation: vi.fn(),
+      send: sendMock,
+      abort: vi.fn(),
+    });
+    sessionStatusFeedMock.mockReturnValue({});
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+      root = null;
+    }
+
+    container?.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("navigates to the new mission before the background list refresh completes", async () => {
+    const { NoctisTeamScreen } = await import("./noctis-team-screen");
+
+    let missionFetchCount = 0;
+    testGlobal.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url !== "/api/noctis/missions?view=active") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      missionFetchCount += 1;
+      if (missionFetchCount === 1) {
+        return new Response(JSON.stringify({ counts: { active: 0, archived: 0 }, missions: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+
+      return new Promise<Response>(() => undefined);
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(
+        <NoctisTeamScreen activeMissionId={null} initialMissionData={null} language="other" />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(missionFetchCount).toBe(1);
+      return true;
+    });
+
+    const startButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "start-mission",
+    );
+    expect(startButton).not.toBeNull();
+
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith("/noctis-team/mission/mission-2", { replace: true });
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -1,5 +1,5 @@
 import { Ellipsis, History, Plus } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMatch, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { WorkspaceLaunchActions } from "@/components/workspace-launch-actions";
@@ -30,7 +30,6 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   type MissionResumePayload,
-  type MissionSummary,
   useAgentSession,
 } from "@/hooks/use-agent-session";
 import { useProjectRegistry } from "@/hooks/use-project-registry";
@@ -52,6 +51,7 @@ import {
 import type {
   MissionExecutionTargetMode,
   MissionOutputSummary,
+  MissionSummary,
   MissionSurfaceId,
 } from "@/lib/types/mission";
 import { isMissionSummaryRunning } from "@/lib/mission-list-running-state";
@@ -75,6 +75,7 @@ import {
   resolveMissionInspectorTab,
 } from "./output-detail-routing";
 import { PartyStatusPanel } from "./party-status-panel";
+import { reconcileFreshMissionIds } from "./mission-summary-freshness";
 
 type BulkMissionAction = "archive" | "restore";
 
@@ -145,6 +146,8 @@ export function NoctisTeamScreen({
   }, [effectiveMissionId, surface.lastMissionStorageKey]);
 
   const [missions, setMissions] = useState<MissionSummary[]>([]);
+  const [missionCounts, setMissionCounts] = useState({ active: 0, archived: 0 });
+  const [freshMissionIds, setFreshMissionIds] = useState<string[]>([]);
   const [missionView, setMissionView] = useState<"active" | "archived">(initialView);
   const [isLoadingMissions, setIsLoadingMissions] = useState(true);
   const [editingMissionId, setEditingMissionId] = useState<string | null>(null);
@@ -186,6 +189,8 @@ export function NoctisTeamScreen({
   const [selectedLunafreyaSkillIds, setSelectedLunafreyaSkillIds] = useState<string[]>(
     initialMissionData?.lunafreyaFacetSelection?.selectedSkillIds ?? [],
   );
+  const activeMissionIdRef = useRef<string | null>(effectiveMissionId);
+  const previousMissionSummariesRef = useRef<MissionSummary[]>([]);
   const {
     data: projectRegistryData,
     error: projectRegistryError,
@@ -511,20 +516,58 @@ export function NoctisTeamScreen({
   const loadMissions = useCallback(async () => {
     setIsLoadingMissions(true);
     try {
-      const res = await fetch(`${missionApiBase}?view=all`);
+      const res = await fetch(`${missionApiBase}?view=${missionView}`);
       if (!res.ok) {
         throw new Error(`missions failed: ${res.status}`);
       }
-      const data = (await res.json()) as { missions?: MissionSummary[] };
-      setMissions(data.missions ?? []);
+      const data = (await res.json()) as {
+        counts?: { active?: number; archived?: number };
+        missions?: MissionSummary[];
+      };
+      const nextMissions = data.missions ?? [];
+      setMissionCounts({
+        active: data.counts?.active ?? 0,
+        archived: data.counts?.archived ?? 0,
+      });
+      setFreshMissionIds((currentFreshMissionIds) =>
+        reconcileFreshMissionIds({
+          currentFreshMissionIds,
+          previousMissions: previousMissionSummariesRef.current,
+          nextMissions,
+          activeMissionId: activeMissionIdRef.current,
+        }),
+      );
+      previousMissionSummariesRef.current = nextMissions;
+      setMissions(nextMissions);
     } catch {
+      previousMissionSummariesRef.current = [];
+      setFreshMissionIds([]);
+      setMissionCounts({ active: 0, archived: 0 });
       setMissions([]);
     } finally {
       setIsLoadingMissions(false);
     }
-  }, [missionApiBase]);
+  }, [missionApiBase, missionView]);
 
-  const sessionStates = useSessionStatusFeed({ onSessionIdle: () => void loadMissions() });
+  const sessionStates = useSessionStatusFeed();
+
+  useEffect(() => {
+    activeMissionIdRef.current = effectiveMissionId;
+  }, [effectiveMissionId]);
+
+  useEffect(() => {
+    void loadMissions();
+  }, [loadMissions]);
+
+  useEffect(() => {
+    if (!effectiveMissionId) {
+      return;
+    }
+
+    setFreshMissionIds((currentFreshMissionIds) =>
+      currentFreshMissionIds.filter((missionId) => missionId !== effectiveMissionId),
+    );
+  }, [effectiveMissionId]);
 
   const loadMissionOutputs = useCallback(async () => {
     if (!effectiveMissionId) {
@@ -574,10 +617,6 @@ export function NoctisTeamScreen({
   }, [effectiveMissionId, missionApiBase]);
 
   useEffect(() => {
-    void loadMissions();
-  }, [loadMissions]);
-
-  useEffect(() => {
     void loadMissionOutputs();
   }, [loadMissionOutputs]);
 
@@ -590,20 +629,6 @@ export function NoctisTeamScreen({
       missionOutputs.find((output) => getMissionOutputKey(output) === selectedOutputKey) ?? null,
     [missionOutputs, selectedOutputKey],
   );
-
-  const missionCounts = useMemo(() => {
-    return missions.reduce(
-      (counts, mission) => {
-        if (mission.status === "archived") {
-          counts.archived += 1;
-        } else {
-          counts.active += 1;
-        }
-        return counts;
-      },
-      { active: 0, archived: 0 }
-    );
-  }, [missions]);
 
   const visibleMissions = useMemo(
     () => missions.filter((mission) => (missionView === "archived" ? mission.status === "archived" : mission.status !== "archived")),
@@ -710,6 +735,17 @@ export function NoctisTeamScreen({
                 }
               : entry
           )
+        );
+        setMissionCounts((currentCounts) =>
+          action === "archive"
+            ? {
+                active: Math.max(0, currentCounts.active - 1),
+                archived: currentCounts.archived + 1,
+              }
+            : {
+                active: currentCounts.active + 1,
+                archived: Math.max(0, currentCounts.archived - 1),
+              },
         );
         setEditingMissionId(null);
 
@@ -847,8 +883,8 @@ export function NoctisTeamScreen({
         if (typeof window !== "undefined") {
           clearMissionSurfaceNewMissionDraft(window.localStorage, surface.id);
         }
-        await loadMissions();
         navigate(buildMissionPath(missionId, missionRouteBase), { replace: true });
+        void loadMissions();
       }
     },
     [
@@ -1111,6 +1147,7 @@ export function NoctisTeamScreen({
                       mission={mission}
                       routeBase={missionRouteBase}
                       isRunning={isMissionSummaryRunning(mission, sessionStates)}
+                      hasFreshPrimaryMessage={freshMissionIds.includes(mission.missionId)}
                       isActive={effectiveMissionId === mission.missionId}
                       isArchivedView={missionView === "archived"}
                       isEditing={editingMissionId === mission.missionId}

--- a/web/app/routes/_layout.noctis-team/components/use-mission-summary-polling.test.ts
+++ b/web/app/routes/_layout.noctis-team/components/use-mission-summary-polling.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMissionSummaryPolling } from "./use-mission-summary-polling";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function HookProbe({ onPoll }: { onPoll: () => void }) {
+  useMissionSummaryPolling({
+    enabled: true,
+    onPoll,
+  });
+
+  useEffect(() => undefined, []);
+  return null;
+}
+
+describe("useMissionSummaryPolling", () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+      root = null;
+    }
+
+    container?.remove();
+    vi.useRealTimers();
+  });
+
+  it("polls every 3 seconds while visible, pauses while hidden, and refreshes immediately on visibility restore", async () => {
+    vi.useFakeTimers();
+
+    let visibilityState: DocumentVisibilityState = "visible";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    const onPoll = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(createElement(HookProbe, { onPoll }));
+    });
+
+    await flushEffects();
+    expect(onPoll).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+    expect(onPoll).toHaveBeenCalledTimes(2);
+
+    visibilityState = "hidden";
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(9000);
+      await Promise.resolve();
+    });
+    expect(onPoll).toHaveBeenCalledTimes(2);
+
+    visibilityState = "visible";
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+
+    expect(onPoll).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(onPoll).toHaveBeenCalledTimes(4);
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/use-mission-summary-polling.ts
+++ b/web/app/routes/_layout.noctis-team/components/use-mission-summary-polling.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+
+const VISIBLE_POLL_MS = 3000;
+
+export function useMissionSummaryPolling(options: {
+  enabled?: boolean;
+  onPoll: () => void | Promise<void>;
+}) {
+  const enabled = options.enabled ?? true;
+  const onPollRef = useRef(options.onPoll);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onPollRef.current = options.onPoll;
+  }, [options.onPoll]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      return;
+    }
+
+    const clearPolling = () => {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    const startPolling = () => {
+      clearPolling();
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      timerRef.current = window.setInterval(() => {
+        void onPollRef.current();
+      }, VISIBLE_POLL_MS);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        clearPolling();
+        return;
+      }
+
+      void onPollRef.current();
+      startPolling();
+    };
+
+    void onPollRef.current();
+    startPolling();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearPolling();
+    };
+  }, [enabled]);
+}

--- a/web/app/routes/api.lunafreya.mission.continue.ts
+++ b/web/app/routes/api.lunafreya.mission.continue.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { getProjectRoot } from "@/lib/get-project-root.server";
 import { DEFAULT_LUNAFREYA_JOB_LABEL } from "@/lib/lunafreya-prompt-context";
 import { resolveLunafreyaFacetSelection } from "@/lib/lunafreya-facet-selection.server";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { resolveMissionExecutionRoot } from "@/lib/mission-execution-workspace.server";
 import { getMissionCompatibilityIssue } from "@/lib/mission-runtime-compatibility.server";
 import {
@@ -219,7 +220,7 @@ export const action = async ({ request }: { request: Request }) => {
     if (!sessionId) {
       const sessionResult = await client.session.create({
         directory: executionRoot.sessionHostRoot,
-        title: `mission:${missionId}`,
+        title: getManagedSessionTitle(missionId, "lunafreya"),
       });
 
       if (sessionResult.error) {

--- a/web/app/routes/api.lunafreya.mission.start.ts
+++ b/web/app/routes/api.lunafreya.mission.start.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { getProjectRoot } from "@/lib/get-project-root.server";
 import { resolveLunafreyaFacetSelection } from "@/lib/lunafreya-facet-selection.server";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { normalizeIncomingMissionExecutionTargetMode } from "@/lib/mission-execution-target-mode";
 import {
   provisionMissionExecutionWorkspace,
@@ -161,7 +162,7 @@ export const action = async ({ request }: { request: Request }) => {
 
     const sessionResult = await client.session.create({
       directory: managedRoots.sessionHostRoot,
-      title: `mission:${missionId}`,
+      title: getManagedSessionTitle(missionId, "lunafreya"),
     });
 
     if (sessionResult.error) {

--- a/web/app/routes/api.lunafreya.mission.test.ts
+++ b/web/app/routes/api.lunafreya.mission.test.ts
@@ -251,7 +251,7 @@ describe("Lunafreya mission routing", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: root,
-        title: `mission:${data.missionId}`,
+        title: `mission:${data.missionId}:lunafreya`,
       }),
     );
 
@@ -454,7 +454,7 @@ describe("Lunafreya mission routing", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: root,
-        title: `mission:${mission.id}`,
+        title: `mission:${mission.id}:lunafreya`,
       }),
     );
     expect(getMission(mission.id)?.primarySessionId).toBe("session-lunafreya-recreated");

--- a/web/app/routes/api.lunafreya.missions.test.ts
+++ b/web/app/routes/api.lunafreya.missions.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMission, deleteMission, updateMissionMetadata } from "@/lib/mission-store";
+import { loader } from "./api.lunafreya.missions";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-lunafreya-missions-route-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+afterEach(() => {
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("api.lunafreya.missions", () => {
+  it("returns the selected Lunafreya mission view with shared active and archived counts", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const activeMissionId = `luna-active-${crypto.randomUUID()}`;
+    const archivedMissionId = `luna-archived-${crypto.randomUUID()}`;
+    const noctisMissionId = `noctis-${crypto.randomUUID()}`;
+    missionIds.push(activeMissionId, archivedMissionId, noctisMissionId);
+
+    createMission(activeMissionId, "session-luna-active", {
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+      title: "Lunafreya Active",
+    });
+    createMission(archivedMissionId, "session-luna-archived", {
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+      title: "Lunafreya Archived",
+    });
+    updateMissionMetadata(archivedMissionId, { status: "archived" });
+    createMission(noctisMissionId, "session-noctis", {
+      title: "Noctis Mission",
+    });
+
+    const response = await loader({
+      request: new Request("http://localhost/api/lunafreya/missions?view=archived"),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{
+      counts: { active: number; archived: number };
+      missions: Array<{ missionId: string; title: string; status: string }>;
+    }>(response);
+
+    expect(data.counts).toEqual({ active: 1, archived: 1 });
+    expect(data.missions).toEqual([
+      expect.objectContaining({
+        missionId: archivedMissionId,
+        status: "archived",
+        title: "Lunafreya Archived",
+      }),
+    ]);
+  });
+});

--- a/web/app/routes/api.lunafreya.missions.ts
+++ b/web/app/routes/api.lunafreya.missions.ts
@@ -1,4 +1,4 @@
-import { listMissionSummaries } from "@/lib/mission-store";
+import { listMissionSummariesWithCounts } from "@/lib/mission-store";
 import type { Route } from "./+types/api.lunafreya.missions";
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -10,8 +10,8 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         ? requestedView
         : "active";
 
-    return Response.json({ missions: listMissionSummaries({ view, surfaceId: "lunafreya" }) });
+    return Response.json(listMissionSummariesWithCounts({ view, surfaceId: "lunafreya" }));
   } catch {
-    return Response.json({ missions: [] }, { status: 500 });
+    return Response.json({ counts: { active: 0, archived: 0 }, missions: [] }, { status: 500 });
   }
 };

--- a/web/app/routes/api.noctis.mission.continue.ts
+++ b/web/app/routes/api.noctis.mission.continue.ts
@@ -1,4 +1,6 @@
 import { getProjectRoot } from "@/lib/get-project-root.server";
+import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { getMissionCompatibilityIssue } from "@/lib/mission-runtime-compatibility.server";
 import { resolveMissionExecutionRoot } from "@/lib/mission-execution-workspace.server";
 import {
@@ -18,6 +20,10 @@ import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispat
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
+import {
+  activateTmuxMissionWriteFocus,
+  getTmuxMissionWriteConflict,
+} from "@/lib/tmux-mission-activation.server";
 import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { Route } from "./+types/api.noctis.mission.continue";
 
@@ -116,6 +122,23 @@ export const action = async ({ request }: Route.ActionArgs) => {
       );
     }
     const client = getOpencodeClient();
+    if (transportStatus.transportMode === "tmux-resident") {
+      const conflict = await getTmuxMissionWriteConflict({
+        appRoot,
+        missionId,
+        client,
+      });
+      if (conflict) {
+        return Response.json(
+          {
+            error: `Tmux write focus is still held by mission ${conflict.activeMissionId}.`,
+          },
+          { status: 409 },
+        );
+      }
+
+      activateTmuxMissionWriteFocus({ appRoot, missionId });
+    }
     const missionDebugContext = {
       allowedWorkers,
       executionProjectId: mission.executionProjectId,
@@ -142,7 +165,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
     if (!sessionId) {
       const sessionResult = await client.session.create({
         directory: executionRoot.sessionHostRoot,
-        title: `mission:${missionId}`,
+        title: getManagedSessionTitle(missionId, "noctis"),
       });
 
       if (sessionResult.error) {
@@ -197,6 +220,12 @@ export const action = async ({ request }: Route.ActionArgs) => {
       queuePrimaryAgentTmuxDispatch({
         missionId,
         sessionId,
+        sessionTitle: await resolveManagedSessionActivationTitle({
+          client,
+          missionId,
+          agentId: noctisAgentProfile,
+          sessionId,
+        }),
         agent: noctisAgentProfile,
         parts: composed.payloadParts,
         ...(model ? { model } : {}),

--- a/web/app/routes/api.noctis.mission.execution-workspace.test.ts
+++ b/web/app/routes/api.noctis.mission.execution-workspace.test.ts
@@ -13,17 +13,22 @@ import {
 } from "@/lib/mission-store";
 import { getProjectRoot } from "@/lib/get-project-root.server";
 import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
+import { readTmuxActiveMission, writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 
-const { promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+const { promptAsyncMock, sessionCreateMock, sessionListMock, sessionStatusMock } = vi.hoisted(() => ({
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
+  sessionListMock: vi.fn(),
+  sessionStatusMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
   getOpencodeClient: () => ({
     session: {
       create: sessionCreateMock,
+      list: sessionListMock,
       promptAsync: promptAsyncMock,
+      status: sessionStatusMock,
     },
   }),
 }));
@@ -200,7 +205,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: process.env.MULTI_AGENT_FF15_ROOT,
-        title: `mission:${data.missionId}`,
+        title: `mission:${data.missionId}:noctis`,
       }),
     );
   });
@@ -282,6 +287,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       payload: {
         agent: "noctis",
         sessionId: "session-tmux-start",
+        sessionTitle: `mission:${data.missionId}:noctis`,
         parts: [
           {
             type: "text",
@@ -301,6 +307,49 @@ describe("Noctis mission execution workspace lifecycle", () => {
     expect(mission?.activityLog.map((entry) => entry.body).join("\n") ?? "").not.toContain(
       "Start through tmux transport.",
     );
+  });
+
+  it("blocks tmux mission start when another writable mission is still busy", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    const activeMission = createMission(`mission-tmux-active-${crypto.randomUUID()}`, "session-active", {
+      title: "Active tmux mission",
+      objective: "Own the writable tmux focus",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(activeMission.id);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.id,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-active": "busy",
+      },
+      error: null,
+    });
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/noctis/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Start through tmux transport while another mission is busy.",
+          executionProjectId: "alpha",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(409);
+    expect(await readJson<{ error: string }>(response)).toEqual({
+      error: expect.stringContaining(activeMission.id),
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
   });
 
   it("defaults new missions to the execution project root when executionTargetMode is omitted", async () => {
@@ -333,7 +382,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: root,
-        title: `mission:${data.missionId}`,
+        title: `mission:${data.missionId}:noctis`,
       }),
     );
   });
@@ -371,7 +420,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: root,
-        title: `mission:${data.missionId}`,
+        title: `mission:${data.missionId}:noctis`,
       }),
     );
   });
@@ -450,7 +499,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       2,
       expect.objectContaining({
         directory: process.env.MULTI_AGENT_FF15_ROOT,
-        title: `mission:${missionId}`,
+        title: `mission:${missionId}:noctis`,
       }),
     );
     expect(getMission(missionId)?.noctisSessionId).toBe("session-noctis-recreated");
@@ -491,7 +540,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     expect(sessionCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         directory: root,
-        title: `mission:${mission.id}`,
+        title: `mission:${mission.id}:noctis`,
       }),
     );
     expect(getMission(mission.id)?.noctisSessionId).toBe("session-noctis-direct-continued");
@@ -668,6 +717,15 @@ describe("Noctis mission execution workspace lifecycle", () => {
       executionTargetMode: "execution_project",
     });
     missionIds.push(mission.id);
+    sessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-tmux-existing",
+          title: `mission:${mission.id}`,
+        },
+      ],
+      error: null,
+    });
 
     const response = await continueAction({
       request: new Request("http://localhost/api/noctis/mission/continue", {
@@ -695,6 +753,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       payload: {
         agent: "noctis",
         sessionId: getMissionPrimarySessionId(getMission(mission.id)) ?? "session-tmux-existing",
+        sessionTitle: `mission:${mission.id}`,
       },
     });
 
@@ -731,5 +790,116 @@ describe("Noctis mission execution workspace lifecycle", () => {
       error: expect.stringContaining("Missing tmux transport endpoint manifest"),
     });
     expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks tmux mission continue when another writable mission is still busy", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+
+    const activeMission = createMission(`mission-tmux-active-${crypto.randomUUID()}`, "session-active", {
+      title: "Active tmux mission",
+      objective: "Own the writable tmux focus",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    const targetMission = createMission(`mission-tmux-target-${crypto.randomUUID()}`, "session-target", {
+      title: "Target tmux mission",
+      objective: "Attempt to continue while another mission is busy",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(activeMission.id, targetMission.id);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.id,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-active": "busy",
+        "session-target": "idle",
+      },
+      error: null,
+    });
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: targetMission.id,
+          message: "Do not steal focus from the busy mission.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(409);
+    expect(await readJson<{ error: string }>(response)).toEqual({
+      error: expect.stringContaining(activeMission.id),
+    });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("replaces tmux write focus when the previously active mission is idle", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    const activeMission = createMission(`mission-tmux-idle-${crypto.randomUUID()}`, "session-idle", {
+      title: "Idle tmux mission",
+      objective: "Yield writable focus when idle",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    const targetMission = createMission(`mission-tmux-target-${crypto.randomUUID()}`, "session-target", {
+      title: "Target tmux mission",
+      objective: "Take writable focus",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(activeMission.id, targetMission.id);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.id,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-idle": "idle",
+      },
+      error: null,
+    });
+    sessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-target",
+          title: `mission:${targetMission.id}`,
+        },
+      ],
+      error: null,
+    });
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: targetMission.id,
+          message: "Resume after the previous tmux mission went idle.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await readJson<{ noctisSessionId: string }>(response)).toEqual({
+      noctisSessionId: "session-target",
+    });
+    expect(readTmuxActiveMission(root)).toMatchObject({
+      missionId: targetMission.id,
+    });
   });
 });

--- a/web/app/routes/api.noctis.mission.start.ts
+++ b/web/app/routes/api.noctis.mission.start.ts
@@ -1,9 +1,11 @@
 import { getProjectRoot } from "@/lib/get-project-root.server";
+import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
 import { normalizeIncomingMissionExecutionTargetMode } from "@/lib/mission-execution-target-mode";
 import {
   provisionMissionExecutionWorkspace,
   resolveManagedMissionStartRoots,
 } from "@/lib/mission-execution-workspace.server";
+import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { buildDelegationLedger, createMission, setAgentModels } from "@/lib/mission-store";
 import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selection";
 import {
@@ -21,6 +23,10 @@ import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispat
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
+import {
+  activateTmuxMissionWriteFocus,
+  getTmuxMissionWriteConflict,
+} from "@/lib/tmux-mission-activation.server";
 import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 import type { Route } from "./+types/api.noctis.mission.start";
@@ -118,7 +124,26 @@ export const action = async ({ request }: Route.ActionArgs) => {
         { status: 503 },
       );
     }
+    const missionId = crypto.randomUUID();
+    const missionCreatedAt = new Date().toISOString();
     const client = getOpencodeClient();
+    if (transportStatus.transportMode === "tmux-resident") {
+      const conflict = await getTmuxMissionWriteConflict({
+        appRoot: projectRoot,
+        missionId,
+        client,
+      });
+      if (conflict) {
+        return Response.json(
+          {
+            error: `Tmux write focus is still held by mission ${conflict.activeMissionId}.`,
+          },
+          { status: 409 },
+        );
+      }
+
+      activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId, updatedAt: missionCreatedAt });
+    }
     const executionProject = readRegisteredProjectDefinition(projectRoot, executionProjectId);
     if (!executionProject) {
       return Response.json({ error: "Execution project is not registered." }, { status: 409 });
@@ -151,8 +176,6 @@ export const action = async ({ request }: Route.ActionArgs) => {
     if (!selectedOperation) {
       return Response.json({ error: "No operation is available" }, { status: 409 });
     }
-    const missionId = crypto.randomUUID();
-    const missionCreatedAt = new Date().toISOString();
     const executionWorkspace =
       executionTargetMode === "mission_workspace"
         ? provisionMissionExecutionWorkspace({
@@ -172,7 +195,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
     const sessionResult = await client.session.create({
       directory: managedRoots.sessionHostRoot,
-      title: `mission:${missionId}`,
+      title: getManagedSessionTitle(missionId, "noctis"),
     });
 
     if (sessionResult.error) {
@@ -223,6 +246,12 @@ export const action = async ({ request }: Route.ActionArgs) => {
       queuePrimaryAgentTmuxDispatch({
         missionId,
         sessionId,
+        sessionTitle: await resolveManagedSessionActivationTitle({
+          client,
+          missionId,
+          agentId: noctisAgentProfile,
+          sessionId,
+        }),
         agent: noctisAgentProfile,
         parts: composed.payloadParts,
         system: ledger,

--- a/web/app/routes/api.noctis.missions.$missionId.runtime.test.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.runtime.test.ts
@@ -134,11 +134,14 @@ describe("api.noctis.missions.$missionId.runtime", () => {
     });
 
     sessionStatusMock.mockResolvedValue({ data: { "session-noctis": "idle" } });
+    sessionMessagesMock.mockResolvedValue({ data: [] });
 
     const response = await loader({ params: { missionId } } as never);
     expect(response.status).toBe(200);
 
     const data = await readJson<{
+      latestPrimaryMessageCreatedAt?: string | null;
+      latestPrimaryMessageId?: string | null;
       primaryMessages?: unknown;
       noctisMessages?: unknown;
       primarySessionId: string | null;
@@ -146,10 +149,52 @@ describe("api.noctis.missions.$missionId.runtime", () => {
     }>(response);
 
     expect(data.primarySessionId).toBe("session-noctis");
+    expect(data.latestPrimaryMessageId).toBeNull();
+    expect(data.latestPrimaryMessageCreatedAt).toBeNull();
     expect(data.primaryMessages).toBeUndefined();
     expect(data.noctisMessages).toBeUndefined();
     expect(data.sessionStatuses["session-noctis"]).toBe("idle");
-    expect(sessionMessagesMock).not.toHaveBeenCalled();
+    expect(sessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-noctis" });
+  });
+
+  it("includes latest primary-message freshness metadata for active mission hydration", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-runtime-freshness-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", {
+      title: "Freshness mission",
+      objective: "Verify runtime freshness metadata",
+    });
+
+    sessionStatusMock.mockResolvedValue({ data: { "session-noctis": "busy" } });
+    sessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "message-2",
+            role: "assistant",
+            time: { created: Date.parse("2026-04-29T00:02:00.000Z") },
+          },
+          parts: [{ type: "text", text: "Fresh runtime reply" }],
+        },
+      ],
+    });
+
+    const response = await loader({ params: { missionId } } as never);
+    expect(response.status).toBe(200);
+
+    const data = await readJson<{
+      latestPrimaryMessageCreatedAt?: string | null;
+      latestPrimaryMessageId?: string | null;
+      primarySessionId: string | null;
+    }>(response);
+
+    expect(data.primarySessionId).toBe("session-noctis");
+    expect(data.latestPrimaryMessageId).toBe("message-2");
+    expect(data.latestPrimaryMessageCreatedAt).toBe("2026-04-29T00:02:00.000Z");
+    expect(sessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-noctis" });
   });
 
   it("returns derived workflow progress for the active mission workflow", async () => {

--- a/web/app/routes/api.noctis.missions.$missionId.runtime.test.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.runtime.test.ts
@@ -1,9 +1,16 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { sessionMessagesMock, sessionStatusMock } = vi.hoisted(() => ({
+const {
+  listSessionStatusTargetsMock,
+  resolveSessionRouteTargetMock,
+  sessionMessagesMock,
+  sessionStatusMock,
+} = vi.hoisted(() => ({
+  listSessionStatusTargetsMock: vi.fn(),
+  resolveSessionRouteTargetMock: vi.fn(),
   sessionMessagesMock: vi.fn(),
   sessionStatusMock: vi.fn(),
 }));
@@ -15,6 +22,11 @@ vi.mock("@/lib/opencode-client", () => ({
       status: sessionStatusMock,
     },
   }),
+}));
+
+vi.mock("@/lib/session-owner-routing.server", () => ({
+  listSessionStatusTargets: listSessionStatusTargetsMock,
+  resolveSessionRouteTarget: resolveSessionRouteTargetMock,
 }));
 
 import {
@@ -54,7 +66,25 @@ async function readJson<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
 }
 
+beforeEach(() => {
+  listSessionStatusTargetsMock.mockReturnValue([]);
+  resolveSessionRouteTargetMock.mockImplementation((sessionId: string) => ({
+    client: {
+      session: {
+        messages: sessionMessagesMock,
+      },
+    },
+    endpointUrl: null,
+    managedSession: null,
+    mode: "default",
+    ownerAgent: null,
+    sessionId,
+  }));
+});
+
 afterEach(() => {
+  listSessionStatusTargetsMock.mockReset();
+  resolveSessionRouteTargetMock.mockReset();
   sessionMessagesMock.mockReset();
   sessionStatusMock.mockReset();
 

--- a/web/app/routes/api.noctis.missions.test.ts
+++ b/web/app/routes/api.noctis.missions.test.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { sessionMessagesMock, sessionStatusMock } = vi.hoisted(() => ({
+  sessionMessagesMock: vi.fn(),
+  sessionStatusMock: vi.fn(),
+}));
+
+vi.mock("@/lib/opencode-client", () => ({
+  getOpencodeClient: () => ({
+    session: {
+      messages: sessionMessagesMock,
+      status: sessionStatusMock,
+    },
+  }),
+}));
+
+import { createMission, deleteMission, setWorkerSession } from "@/lib/mission-store";
+import { loader } from "./api.noctis.missions";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-noctis-missions-route-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+afterEach(() => {
+  sessionMessagesMock.mockReset();
+  sessionStatusMock.mockReset();
+
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("api.noctis.missions", () => {
+  it("returns stored primary-session freshness without calling session APIs", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-summary-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+
+    const mission = createMission(missionId, "session-primary", {
+      title: "Summary Mission",
+      objective: "Verify summary payload",
+    });
+    setWorkerSession(missionId, "ignis", "session-ignis");
+    mission.latestPrimaryMessageCreatedAt = "2026-04-29T00:00:00.000Z";
+    mission.latestPrimaryMessageId = "message-1";
+
+    const response = await loader({
+      request: new Request("http://localhost/api/noctis/missions?view=all"),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{
+      counts: { active: number; archived: number };
+      missions: Array<{
+        missionId: string;
+        primarySessionId?: string | null;
+        latestPrimaryMessageId?: string | null;
+        latestPrimaryMessageCreatedAt?: string | null;
+        messages?: unknown;
+      }>;
+    }>(response);
+
+    expect(data.counts).toEqual({ active: 1, archived: 0 });
+    expect(data.missions).toEqual([
+      expect.objectContaining({
+        missionId,
+        primarySessionId: "session-primary",
+        latestPrimaryMessageId: "message-1",
+        latestPrimaryMessageCreatedAt: "2026-04-29T00:00:00.000Z",
+      }),
+    ]);
+    expect(data.missions[0]).not.toHaveProperty("messages");
+    expect(sessionStatusMock).not.toHaveBeenCalled();
+    expect(sessionMessagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/routes/api.noctis.missions.ts
+++ b/web/app/routes/api.noctis.missions.ts
@@ -1,4 +1,4 @@
-import { listMissionSummaries } from "@/lib/mission-store";
+import { listMissionSummariesWithCounts } from "@/lib/mission-store";
 import type { Route } from "./+types/api.noctis.missions";
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -10,8 +10,8 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         ? requestedView
         : "active";
 
-    return Response.json({ missions: listMissionSummaries({ view, surfaceId: "noctis_team" }) });
+    return Response.json(listMissionSummariesWithCounts({ view, surfaceId: "noctis_team" }));
   } catch {
-    return Response.json({ missions: [] }, { status: 500 });
+    return Response.json({ counts: { active: 0, archived: 0 }, missions: [] }, { status: 500 });
   }
 };

--- a/web/app/routes/api.session.$id.events.test.ts
+++ b/web/app/routes/api.session.$id.events.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { globalEventMock } = vi.hoisted(() => ({
+const { globalEventMock, resolveSessionRouteTargetMock } = vi.hoisted(() => ({
   globalEventMock: vi.fn(),
+  resolveSessionRouteTargetMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
@@ -10,6 +11,10 @@ vi.mock("@/lib/opencode-client", () => ({
       event: globalEventMock,
     },
   }),
+}));
+
+vi.mock("@/lib/session-owner-routing.server", () => ({
+  resolveSessionRouteTarget: resolveSessionRouteTargetMock,
 }));
 
 import { loader } from "./api.session.$id.events";
@@ -21,6 +26,25 @@ async function* createStream(events: unknown[]) {
 }
 
 describe("api.session.$id.events", () => {
+  beforeEach(() => {
+    resolveSessionRouteTargetMock.mockImplementation(() => ({
+      client: {
+        global: {
+          event: globalEventMock,
+        },
+      },
+      endpointUrl: null,
+      managedSession: null,
+      mode: "default",
+      ownerAgent: null,
+    }));
+  });
+
+  afterEach(() => {
+    globalEventMock.mockReset();
+    resolveSessionRouteTargetMock.mockReset();
+  });
+
   it("streams matching raw session events", async () => {
     globalEventMock.mockResolvedValue({
       stream: createStream([
@@ -81,5 +105,46 @@ describe("api.session.$id.events", () => {
     const body = await response.text();
     expect(body).toContain('"type":"message.part.created"');
     expect(body).toContain('"text":"Hello"');
+  });
+
+  it("subscribes through the resolved owner client for managed sessions", async () => {
+    const managedGlobalEventMock = vi.fn().mockResolvedValue({
+      stream: createStream([
+        {
+          type: "session.status",
+          properties: {
+            sessionID: "session-managed",
+            status: { type: "busy" },
+          },
+        },
+      ]),
+    });
+
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        global: {
+          event: managedGlobalEventMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4401",
+      managedSession: {
+        missionId: "mission-1",
+        ownerAgent: "noctis",
+      },
+      mode: "managed",
+      ownerAgent: "noctis",
+    });
+
+    const response = await loader({
+      request: new Request("http://localhost/api/session/session-managed/events"),
+      params: { id: "session-managed" },
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(resolveSessionRouteTargetMock).toHaveBeenCalledWith("session-managed");
+    expect(managedGlobalEventMock).toHaveBeenCalledTimes(1);
+    expect(globalEventMock).not.toHaveBeenCalled();
+    const body = await response.text();
+    expect(body).toContain('"sessionID":"session-managed"');
   });
 });

--- a/web/app/routes/api.session.$id.events.ts
+++ b/web/app/routes/api.session.$id.events.ts
@@ -1,6 +1,6 @@
 import type { Event } from "@opencode-ai/sdk";
 import { unwrapOpencodeEvent } from "@/lib/opencode-event";
-import { getOpencodeClient } from "@/lib/opencode-client";
+import { resolveSessionRouteTarget } from "@/lib/session-owner-routing.server";
 import type { Route } from "./+types/api.session.$id.events";
 
 function extractSessionId(event: Event): string | undefined {
@@ -29,7 +29,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 
   let stream: AsyncIterable<unknown>;
   try {
-    const client = getOpencodeClient();
+    const { client } = resolveSessionRouteTarget(sessionId);
     const result = await client.global.event();
     stream = result.stream;
   } catch {

--- a/web/app/routes/api.sessions.test.ts
+++ b/web/app/routes/api.sessions.test.ts
@@ -92,7 +92,7 @@ describe("api.sessions", () => {
       data: [
         {
           id: "session-noctis",
-          title: `mission:${missionId}`,
+          title: `mission:${missionId}:noctis`,
           directory: root,
           time: { created: 1, updated: 2 },
         },


### PR DESCRIPTION
## 📝 Summary

- Introduce polling-first synchronization for tmux-managed Noctis and Lunafreya missions so active mission screens stay correct across reloads and stream gaps.
- Route session history and event reads through the owning agent endpoint and persist transport/session ownership metadata for managed sessions.
- Add primary-agent outbox dispatch, tmux mission activation helpers, and mission summary freshness updates to keep Noctis Team state aligned with runtime activity.
- Expand regression coverage across hooks, runtime APIs, session routing, tmux transport, and mission polling behavior.

## 🎯 Motivation

Issue #65 requires active mission transcripts and agent status to stay consistent even when the browser reloads or live session events are incomplete. The previous runtime path could read status and history from the wrong OpenCode endpoint for tmux-managed sessions, which let the web app mark Noctis idle too early and miss replies until a later refresh.

## 🔧 Changes Overview

- Add tmux transport bootstrap and activation support, including persisted transport mode and session ownership metadata plus owner-aware session routing.
- Rework active mission synchronization around runtime polling, pending transcript settlement, primary-agent outbox dispatch, and mission freshness tracking.
- Update Noctis Team and Lunafreya mission surfaces to use summary polling, improved running-state indicators, and transcript rendering fixes for pending replies.
- Align standby and opsx command/prompt compatibility surfaces with the new tmux transport model.
- Add focused regression tests for session owner routing, mission runtime hydration, transcript settlement, tmux activation, and Noctis Team polling flows.

## ✅ Testing

- [x] Tested locally
- [x] Manual testing completed
- [x] Edge cases considered

Commands run:

- `npm --prefix web run test -- app/hooks/use-agent-session.test.ts`
- `npm --prefix web run test -- app/lib/mission-surface-hydration.server.test.ts`
- `npm --prefix web run test -- api.session`
- `bash .opencode/skills/pr-assistant/scripts/quality_checks.sh main`

## 📸 Screenshots

Not included. The UI impact is behavior-focused around polling, runtime status, and transcript hydration rather than visual layout changes.

## 🔗 Related Issues

- Closes #65
- Related to #63
- Related to #64
- Related to #66

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots were not necessary for this behavior-focused update
- [x] Documentation updated or confirmed unnecessary
- [x] Config, CI, or deployment impact reviewed

## 📌 Notes

- This branch includes the supporting tmux transport, session ownership, and primary-agent outbox work needed to complete issue #65 end-to-end.
- No legacy tmux pane fallback was added in this PR; correctness now comes from owner-aware session routing plus polling-based mission synchronization.