### PR TITLE
Dispatch worker delegation and team messages through lazy worker sessions

### DIFF
--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 const AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto", "lunafreya", "iris"] as const;
 const DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
 const LOOP_INTERVAL_MS = 200;
+const NEXT_DISPATCH_DELAY_MS = 3_000;
 const MISSION_STORE_DIR = "noctis-missions";
 const SESSION_NAME = "ff15";
 const STALE_LEASE_MS = 5_000;
@@ -493,15 +494,18 @@ function countQueuedItems(root: string): number {
 
 const root = parseRoot(process.argv.slice(2));
 let processedCount = 0;
+let nextDispatchNotBefore = 0;
 const dispatcherStartedAt = new Date().toISOString();
 
 const tick = () => {
   try {
-    const now = new Date().toISOString();
-    const claimed = claimNextItem(root, now);
+    const nowDate = new Date();
+    const now = nowDate.toISOString();
+    const claimed = nowDate.getTime() >= nextDispatchNotBefore ? claimNextItem(root, now) : null;
     if (claimed) {
       submitClaimedItem(root, claimed);
       processedCount += 1;
+      nextDispatchNotBefore = Date.now() + NEXT_DISPATCH_DELAY_MS;
     }
 
     writeState(root, {

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -11,9 +11,9 @@ const STALE_LEASE_MS = 5_000;
 const TMUX_INTERACTION_DELAY_SECONDS = "0.5";
 
 type AgentId = (typeof AGENT_IDS)[number];
-type PrimaryAgentOutboxStatus = "pending" | "leased" | "submitted";
+type TmuxDispatchStatus = "pending" | "leased" | "submitted";
 
-type PrimaryAgentOutboxItem = {
+type TmuxDispatchItem = {
   createdAt: string;
   id: string;
   lease?: {
@@ -44,7 +44,7 @@ type PrimaryAgentOutboxItem = {
     system?: string;
     variant?: string;
   };
-  status: PrimaryAgentOutboxStatus;
+  status: TmuxDispatchStatus;
   submission?: {
     dispatcherPid?: number;
     submittedAt: string;
@@ -73,7 +73,7 @@ function getMissionStorePath(root: string): string {
 function getOutboxStateDir(
   root: string,
   missionId: string,
-  status: PrimaryAgentOutboxStatus,
+  status: TmuxDispatchStatus,
 ): string {
   return join(getMissionStorePath(root), missionId, "transport", "primary-agent-outbox", status);
 }
@@ -81,7 +81,7 @@ function getOutboxStateDir(
 function getOutboxItemPath(
   root: string,
   missionId: string,
-  status: PrimaryAgentOutboxStatus,
+  status: TmuxDispatchStatus,
   itemId: string,
 ): string {
   return join(getOutboxStateDir(root, missionId, status), `${itemId}.json`);
@@ -111,7 +111,7 @@ function cleanup(root: string): void {
   rmSync(getDispatcherStatePath(root), { force: true });
 }
 
-function isOutboxStatus(value: unknown): value is PrimaryAgentOutboxStatus {
+function isOutboxStatus(value: unknown): value is TmuxDispatchStatus {
   return value === "pending" || value === "leased" || value === "submitted";
 }
 
@@ -119,7 +119,7 @@ function isAgentId(value: unknown): value is AgentId {
   return AGENT_IDS.some((agentId) => agentId === value);
 }
 
-function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
+function normalizeItem(value: unknown): TmuxDispatchItem | null {
   if (!value || typeof value !== "object") {
     return null;
   }
@@ -156,7 +156,7 @@ function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
     return null;
   }
 
-  return record as PrimaryAgentOutboxItem;
+  return record as TmuxDispatchItem;
 }
 
 function listMissionIds(root: string): string[] {
@@ -174,8 +174,8 @@ function listMissionIds(root: string): string[] {
 function readItemsForStatus(
   root: string,
   missionId: string,
-  status: PrimaryAgentOutboxStatus,
-): PrimaryAgentOutboxItem[] {
+  status: TmuxDispatchStatus,
+): TmuxDispatchItem[] {
   const dir = getOutboxStateDir(root, missionId, status);
   if (!existsSync(dir)) {
     return [];
@@ -190,14 +190,14 @@ function readItemsForStatus(
         return null;
       }
     })
-    .filter((item): item is PrimaryAgentOutboxItem => item !== null);
+    .filter((item): item is TmuxDispatchItem => item !== null);
 }
 
-function compareItems(left: PrimaryAgentOutboxItem, right: PrimaryAgentOutboxItem): number {
+function compareItems(left: TmuxDispatchItem, right: TmuxDispatchItem): number {
   return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
 }
 
-function isStale(item: PrimaryAgentOutboxItem, now: string): boolean {
+function isStale(item: TmuxDispatchItem, now: string): boolean {
   if (!item.lease) {
     return false;
   }
@@ -211,7 +211,7 @@ function isStale(item: PrimaryAgentOutboxItem, now: string): boolean {
   return checkedAt - leasedAt > item.lease.staleAfterMs;
 }
 
-function writeItem(root: string, item: PrimaryAgentOutboxItem): void {
+function writeItem(root: string, item: TmuxDispatchItem): void {
   for (const status of ["pending", "leased", "submitted"] as const) {
     mkdirSync(getOutboxStateDir(root, item.missionId, status), { recursive: true });
     rmSync(getOutboxItemPath(root, item.missionId, status, item.id), { force: true });
@@ -224,7 +224,7 @@ function writeItem(root: string, item: PrimaryAgentOutboxItem): void {
   );
 }
 
-function claimNextItem(root: string, now: string): PrimaryAgentOutboxItem | null {
+function claimNextItem(root: string, now: string): TmuxDispatchItem | null {
   const candidates = listMissionIds(root).flatMap((missionId) => {
     const pending = readItemsForStatus(root, missionId, "pending");
     const staleLeased = readItemsForStatus(root, missionId, "leased").filter((item) => isStale(item, now));
@@ -236,7 +236,7 @@ function claimNextItem(root: string, now: string): PrimaryAgentOutboxItem | null
     return null;
   }
 
-  const claimed: PrimaryAgentOutboxItem = {
+  const claimed: TmuxDispatchItem = {
     ...candidate,
     status: "leased",
     updatedAt: now,
@@ -309,7 +309,7 @@ function sendTmuxKeys(
 
 function readCatalogModelSelectionText(
   root: string,
-  model: NonNullable<PrimaryAgentOutboxItem["payload"]["model"]>,
+  model: NonNullable<TmuxDispatchItem["payload"]["model"]>,
 ): string | null {
   const modelKey = `${model.providerID}/${model.modelID}`;
   const catalogPath = join(root, "runtime", "opencode-model-catalog.json");
@@ -328,9 +328,9 @@ function readCatalogModelSelectionText(
   }
 }
 
-function buildDispatchText(item: PrimaryAgentOutboxItem): string {
+function buildDispatchText(item: TmuxDispatchItem): string {
   const header = [
-    `[primary-agent-dispatch] mission=${item.missionId}`,
+    `[tmux-dispatch] mission=${item.missionId}`,
     `session=${item.payload.sessionId}`,
     `agent=${item.payload.agent}`,
   ].join(" ");
@@ -348,7 +348,7 @@ function buildDispatchText(item: PrimaryAgentOutboxItem): string {
     .join("\n\n");
 }
 
-function resolveManagedSessionTitle(item: PrimaryAgentOutboxItem): string {
+function resolveManagedSessionTitle(item: TmuxDispatchItem): string {
   if (typeof item.payload.sessionTitle === "string" && item.payload.sessionTitle.length > 0) {
     return item.payload.sessionTitle;
   }
@@ -359,7 +359,7 @@ function resolveManagedSessionTitle(item: PrimaryAgentOutboxItem): string {
 function activateManagedSession(
   root: string,
   target: string,
-  item: PrimaryAgentOutboxItem,
+  item: TmuxDispatchItem,
   interactionState: { hasSentInput: boolean },
 ): void {
   const sessionTitle = resolveManagedSessionTitle(item);
@@ -391,7 +391,7 @@ function activateManagedSession(
 function applyModelSelection(
   root: string,
   target: string,
-  item: PrimaryAgentOutboxItem,
+  item: TmuxDispatchItem,
   interactionState: { hasSentInput: boolean },
 ): void {
   if (!item.payload.model) {
@@ -459,10 +459,10 @@ function applyModelSelection(
   );
 }
 
-function submitClaimedItem(root: string, item: PrimaryAgentOutboxItem): void {
+function submitClaimedItem(root: string, item: TmuxDispatchItem): void {
   const paneIndex = AGENT_IDS.indexOf(item.payload.agent);
   if (paneIndex === -1) {
-    throw new Error(`Unsupported primary-agent outbox target: ${item.payload.agent}`);
+    throw new Error(`Unsupported tmux dispatch target: ${item.payload.agent}`);
   }
 
   const target = `${SESSION_NAME}:main.${paneIndex}`;

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -129,21 +129,21 @@ function seedPrimaryAgentOutbox(root, missionId, options = {}) {
   );
   mkdirSync(pendingDir, { recursive: true });
   writeFileSync(
-    join(pendingDir, "item-dispatch-1.json"),
+    join(pendingDir, `${options.itemId ?? "item-dispatch-1"}.json`),
     `${JSON.stringify(
       {
-        id: "item-dispatch-1",
+        id: options.itemId ?? "item-dispatch-1",
         missionId,
-        createdAt: "2026-04-28T00:00:00.000Z",
-        updatedAt: "2026-04-28T00:00:00.000Z",
+        createdAt: options.createdAt ?? "2026-04-28T00:00:00.000Z",
+        updatedAt: options.updatedAt ?? options.createdAt ?? "2026-04-28T00:00:00.000Z",
         status: "pending",
         payload: {
-          agent: "lunafreya",
-          sessionId: "session-dispatch-1",
+          agent: options.agent ?? "lunafreya",
+          sessionId: options.sessionId ?? "session-dispatch-1",
           ...(options.sessionTitle ? { sessionTitle: options.sessionTitle } : {}),
-          parts: [{ type: "text", text: "queued prompt body" }],
+          parts: [{ type: "text", text: options.text ?? "queued prompt body" }],
           ...(options.model ? { model: options.model } : {}),
-          system: "queued system body",
+          system: options.system ?? "queued system body",
           ...(options.variant ? { variant: options.variant } : {}),
         },
       },
@@ -295,6 +295,57 @@ test("dispatcher submits queued primary-agent outbox items and retains submitted
   assert.equal(stopResult.code, 0, stopResult.stderr);
 });
 
+test("dispatcher waits 1000ms before starting the next queued dispatch", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedPrimaryAgentOutbox(root, "mission-dispatch-gap", {
+    itemId: "item-dispatch-1",
+    createdAt: "2026-04-28T00:00:00.000Z",
+    updatedAt: "2026-04-28T00:00:00.000Z",
+    sessionId: "session-dispatch-1",
+    text: "queued prompt body one",
+  });
+  seedPrimaryAgentOutbox(root, "mission-dispatch-gap", {
+    itemId: "item-dispatch-2",
+    createdAt: "2026-04-28T00:00:01.000Z",
+    updatedAt: "2026-04-28T00:00:01.000Z",
+    sessionId: "session-dispatch-2",
+    text: "queued prompt body two",
+  });
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const firstSubmittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch-gap",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-1.json",
+  );
+  const secondSubmittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch-gap",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-2.json",
+  );
+
+  assert.equal(await waitFor(() => existsSync(firstSubmittedPath), 3_000), true);
+  await new Promise((resolve) => setTimeout(resolve, 700));
+  assert.equal(existsSync(secondSubmittedPath), false);
+  assert.equal(await waitFor(() => existsSync(secondSubmittedPath), 3_000), true);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
 test("dispatcher reclaims stale leases before submitting retained artifacts", async () => {
   const root = createTempRoot();
   installFakeTmux(root);
@@ -366,7 +417,7 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
     "send-keys -t ff15:main.4 -l Switch model variant",
   );
   const variantIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l high");
-  const payloadIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l [primary-agent-dispatch]");
+  const payloadIndex = tmuxLog.indexOf("send-keys -t ff15:main.4 -l [tmux-dispatch]");
 
   assert.match(tmuxLog, /send-keys -t ff15:main\.4 C-p/);
   assert.equal(switchSessionCommandIndex >= 0, true, tmuxLog);
@@ -392,7 +443,7 @@ test("dispatcher uses command palette flow for tmux model and variant selection"
   );
   assert.match(
     tmuxLog,
-    /send-keys -t ff15:main\.4 -l high\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l \[primary-agent-dispatch\]/,
+    /send-keys -t ff15:main\.4 -l high\nsleep 0\.5\nsend-keys -t ff15:main\.4 Enter\nsleep 0\.5\nsend-keys -t ff15:main\.4 -l \[tmux-dispatch\]/,
   );
   assert.equal((tmuxLog.match(/^sleep 0\.5$/gm) ?? []).length, 16, tmuxLog);
   assert.doesNotMatch(tmuxLog, /send-keys -t ff15:main\.4 \/models/);

--- a/web/app/lib/execution-workspace-sessions.test.ts
+++ b/web/app/lib/execution-workspace-sessions.test.ts
@@ -5,24 +5,41 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getProjectRoot } from "@/lib/get-project-root.server";
+import { buildMissionResumePayload } from "@/lib/mission-api.server";
+import {
+  listTmuxDispatchItems,
+  markTmuxDispatchItemSubmitted,
+} from "@/lib/mission-primary-agent-outbox.server";
 import { provisionMissionExecutionWorkspace } from "@/lib/mission-execution-workspace.server";
 import {
+  addTask,
   createMission,
   deleteMission,
   getMission,
   setWorkerSession,
+  updateTask,
 } from "@/lib/mission-store";
 import { dispatchTaskToWorker } from "@/lib/task-dispatch.server";
 import { writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 import { sendSimpleMessage, sendWorkerReport } from "@/lib/team-message.server";
 
-const { promptAsyncMock, sessionCreateMock, sessionStatusMock } = vi.hoisted(() => ({
+const { createProjectOpencodeClientMock, ownerSessionCreateMock, promptAsyncMock, sessionCreateMock, sessionStatusMock } = vi.hoisted(() => ({
+  createProjectOpencodeClientMock: vi.fn((baseUrl: string) => ({
+    baseUrl,
+    session: {
+      create: ownerSessionCreateMock,
+      promptAsync: promptAsyncMock,
+      status: sessionStatusMock,
+    },
+  })),
+  ownerSessionCreateMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
   sessionStatusMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
+  createProjectOpencodeClient: createProjectOpencodeClientMock,
   getOpencodeClient: () => ({
     session: {
       create: sessionCreateMock,
@@ -51,6 +68,7 @@ function createTempRoot(options?: { transportMode?: "app-owned" | "tmux-resident
   const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-execution-sessions-"));
   tempRoots.push(root);
   cpSync(join(repoRoot, "builtins"), join(root, "builtins"), { recursive: true });
+  mkdirSync(join(root, "runtime"), { recursive: true });
   mkdirSync(join(root, "scripts"), { recursive: true });
   writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
 
@@ -86,6 +104,25 @@ function createTempRoot(options?: { transportMode?: "app-owned" | "tmux-resident
   );
 
   return root;
+}
+
+function writeEndpointManifest(
+  root: string,
+  agents: Array<{ agentId: string; port: number; url: string }>,
+): void {
+  writeFileSync(
+    join(root, "runtime", "opencode-endpoints.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        startedAt: "2026-04-29T00:00:00.000Z",
+        agents,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
 }
 
 function createExecutionMission(root: string): {
@@ -285,6 +322,203 @@ describe("execution workspace sessions", () => {
     expect(promptAsyncMock).not.toHaveBeenCalled();
   });
 
+  it("creates tmux worker dispatch sessions on the worker owner endpoint", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-owner" } });
+    promptAsyncMock.mockResolvedValue({ data: { id: "prompt-worker-owner" } });
+
+    await dispatchTaskToWorker({
+      missionId,
+      agentId: "ignis",
+      message: "Create the tmux worker session on the worker endpoint.",
+    });
+
+    expect(createProjectOpencodeClientMock).toHaveBeenCalledWith("http://127.0.0.1:4403");
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${missionId}:ignis`,
+      }),
+    );
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("creates tmux worker dispatch sessions on the Prompto owner endpoint", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "prompto",
+        port: 4404,
+        url: "http://127.0.0.1:4404",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-prompto-owner" } });
+
+    await dispatchTaskToWorker({
+      missionId,
+      agentId: "prompto",
+      message: "Prompto should receive delegated tmux work.",
+    });
+
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${missionId}:prompto`,
+      }),
+    );
+    const queueItems = listTmuxDispatchItems(missionId);
+    expect(queueItems).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          sessionId: "session-prompto-owner",
+          agent: "prompto",
+        }),
+      }),
+    ]);
+  });
+
+  it("queues tmux worker dispatches instead of prompting inline", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-queued" } });
+
+    const result = await dispatchTaskToWorker({
+      missionId,
+      agentId: "ignis",
+      message: "Queue this worker dispatch through tmux transport.",
+    });
+
+    expect(result).toEqual({
+      sessionId: "session-ignis-queued",
+      taskId: expect.any(String) as string,
+    });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(listTmuxDispatchItems(missionId)).toEqual([
+      expect.objectContaining({
+        status: "pending",
+        payload: expect.objectContaining({
+          agent: "ignis",
+          sessionId: "session-ignis-queued",
+          sessionTitle: `mission:${missionId}:ignis`,
+        }),
+      }),
+    ]);
+  });
+
+  it("records queued transport state for tmux worker dispatches", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-pending" } });
+
+    await dispatchTaskToWorker({
+      missionId,
+      agentId: "ignis",
+      message: "Track queued transport state for this worker dispatch.",
+    });
+
+    expect(getMission(missionId)?.messageLog).toContainEqual(
+      expect.objectContaining({
+        toAgent: "ignis",
+        deliveredToSessionId: "session-ignis-pending",
+        deliveryStatus: "queued",
+      }),
+    );
+    expect(getMission(missionId)?.conversationLog).toEqual([
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "queued",
+          sessionId: "session-ignis-pending",
+        }),
+      }),
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "queued",
+          sessionId: "session-ignis-pending",
+        }),
+      }),
+    ]);
+  });
+
+  it("reconciles submitted tmux worker dispatches to sent transport state", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-submitted" } });
+
+    await dispatchTaskToWorker({
+      missionId,
+      agentId: "ignis",
+      message: "Reconcile queued tmux worker dispatch to sent state.",
+    });
+
+    const [item] = listTmuxDispatchItems(missionId);
+    markTmuxDispatchItemSubmitted({
+      missionId,
+      itemId: item.id,
+      submittedAt: "2026-05-01T00:00:00.000Z",
+      submittedBy: "dispatcher:test",
+    });
+
+    const mission = getMission(missionId);
+    expect(mission).toBeTruthy();
+    buildMissionResumePayload(mission!);
+
+    expect(getMission(missionId)?.messageLog).toContainEqual(
+      expect.objectContaining({
+        deliveredToSessionId: "session-ignis-submitted",
+        deliveryStatus: "sent",
+      }),
+    );
+    expect(getMission(missionId)?.conversationLog).toEqual([
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "sent",
+          sessionId: "session-ignis-submitted",
+        }),
+      }),
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "sent",
+          sessionId: "session-ignis-submitted",
+        }),
+      }),
+    ]);
+  });
+
   it("uses the mission execution workspace for team-message worker sessions", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;
@@ -393,6 +627,235 @@ describe("execution workspace sessions", () => {
 
     expect(sessionCreateMock).not.toHaveBeenCalled();
     expect(promptAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("does not block team-message delivery for completed tasks on the previous tmux mission", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const activeMission = createExecutionMission(root);
+    const targetMission = createExecutionMission(root);
+    addTask(activeMission.missionId, {
+      id: "task-completed-focus-release",
+      assignedTo: "ignis",
+      dependencies: [],
+      status: "pending",
+      message: "Complete and release tmux focus.",
+    });
+    updateTask(
+      activeMission.missionId,
+      "task-completed-focus-release",
+      "completed",
+      "Completed work should not hold tmux focus.",
+    );
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.missionId,
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-noctis": "idle",
+      },
+      error: null,
+    });
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-completed-task-release" } });
+
+    const result = await sendSimpleMessage({
+      missionId: targetMission.missionId,
+      toAgent: "ignis",
+      body: "Completed tasks should not keep writable focus.",
+      fromActor: "user",
+    });
+
+    expect(result).toMatchObject({
+      sessionId: "session-ignis-completed-task-release",
+      messageId: expect.any(String) as string,
+    });
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${targetMission.missionId}:ignis`,
+      }),
+    );
+  });
+
+  it("creates tmux team-message worker sessions on the worker owner endpoint", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-message-owner" } });
+    promptAsyncMock.mockResolvedValue({ data: { id: "prompt-message-owner" } });
+
+    await sendSimpleMessage({
+      missionId,
+      toAgent: "ignis",
+      body: "Route this tmux message through the worker endpoint.",
+      fromActor: "user",
+    });
+
+    expect(createProjectOpencodeClientMock).toHaveBeenCalledWith("http://127.0.0.1:4403");
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${missionId}:ignis`,
+      }),
+    );
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("queues tmux team messages instead of prompting inline", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-message-queued" } });
+
+    const result = await sendSimpleMessage({
+      missionId,
+      toAgent: "ignis",
+      body: "Queue this tmux team message.",
+      fromActor: "user",
+    });
+
+    expect(result).toMatchObject({
+      sessionId: "session-ignis-message-queued",
+      messageId: expect.any(String) as string,
+    });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(listTmuxDispatchItems(missionId)).toEqual([
+      expect.objectContaining({
+        status: "pending",
+        payload: expect.objectContaining({
+          agent: "ignis",
+          sessionId: "session-ignis-message-queued",
+          sessionTitle: `mission:${missionId}:ignis`,
+        }),
+      }),
+    ]);
+  });
+
+  it("records queued transport state for tmux team messages", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-message-pending" } });
+
+    await sendSimpleMessage({
+      missionId,
+      toAgent: "ignis",
+      body: "Track queued transport state for this tmux message.",
+      fromActor: "user",
+    });
+
+    expect(getMission(missionId)?.messageLog).toContainEqual(
+      expect.objectContaining({
+        toAgent: "ignis",
+        deliveredToSessionId: "session-ignis-message-pending",
+        deliveryStatus: "queued",
+      }),
+    );
+    expect(getMission(missionId)?.conversationLog).toEqual([
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "queued",
+          sessionId: "session-ignis-message-pending",
+        }),
+      }),
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "queued",
+          sessionId: "session-ignis-message-pending",
+        }),
+      }),
+    ]);
+  });
+
+  it("reconciles submitted tmux team messages to sent transport state", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4403,
+        url: "http://127.0.0.1:4403",
+      },
+    ]);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-ignis-message-submitted" } });
+
+    await sendSimpleMessage({
+      missionId,
+      toAgent: "ignis",
+      body: "Reconcile tmux submission to sent state.",
+      fromActor: "user",
+    });
+
+    const [item] = listTmuxDispatchItems(missionId);
+    markTmuxDispatchItemSubmitted({
+      missionId,
+      itemId: item.id,
+      submittedAt: "2026-05-01T00:00:00.000Z",
+      submittedBy: "dispatcher:test",
+    });
+
+    const mission = getMission(missionId);
+    expect(mission).toBeTruthy();
+    buildMissionResumePayload(mission!);
+
+    expect(getMission(missionId)?.messageLog).toContainEqual(
+      expect.objectContaining({
+        deliveredToSessionId: "session-ignis-message-submitted",
+        deliveryStatus: "sent",
+      }),
+    );
+    expect(getMission(missionId)?.activityLog).toContainEqual(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          deliveryStatus: "sent",
+          sessionId: "session-ignis-message-submitted",
+        }),
+      }),
+    );
+    expect(getMission(missionId)?.conversationLog).toEqual([
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "sent",
+          sessionId: "session-ignis-message-submitted",
+        }),
+      }),
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          deliveryStatus: "sent",
+          sessionId: "session-ignis-message-submitted",
+        }),
+      }),
+    ]);
   });
 
   it("records report-return banter when a worker sends a report back to Noctis", async () => {

--- a/web/app/lib/mission-api.server.ts
+++ b/web/app/lib/mission-api.server.ts
@@ -15,9 +15,31 @@ import {
   getMissionPrimaryAgentId,
   getMissionPrimarySessionId,
   getMissionSurfaceId,
+  reconcileMissionTmuxDispatchStatuses,
 } from "./mission-store";
 import { getMissionSurfaceForMission } from "./mission-surface";
 import { buildMissionWorkflowProgress } from "./mission-workflow-progress.server";
+
+function reconcileQueuedDispatchState(mission: Mission) {
+  const primaryAgentOutbox = listPrimaryAgentOutboxItems(mission.id);
+  const updates = primaryAgentOutbox
+    .map((item) => {
+      const recordLinks = item.payload.recordLinks;
+      if (!recordLinks) {
+        return null;
+      }
+
+      return {
+        ...recordLinks,
+        deliveryStatus: item.status === "submitted" ? ("sent" as const) : ("queued" as const),
+        sessionId: item.payload.sessionId,
+      };
+    })
+    .filter((update): update is NonNullable<typeof update> => update !== null);
+
+  reconcileMissionTmuxDispatchStatuses(mission.id, updates);
+  return primaryAgentOutbox;
+}
 
 type MissionSessionPayload = {
   primary: string | null;
@@ -69,6 +91,7 @@ export function buildMissionResumePayload(mission: Mission) {
   const primaryAgentId = getMissionPrimaryAgentId(mission);
   const primarySessionId = getMissionPrimarySessionId(mission);
   const resumeBlock = getMissionResumeBlock(mission);
+  const primaryAgentOutbox = reconcileQueuedDispatchState(mission);
 
   return {
     missionId: mission.id,
@@ -98,7 +121,7 @@ export function buildMissionResumePayload(mission: Mission) {
     operationState: mission.operationState ?? null,
     workflowProgress: buildMissionWorkflowProgress(mission.operationState),
     lunafreyaFacetSelection: mission.lunafreyaFacetSelection ?? null,
-    primaryAgentOutbox: listPrimaryAgentOutboxItems(mission.id),
+    primaryAgentOutbox,
     activityLog: mission.activityLog,
   };
 }

--- a/web/app/lib/mission-primary-agent-outbox.server.test.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.test.ts
@@ -6,9 +6,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createMission, deleteMission, getMissionDir } from "./mission-store";
 import {
   enqueuePrimaryAgentOutboxItem,
+  enqueueTmuxDispatchItem,
   leasePrimaryAgentOutboxItem,
+  leaseTmuxDispatchItem,
   listPrimaryAgentOutboxItems,
+  listTmuxDispatchItems,
   markPrimaryAgentOutboxItemSubmitted,
+  markTmuxDispatchItemSubmitted,
+  updateTmuxDispatchItemRecordLinks,
 } from "./mission-primary-agent-outbox.server";
 
 const tempRoots: string[] = [];
@@ -194,5 +199,87 @@ describe("mission primary-agent outbox", () => {
       },
       staleAfterMs: 1_000,
     });
+  });
+
+  it("provides generic tmux dispatch lifecycle helpers for worker-targeted items", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-generic", "session-primary-generic", {
+      title: "Generic Dispatch Mission",
+      objective: "Verify generic dispatch lifecycle helpers",
+    });
+    missionIds.push(mission.id);
+
+    const item = enqueueTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-generic-1",
+      createdAt: "2026-04-28T00:20:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis-1",
+        sessionTitle: `mission:${mission.id}:ignis`,
+        parts: [{ type: "text", text: "generic queued prompt" }],
+      },
+    });
+
+    expect(listTmuxDispatchItems(mission.id)).toEqual([item]);
+
+    const leased = leaseTmuxDispatchItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-generic",
+      leasedAt: "2026-04-28T00:21:00.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    expect(leased?.status).toBe("leased");
+
+    const submitted = markTmuxDispatchItemSubmitted({
+      missionId: mission.id,
+      itemId: "item-generic-1",
+      submittedAt: "2026-04-28T00:22:00.000Z",
+      submittedBy: "dispatcher-generic",
+      dispatcherPid: 7171,
+    });
+
+    expect(submitted.status).toBe("submitted");
+    expect(listTmuxDispatchItems(mission.id)).toEqual([submitted]);
+  });
+
+  it("stores record links on queued tmux dispatch items", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-record-links", "session-primary-links", {
+      title: "Record Link Mission",
+      objective: "Verify tmux dispatch record-link persistence",
+    });
+    missionIds.push(mission.id);
+
+    enqueueTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-links-1",
+      createdAt: "2026-04-28T00:30:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis-links",
+        parts: [{ type: "text", text: "linked prompt" }],
+      },
+    });
+
+    const updated = updateTmuxDispatchItemRecordLinks({
+      missionId: mission.id,
+      itemId: "item-links-1",
+      recordLinks: {
+        activityEntryId: "activity_msg_links",
+        conversationEntryIds: ["banter-a", "banter-b"],
+        messageLogEntryId: "msg_links",
+      },
+    });
+
+    expect(updated.payload.recordLinks).toEqual({
+      activityEntryId: "activity_msg_links",
+      conversationEntryIds: ["banter-a", "banter-b"],
+      messageLogEntryId: "msg_links",
+    });
+    expect(listTmuxDispatchItems(mission.id)).toEqual([updated]);
   });
 });

--- a/web/app/lib/mission-primary-agent-outbox.server.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.ts
@@ -10,6 +10,7 @@ const PRIMARY_AGENT_OUTBOX_DIR = "primary-agent-outbox";
 const OUTBOX_STATUSES = ["pending", "leased", "submitted"] as const;
 
 export type PrimaryAgentOutboxStatus = (typeof OUTBOX_STATUSES)[number];
+export type TmuxDispatchStatus = PrimaryAgentOutboxStatus;
 
 export interface PrimaryAgentOutboxRecoveredLease {
   attempt: number;
@@ -17,6 +18,7 @@ export interface PrimaryAgentOutboxRecoveredLease {
   owner: string;
   staleAfterMs: number;
 }
+export type TmuxDispatchRecoveredLease = PrimaryAgentOutboxRecoveredLease;
 
 export interface PrimaryAgentOutboxLease {
   attempt: number;
@@ -25,12 +27,21 @@ export interface PrimaryAgentOutboxLease {
   staleAfterMs: number;
   recoveredFrom?: PrimaryAgentOutboxRecoveredLease;
 }
+export type TmuxDispatchLease = PrimaryAgentOutboxLease;
 
 export interface PrimaryAgentOutboxSubmission {
   dispatcherPid?: number;
   submittedAt: string;
   submittedBy: string;
 }
+export type TmuxDispatchSubmission = PrimaryAgentOutboxSubmission;
+
+export interface PrimaryAgentOutboxRecordLinks {
+  activityEntryId?: string;
+  conversationEntryIds?: string[];
+  messageLogEntryId?: string;
+}
+export type TmuxDispatchRecordLinks = PrimaryAgentOutboxRecordLinks;
 
 export interface PrimaryAgentOutboxPayload {
   agent: AgentId;
@@ -40,7 +51,9 @@ export interface PrimaryAgentOutboxPayload {
   system?: string;
   model?: Pick<ModelSelection, "providerID" | "modelID">;
   variant?: string;
+  recordLinks?: PrimaryAgentOutboxRecordLinks;
 }
+export type TmuxDispatchPayload = PrimaryAgentOutboxPayload;
 
 export interface PrimaryAgentOutboxItem {
   id: string;
@@ -52,6 +65,7 @@ export interface PrimaryAgentOutboxItem {
   lease?: PrimaryAgentOutboxLease;
   submission?: PrimaryAgentOutboxSubmission;
 }
+export type TmuxDispatchItem = PrimaryAgentOutboxItem;
 
 function isOutboxStatus(value: unknown): value is PrimaryAgentOutboxStatus {
   return OUTBOX_STATUSES.some((status) => status === value);
@@ -87,6 +101,36 @@ function normalizePromptParts(value: unknown): TextPromptPart[] | null {
   return parts.length === value.length ? parts : null;
 }
 
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const entries = value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+  return entries.length === value.length && entries.length > 0 ? entries : undefined;
+}
+
+function normalizeRecordLinks(value: unknown): PrimaryAgentOutboxRecordLinks | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const activityEntryId = normalizeString(record.activityEntryId);
+  const conversationEntryIds = normalizeStringArray(record.conversationEntryIds);
+  const messageLogEntryId = normalizeString(record.messageLogEntryId);
+
+  if (!activityEntryId && !conversationEntryIds && !messageLogEntryId) {
+    return undefined;
+  }
+
+  return {
+    ...(activityEntryId ? { activityEntryId } : {}),
+    ...(conversationEntryIds ? { conversationEntryIds } : {}),
+    ...(messageLogEntryId ? { messageLogEntryId } : {}),
+  };
+}
+
 function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -118,6 +162,9 @@ function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
         }
       : {}),
     ...(normalizeString(record.variant) ? { variant: normalizeString(record.variant) } : {}),
+    ...(normalizeRecordLinks(record.recordLinks)
+      ? { recordLinks: normalizeRecordLinks(record.recordLinks) }
+      : {}),
   };
 }
 
@@ -341,8 +388,21 @@ export function enqueuePrimaryAgentOutboxItem(input: {
   return item;
 }
 
+export function enqueueTmuxDispatchItem(input: {
+  missionId: string;
+  itemId?: string;
+  createdAt?: string;
+  payload: TmuxDispatchPayload;
+}): TmuxDispatchItem {
+  return enqueuePrimaryAgentOutboxItem(input);
+}
+
 export function listPrimaryAgentOutboxItems(missionId: string): PrimaryAgentOutboxItem[] {
   return OUTBOX_STATUSES.flatMap((status) => readItemsForStatus(missionId, status)).sort(compareItems);
+}
+
+export function listTmuxDispatchItems(missionId: string): TmuxDispatchItem[] {
+  return listPrimaryAgentOutboxItems(missionId);
 }
 
 export function leasePrimaryAgentOutboxItem(input: {
@@ -388,6 +448,15 @@ export function leasePrimaryAgentOutboxItem(input: {
   return nextItem;
 }
 
+export function leaseTmuxDispatchItem(input: {
+  missionId: string;
+  leaseOwner: string;
+  leasedAt: string;
+  staleAfterMs: number;
+}): TmuxDispatchItem | null {
+  return leasePrimaryAgentOutboxItem(input);
+}
+
 export function markPrimaryAgentOutboxItemSubmitted(input: {
   missionId: string;
   itemId: string;
@@ -409,6 +478,42 @@ export function markPrimaryAgentOutboxItemSubmitted(input: {
       submittedAt,
       submittedBy: input.submittedBy,
       ...(typeof input.dispatcherPid === "number" ? { dispatcherPid: input.dispatcherPid } : {}),
+    },
+  };
+
+  writeItem(item, record.status);
+  return item;
+}
+
+export function markTmuxDispatchItemSubmitted(input: {
+  missionId: string;
+  itemId: string;
+  submittedAt: string;
+  submittedBy: string;
+  dispatcherPid?: number;
+}): TmuxDispatchItem {
+  return markPrimaryAgentOutboxItemSubmitted(input);
+}
+
+export function updateTmuxDispatchItemRecordLinks(input: {
+  missionId: string;
+  itemId: string;
+  recordLinks: TmuxDispatchRecordLinks;
+}): TmuxDispatchItem {
+  const record = findItem(input.missionId, input.itemId);
+  if (!record) {
+    throw new Error(`Tmux dispatch item not found: ${input.itemId}`);
+  }
+
+  const item: TmuxDispatchItem = {
+    ...record.item,
+    updatedAt: new Date().toISOString(),
+    payload: {
+      ...record.item.payload,
+      recordLinks: {
+        ...(record.item.payload.recordLinks ?? {}),
+        ...input.recordLinks,
+      },
     },
   };
 

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -963,6 +963,80 @@ export function appendMissionActivity(
   touchMission(mission);
 }
 
+export function reconcileMissionTmuxDispatchStatuses(
+  missionId: string,
+  updates: Array<{
+    activityEntryId?: string;
+    conversationEntryIds?: string[];
+    deliveryStatus: "queued" | "sent";
+    messageLogEntryId?: string;
+    sessionId: string;
+  }>,
+): void {
+  const mission = getMission(missionId);
+  if (!mission || updates.length === 0) {
+    return;
+  }
+
+  let changed = false;
+
+  for (const update of updates) {
+    if (update.messageLogEntryId) {
+      const entry = mission.messageLog.find((candidate) => candidate.id === update.messageLogEntryId);
+      if (entry && entry.deliveryStatus !== update.deliveryStatus) {
+        entry.deliveryStatus = update.deliveryStatus;
+        changed = true;
+      }
+    }
+
+    if (update.activityEntryId) {
+      const activity = mission.activityLog.find((candidate) => candidate.id === update.activityEntryId);
+      if (activity?.source && activity.source.deliveryStatus !== update.deliveryStatus) {
+        activity.source.deliveryStatus = update.deliveryStatus;
+        changed = true;
+      }
+    }
+
+    if (update.conversationEntryIds && update.conversationEntryIds.length > 0) {
+      for (const entryId of update.conversationEntryIds) {
+        const conversationEntry = mission.conversationLog.find((candidate) => candidate.id === entryId);
+        if (!conversationEntry) {
+          continue;
+        }
+
+        if (!conversationEntry.transport) {
+          conversationEntry.transport = {
+            deliveredToSessionId: update.sessionId,
+            deliveryStatus: update.deliveryStatus,
+            sessionId: update.sessionId,
+          };
+          changed = true;
+          continue;
+        }
+
+        if (conversationEntry.transport.deliveryStatus !== update.deliveryStatus) {
+          conversationEntry.transport.deliveryStatus = update.deliveryStatus;
+          changed = true;
+        }
+
+        if (conversationEntry.transport.sessionId !== update.sessionId) {
+          conversationEntry.transport.sessionId = update.sessionId;
+          changed = true;
+        }
+
+        if (conversationEntry.transport.deliveredToSessionId !== update.sessionId) {
+          conversationEntry.transport.deliveredToSessionId = update.sessionId;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    touchMission(mission);
+  }
+}
+
 export function buildDelegationLedger(mission: Mission): string {
   const ledger: DelegationLedger = mission.delegationLedger;
   return JSON.stringify(ledger, null, 2);

--- a/web/app/lib/primary-agent-outbox-dispatch.server.test.ts
+++ b/web/app/lib/primary-agent-outbox-dispatch.server.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { listPrimaryAgentOutboxItems } from "./mission-primary-agent-outbox.server";
+import { createMission, deleteMission, getMission } from "./mission-store";
+import { queueTmuxAgentDispatch } from "./primary-agent-outbox-dispatch.server";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-tmux-dispatch-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+afterEach(() => {
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("primary-agent-outbox-dispatch.server", () => {
+  it("queues worker-targeted tmux deliveries with caller-defined activity text", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-worker-queue", "session-noctis", {
+      title: "Worker queue mission",
+      objective: "Queue delegated worker deliveries through tmux transport",
+      executionProjectId: "alpha",
+    });
+    missionIds.push(mission.id);
+
+    const item = queueTmuxAgentDispatch({
+      missionId: mission.id,
+      agent: "ignis",
+      sessionId: "session-ignis",
+      sessionTitle: `mission:${mission.id}:ignis`,
+      parts: [{ type: "text", text: "Delegated worker task payload" }],
+      activityBody: "Queued tmux worker delivery.",
+    });
+
+    expect(item).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis",
+        sessionTitle: `mission:${mission.id}:ignis`,
+      },
+    });
+    expect(listPrimaryAgentOutboxItems(mission.id)).toEqual([item]);
+    expect(getMission(mission.id)?.activityLog).toContainEqual(
+      expect.objectContaining({
+        kind: "system_event",
+        body: "Queued tmux worker delivery.",
+      }),
+    );
+    expect(getMission(mission.id)?.activityLog.map((entry) => entry.body).join("\n") ?? "").not.toContain(
+      "Delegated worker task payload",
+    );
+  });
+});

--- a/web/app/lib/primary-agent-outbox-dispatch.server.ts
+++ b/web/app/lib/primary-agent-outbox-dispatch.server.ts
@@ -2,16 +2,19 @@ import { appendMissionActivity } from "./mission-store";
 import {
   enqueuePrimaryAgentOutboxItem,
   type PrimaryAgentOutboxItem,
+  type TmuxDispatchRecordLinks,
 } from "./mission-primary-agent-outbox.server";
 import type { TextPromptPart } from "./prompt-parts";
 import type { AgentId, ModelSelection } from "./types/mission";
 
-export function queuePrimaryAgentTmuxDispatch(input: {
+export function queueTmuxAgentDispatch(input: {
   agent: AgentId;
+  activityBody: string;
   missionId: string;
   model?: Pick<ModelSelection, "providerID" | "modelID">;
   parts: TextPromptPart[];
   queuedAt?: string;
+  recordLinks?: TmuxDispatchRecordLinks;
   sessionId: string;
   sessionTitle?: string;
   system?: string;
@@ -29,6 +32,7 @@ export function queuePrimaryAgentTmuxDispatch(input: {
       ...(input.system ? { system: input.system } : {}),
       ...(input.model ? { model: input.model } : {}),
       ...(input.variant ? { variant: input.variant } : {}),
+      ...(input.recordLinks ? { recordLinks: input.recordLinks } : {}),
     },
   });
 
@@ -37,7 +41,7 @@ export function queuePrimaryAgentTmuxDispatch(input: {
     actor: "system",
     speaker: "system",
     kind: "system_event",
-    body: "Queued primary-agent tmux delivery.",
+    body: input.activityBody,
     createdAt: queuedAt,
     source: {
       type: "system",
@@ -46,4 +50,21 @@ export function queuePrimaryAgentTmuxDispatch(input: {
   });
 
   return item;
+}
+
+export function queuePrimaryAgentTmuxDispatch(input: {
+  agent: AgentId;
+  missionId: string;
+  model?: Pick<ModelSelection, "providerID" | "modelID">;
+  parts: TextPromptPart[];
+  queuedAt?: string;
+  sessionId: string;
+  sessionTitle?: string;
+  system?: string;
+  variant?: string;
+}): PrimaryAgentOutboxItem {
+  return queueTmuxAgentDispatch({
+    ...input,
+    activityBody: "Queued primary-agent tmux delivery.",
+  });
 }

--- a/web/app/lib/session-owner-routing.server.ts
+++ b/web/app/lib/session-owner-routing.server.ts
@@ -1,9 +1,14 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { isWorkerAgentId } from "./agent-identity";
+import { getProjectRoot } from "./get-project-root.server";
 import type { ManagedSessionInfo } from "./managed-session.server";
 import { findManagedSession } from "./managed-session.server";
+import { getManagedSessionTitle } from "./managed-session-titles";
+import { getMission, setMissionPrimarySession, setWorkerSession } from "./mission-store";
 import { createProjectOpencodeClient, getOpencodeClient } from "./opencode-client";
-import { getProjectRoot } from "./get-project-root.server";
+import type { AgentId } from "./types/mission";
+import { activateTmuxMissionWriteFocus, getTmuxMissionWriteConflict } from "./tmux-mission-activation.server";
 
 type EndpointManifest = {
   agents: Array<{
@@ -27,6 +32,41 @@ export interface SessionStatusTarget {
   agentId: string;
   client: ReturnType<typeof createProjectOpencodeClient>;
   endpointUrl: string;
+}
+
+export interface TmuxWriteTarget {
+  client: ReturnType<typeof createProjectOpencodeClient>;
+  createdSession: boolean;
+  endpointUrl: string;
+  ownerAgent: AgentId;
+  sessionId: string;
+  sessionTitle: string;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+  return String(error);
+}
+
+function resolveManagedEndpointUrl(root: string, ownerAgent: string, context: string): string {
+  const endpointUrl = readEndpointManifest(root)?.agents.find((agent) => agent.agentId === ownerAgent)?.url ?? null;
+
+  if (!endpointUrl) {
+    throw new Error(`No tmux transport endpoint configured for ${context} owner ${ownerAgent}.`);
+  }
+
+  return endpointUrl;
 }
 
 function readEndpointManifest(root: string): EndpointManifest | null {
@@ -92,15 +132,7 @@ export function resolveSessionRouteTarget(sessionId: string): SessionRouteTarget
   }
 
   const root = getProjectRoot();
-  const endpointUrl =
-    readEndpointManifest(root)?.agents.find((agent) => agent.agentId === managedSession.ownerAgent)?.url ??
-    null;
-
-  if (!endpointUrl) {
-    throw new Error(
-      `No tmux transport endpoint configured for managed session ${sessionId} owner ${managedSession.ownerAgent}.`,
-    );
-  }
+  const endpointUrl = resolveManagedEndpointUrl(root, managedSession.ownerAgent, `managed session ${sessionId}`);
 
   return {
     client: createProjectOpencodeClient(endpointUrl),
@@ -122,4 +154,75 @@ export function listSessionStatusTargets(): SessionStatusTarget[] {
     client: createProjectOpencodeClient(agent.url),
     endpointUrl: agent.url,
   }));
+}
+
+export async function resolveTmuxWriteTarget(input: {
+  missionId: string;
+  agentId: AgentId;
+  sessionHostRoot: string;
+}): Promise<TmuxWriteTarget> {
+  const mission = getMission(input.missionId);
+  if (!mission) {
+    throw new Error("Mission not found");
+  }
+
+  const root = getProjectRoot();
+  const defaultClient = getOpencodeClient();
+  const conflict = await getTmuxMissionWriteConflict({
+    appRoot: root,
+    missionId: input.missionId,
+    client: defaultClient,
+  });
+  if (conflict) {
+    throw new Error(`Tmux write focus is still held by mission ${conflict.activeMissionId}.`);
+  }
+
+  activateTmuxMissionWriteFocus({ appRoot: root, missionId: input.missionId });
+
+  const sessionTitle = getManagedSessionTitle(input.missionId, input.agentId);
+  const existingSessionId = isWorkerAgentId(input.agentId)
+    ? mission.workerSessions[input.agentId]
+    : mission.primarySessionId || mission.noctisSessionId;
+  const endpointUrl = resolveManagedEndpointUrl(root, input.agentId, `managed write target ${input.agentId}`);
+  const client = createProjectOpencodeClient(endpointUrl);
+
+  if (existingSessionId) {
+    return {
+      client,
+      createdSession: false,
+      endpointUrl,
+      ownerAgent: input.agentId,
+      sessionId: existingSessionId,
+      sessionTitle,
+    };
+  }
+
+  const sessionResult = await client.session.create({
+    directory: input.sessionHostRoot,
+    title: sessionTitle,
+  });
+
+  if (sessionResult.error) {
+    throw new Error(toErrorMessage(sessionResult.error));
+  }
+
+  const sessionId = sessionResult.data?.id;
+  if (!sessionId) {
+    throw new Error("Session creation returned no ID");
+  }
+
+  if (isWorkerAgentId(input.agentId)) {
+    setWorkerSession(input.missionId, input.agentId, sessionId);
+  } else {
+    setMissionPrimarySession(input.missionId, input.agentId, sessionId);
+  }
+
+  return {
+    client,
+    createdSession: true,
+    endpointUrl,
+    ownerAgent: input.agentId,
+    sessionId,
+    sessionTitle,
+  };
 }

--- a/web/app/lib/task-dispatch.server.ts
+++ b/web/app/lib/task-dispatch.server.ts
@@ -26,11 +26,9 @@ import {
   saveOperationState,
 } from "@/lib/operation-runtime/state";
 import { composeWorkerTaskPrompt } from "@/lib/prompt-composition-engine";
+import { queueTmuxAgentDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
 import { getRuntimeScriptPath } from "@/lib/runtime-script-path";
-import {
-  activateTmuxMissionWriteFocus,
-  getTmuxMissionWriteConflict,
-} from "@/lib/tmux-mission-activation.server";
+import { resolveTmuxWriteTarget } from "@/lib/session-owner-routing.server";
 import type { AgentId, MissionMessageLogEntry, Task, WorkerAgentId } from "@/lib/types/mission";
 
 function createTaskId(): string {
@@ -177,7 +175,7 @@ export async function dispatchTaskToWorker(input: {
     throw new Error("Mission not found");
   }
   const projectRoot = getProjectRoot();
-  const client = getOpencodeClient();
+  const defaultClient = getOpencodeClient();
 
   const handoffFromAgent = input.fromAgent ?? "noctis";
   const orchestratedBy = input.orchestratedBy ?? "noctis";
@@ -199,19 +197,6 @@ export async function dispatchTaskToWorker(input: {
     if (!effectiveWorkers.includes(input.agentId)) {
       throw new Error(`Delegation to ${input.agentId} is not allowed for the active step`);
     }
-  }
-
-  if (mission.transportMode === "tmux-resident") {
-    const conflict = await getTmuxMissionWriteConflict({
-      appRoot: projectRoot,
-      missionId: input.missionId,
-      client,
-    });
-    if (conflict) {
-      throw new Error(`Tmux write focus is still held by mission ${conflict.activeMissionId}.`);
-    }
-
-    activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId: input.missionId });
   }
 
   const reusableTask = explicitTaskId
@@ -270,7 +255,19 @@ export async function dispatchTaskToWorker(input: {
   });
 
   const managedRoots = resolveManagedRootsForWorkerDispatch(input.missionId);
-  const existingSessionId = mission.workerSessions[input.agentId];
+  let workerClient = defaultClient;
+  let existingSessionId = mission.workerSessions[input.agentId];
+  let tmuxWriteTarget: Awaited<ReturnType<typeof resolveTmuxWriteTarget>> | null = null;
+
+  if (mission.transportMode === "tmux-resident") {
+    tmuxWriteTarget = await resolveTmuxWriteTarget({
+      missionId: input.missionId,
+      agentId: input.agentId,
+      sessionHostRoot: managedRoots.sessionHostRoot,
+    });
+    workerClient = tmuxWriteTarget.client;
+    existingSessionId = tmuxWriteTarget.sessionId;
+  }
 
   const markDelegatedDispatchFailed = (summary: string) => {
     if (!isDelegatedChildDispatch || !operationState) {
@@ -285,9 +282,11 @@ export async function dispatchTaskToWorker(input: {
     saveOperationState(input.missionId, operationState);
   };
 
+  const ledger = buildDelegationLedger(mission);
+
   const appendLog = (
     sessionId: string,
-    deliveryStatus: "sent" | "failed",
+    deliveryStatus: "queued" | "sent" | "failed",
     error?: string,
   ): MissionMessageLogEntry => {
     const entry: MissionMessageLogEntry = {
@@ -324,7 +323,43 @@ export async function dispatchTaskToWorker(input: {
         originalPrompt: taskPrompt,
         operationStateOverride: operationState,
       });
-      const promptResult = await client.session.promptAsync({
+      if (mission.transportMode === "tmux-resident" && tmuxWriteTarget) {
+        const entry = appendLog(existingSessionId, "queued");
+        const banterEntries = recordDirectedTaskDelegation({
+          missionId: input.missionId,
+          fromAgent: handoffFromAgent,
+          toAgent: input.agentId,
+          orchestratedBy,
+          taskId,
+          stepName: input.stepName,
+          canonicalMessage: input.canonicalMessage ?? input.message,
+          createdAt: entry.createdAt,
+          transport: {
+            deliveredToSessionId: entry.deliveredToSessionId,
+            deliveryStatus: entry.deliveryStatus,
+            error: entry.error,
+            sessionId: entry.deliveredToSessionId,
+          },
+        });
+        queueTmuxAgentDispatch({
+          missionId: input.missionId,
+          agent: input.agentId,
+          sessionId: existingSessionId,
+          sessionTitle: tmuxWriteTarget.sessionTitle,
+          parts: composed.payloadParts,
+          ...(tmuxWriteTarget.createdSession ? { system: ledger } : {}),
+          ...(model ? { model } : {}),
+          ...(variant ? { variant } : {}),
+          activityBody: "Queued tmux worker delivery.",
+          recordLinks: {
+            conversationEntryIds: banterEntries.map((banterEntry) => banterEntry.id),
+            messageLogEntryId: entry.id,
+          },
+        });
+        return { sessionId: existingSessionId, taskId };
+      }
+
+      const promptResult = await workerClient.session.promptAsync({
         sessionID: existingSessionId,
         parts: composed.payloadParts,
         agent: input.agentId,
@@ -369,8 +404,7 @@ export async function dispatchTaskToWorker(input: {
     }
   }
 
-  const ledger = buildDelegationLedger(mission);
-  const sessionResult = await client.session.create({
+  const sessionResult = await defaultClient.session.create({
     directory: managedRoots.sessionHostRoot,
     title: getManagedSessionTitle(input.missionId, input.agentId),
   });
@@ -403,7 +437,7 @@ export async function dispatchTaskToWorker(input: {
       originalPrompt: taskPrompt,
       operationStateOverride: operationState,
     });
-    const promptResult = await client.session.promptAsync({
+    const promptResult = await defaultClient.session.promptAsync({
       sessionID: sessionId,
       parts: composed.payloadParts,
       agent: input.agentId,

--- a/web/app/lib/team-message.server.ts
+++ b/web/app/lib/team-message.server.ts
@@ -15,15 +15,14 @@ import {
   updateMissionExecutionContext,
 } from "@/lib/mission-store";
 import { getManagedSessionTitle } from "@/lib/managed-session-titles";
+import { updateTmuxDispatchItemRecordLinks } from "@/lib/mission-primary-agent-outbox.server";
 import { splitModelSelection } from "@/lib/model-variant-selection";
 import { getOpencodeClient } from "@/lib/opencode-client";
 import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeTeamMessagePrompt } from "@/lib/prompt-composition-engine";
+import { queueTmuxAgentDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
+import { resolveTmuxWriteTarget } from "@/lib/session-owner-routing.server";
 import { getActivityActorLabel } from "@/lib/team-message-format";
-import {
-  activateTmuxMissionWriteFocus,
-  getTmuxMissionWriteConflict,
-} from "@/lib/tmux-mission-activation.server";
 import type {
   ActivityActorId,
   AgentId,
@@ -107,7 +106,12 @@ function serializeMeta(message: TeamMessage, displayFrom: ActivityActorId): stri
   ].join("\n");
 }
 
-async function resolveTargetSession(missionId: string, toAgent: AgentId): Promise<string> {
+async function resolveTargetSession(missionId: string, toAgent: AgentId): Promise<{
+  client: ReturnType<typeof getOpencodeClient>;
+  mode: "direct" | "tmux";
+  sessionId: string;
+  sessionTitle: string;
+}> {
   const mission = getMission(missionId);
   if (!mission) {
     throw new Error("Mission not found");
@@ -133,24 +137,31 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
     clearMissionSessions(missionId);
   }
 
-  const client = getOpencodeClient();
   if (mission.transportMode === "tmux-resident") {
-    const conflict = await getTmuxMissionWriteConflict({
-      appRoot: projectRoot,
+    const writeTarget = await resolveTmuxWriteTarget({
       missionId,
-      client,
+      agentId: toAgent,
+      sessionHostRoot: executionRoot.sessionHostRoot,
     });
-    if (conflict) {
-      throw new Error(`Tmux write focus is still held by mission ${conflict.activeMissionId}.`);
-    }
-
-    activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId });
+    return {
+      client: writeTarget.client,
+      mode: "tmux",
+      sessionId: writeTarget.sessionId,
+      sessionTitle: writeTarget.sessionTitle,
+    };
   }
+
+  const client = getOpencodeClient();
 
   if (!isWorkerAgentId(toAgent)) {
     const existingPrimarySessionId = mission.primarySessionId || mission.noctisSessionId;
     if (existingPrimarySessionId) {
-      return existingPrimarySessionId;
+      return {
+        client,
+        mode: "direct",
+        sessionId: existingPrimarySessionId,
+        sessionTitle: getManagedSessionTitle(missionId, toAgent),
+      };
     }
 
     const sessionResult = await client.session.create({
@@ -164,12 +175,22 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
     }
 
     setMissionPrimarySession(missionId, toAgent, sessionId);
-    return sessionId;
+    return {
+      client,
+      mode: "direct",
+      sessionId,
+      sessionTitle: getManagedSessionTitle(missionId, toAgent),
+    };
   }
 
-  const existing = mission.workerSessions[toAgent];
-  if (existing) {
-    return existing;
+  const existingWorkerSessionId = mission.workerSessions[toAgent];
+  if (existingWorkerSessionId) {
+    return {
+      client,
+      mode: "direct",
+      sessionId: existingWorkerSessionId,
+      sessionTitle: getManagedSessionTitle(missionId, toAgent),
+    };
   }
 
   const sessionResult = await client.session.create({
@@ -183,12 +204,23 @@ async function resolveTargetSession(missionId: string, toAgent: AgentId): Promis
   }
 
   setWorkerSession(missionId, toAgent, sessionId);
-  return sessionId;
+  return {
+    client,
+    mode: "direct",
+    sessionId,
+    sessionTitle: getManagedSessionTitle(missionId, toAgent),
+  };
 }
 
 async function deliverMissionMessage(
   input: SendTeamMessageInput
-): Promise<{ sessionId: string; messageId: string; createdAt: string }> {
+): Promise<{
+  sessionId: string;
+  messageId: string;
+  createdAt: string;
+  deliveryStatus: "queued" | "sent";
+  outboxItemId?: string;
+}> {
   assertHubSafe(input.fromAgent, input.toAgent);
   assertIntentContract(input);
 
@@ -211,7 +243,8 @@ async function deliverMissionMessage(
     createdAt: new Date().toISOString(),
   };
 
-  const sessionId = await resolveTargetSession(input.missionId, input.toAgent);
+  const target = await resolveTargetSession(input.missionId, input.toAgent);
+  const sessionId = target.sessionId;
   const projectRoot = getProjectRoot();
 
   const system = serializeMeta(message, input.activitySpeaker ?? input.fromAgent);
@@ -236,11 +269,56 @@ async function deliverMissionMessage(
     workflowExtensionOverride: input.workflowGuidance,
   });
 
-  const client = getOpencodeClient();
   const { model, variant } = splitModelSelection(mission.agentModels[input.toAgent]);
 
+  if (target.mode === "tmux") {
+    const queuedEntry: MissionMessageLogEntry = {
+      ...message,
+      deliveredToSessionId: sessionId,
+      deliveryStatus: "queued",
+    };
+    appendMissionMessage(input.missionId, queuedEntry);
+    appendMissionActivity(input.missionId, {
+      id: `activity_${message.id}`,
+      actor: input.activityActor ?? input.fromAgent,
+      speaker: input.activitySpeaker ?? input.fromAgent,
+      kind: input.activityKind ?? "team_message",
+      body: input.body,
+      createdAt: message.createdAt,
+      source: {
+        type: "team_message",
+        sessionId,
+        messageId: message.id,
+        taskId: message.taskId,
+        next: message.next,
+        reportStatus: message.reportStatus,
+        deliveryStatus: "queued",
+      },
+    });
+
+    const queuedItem = queueTmuxAgentDispatch({
+      missionId: input.missionId,
+      agent: input.toAgent,
+      sessionId,
+      sessionTitle: target.sessionTitle,
+      parts: composed.payloadParts,
+      system,
+      ...(model ? { model } : {}),
+      ...(variant ? { variant } : {}),
+      activityBody: "Queued tmux team-message delivery.",
+    });
+
+    return {
+      createdAt: message.createdAt,
+      deliveryStatus: "queued",
+      messageId: message.id,
+      outboxItemId: queuedItem.id,
+      sessionId,
+    };
+  }
+
   try {
-    const _result = await client.session.promptAsync({
+    const _result = await target.client.session.promptAsync({
       sessionID: sessionId,
       parts: composed.payloadParts,
       agent: input.toAgent,
@@ -272,7 +350,12 @@ async function deliverMissionMessage(
         deliveryStatus: "sent",
       },
     });
-    return { sessionId, messageId: message.id, createdAt: message.createdAt };
+    return {
+      createdAt: message.createdAt,
+      deliveryStatus: "sent",
+      messageId: message.id,
+      sessionId,
+    };
   } catch (error) {
     const failedEntry: MissionMessageLogEntry = {
       ...message,
@@ -302,19 +385,35 @@ export async function sendSimpleMessage(input: {
     activityKind: "team_message",
   });
 
-  recordDirectedTaskDelegation({
+  const banterEntries = recordDirectedTaskDelegation({
     missionId: input.missionId,
     fromAgent: "noctis",
     toAgent: input.toAgent,
     orchestratedBy: "noctis",
     canonicalMessage: input.body,
     createdAt: delivery.createdAt,
-    transport: {
-      deliveredToSessionId: delivery.sessionId,
-      deliveryStatus: "sent",
-      sessionId: delivery.sessionId,
-    },
+    ...((delivery.deliveryStatus === "sent" || delivery.deliveryStatus === "queued")
+      ? {
+          transport: {
+            deliveredToSessionId: delivery.sessionId,
+            deliveryStatus: delivery.deliveryStatus,
+            sessionId: delivery.sessionId,
+          },
+        }
+      : {}),
   });
+
+  if (delivery.deliveryStatus === "queued" && delivery.outboxItemId) {
+    updateTmuxDispatchItemRecordLinks({
+      missionId: input.missionId,
+      itemId: delivery.outboxItemId,
+      recordLinks: {
+        activityEntryId: `activity_${delivery.messageId}`,
+        conversationEntryIds: banterEntries.map((entry) => entry.id),
+        messageLogEntryId: delivery.messageId,
+      },
+    });
+  }
 
   return delivery;
 }
@@ -345,7 +444,7 @@ export async function sendWorkerReport(input: {
     workflowGuidance: input.workflowGuidance,
   });
 
-  recordDirectedReportReturn({
+  const banterEntries = recordDirectedReportReturn({
     missionId: input.missionId,
     fromAgent: input.fromAgent,
     toAgent: "noctis",
@@ -355,12 +454,28 @@ export async function sendWorkerReport(input: {
     reportStatus: input.reportStatus ?? "completed",
     reportBody: input.message,
     createdAt: delivery.createdAt,
-    transport: {
-      deliveredToSessionId: delivery.sessionId,
-      deliveryStatus: "sent",
-      sessionId: delivery.sessionId,
-    },
+    ...((delivery.deliveryStatus === "sent" || delivery.deliveryStatus === "queued")
+      ? {
+          transport: {
+            deliveredToSessionId: delivery.sessionId,
+            deliveryStatus: delivery.deliveryStatus,
+            sessionId: delivery.sessionId,
+          },
+        }
+      : {}),
   });
+
+  if (delivery.deliveryStatus === "queued" && delivery.outboxItemId) {
+    updateTmuxDispatchItemRecordLinks({
+      missionId: input.missionId,
+      itemId: delivery.outboxItemId,
+      recordLinks: {
+        activityEntryId: `activity_${delivery.messageId}`,
+        conversationEntryIds: banterEntries.map((entry) => entry.id),
+        messageLogEntryId: delivery.messageId,
+      },
+    });
+  }
 
   return delivery;
 }

--- a/web/app/lib/tmux-mission-activation.server.ts
+++ b/web/app/lib/tmux-mission-activation.server.ts
@@ -1,5 +1,4 @@
 import { getMission, getMissionPrimarySessionId } from "@/lib/mission-store";
-import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
 import { isSessionStatusActive, type SessionStatus } from "@/lib/session-status";
 import { readTmuxActiveMission, writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 import type { Mission } from "@/lib/types/mission";
@@ -23,24 +22,6 @@ function getRelevantMissionSessionIds(mission: Mission): string[] {
   ].filter((sessionId, index, values): sessionId is string => {
     return typeof sessionId === "string" && sessionId.length > 0 && values.indexOf(sessionId) === index;
   });
-}
-
-function hasActiveDelegationWork(mission: Mission): boolean {
-  if (mission.delegationLedger.activeTasks.length > 0) {
-    return true;
-  }
-
-  return (
-    mission.operationState?.delegatedTasks?.some(
-      (task: { status?: string }) => task.status === "dispatched",
-    ) ?? false
-  );
-}
-
-function hasPendingPrimaryOutboxWork(missionId: string): boolean {
-  return listPrimaryAgentOutboxItems(missionId).some(
-    (item) => item.status === "pending" || item.status === "leased",
-  );
 }
 
 function coerceStatusesById(result: Record<string, unknown> | undefined, sessionIds: string[]): Record<string, SessionStatus> {
@@ -77,10 +58,6 @@ export async function getTmuxMissionWriteConflict(input: {
   const mission = getMission(activeMission.missionId);
   if (!mission) {
     return null;
-  }
-
-  if (hasPendingPrimaryOutboxWork(mission.id) || hasActiveDelegationWork(mission)) {
-    return { activeMissionId: mission.id };
   }
 
   const relevantSessionIds = getRelevantMissionSessionIds(mission);

--- a/web/app/lib/types/mission.ts
+++ b/web/app/lib/types/mission.ts
@@ -220,7 +220,7 @@ export interface MissionActivitySource {
   taskId?: string;
   next?: WorkflowNext;
   reportStatus?: ReportStatus;
-  deliveryStatus?: "sent" | "failed";
+  deliveryStatus?: "queued" | "sent" | "failed";
   lunafreyaFacetSnapshot?: LunafreyaFacetSnapshot;
 }
 
@@ -249,7 +249,7 @@ export interface BanterEntryPayload {
 
 export interface BanterTransport {
   deliveredToSessionId?: string;
-  deliveryStatus?: "sent" | "failed";
+  deliveryStatus?: "queued" | "sent" | "failed";
   error?: string;
   sessionId?: string;
 }
@@ -297,7 +297,7 @@ export interface TeamMessage {
 
 export interface MissionMessageLogEntry extends TeamMessage {
   deliveredToSessionId: string;
-  deliveryStatus: "sent" | "failed";
+  deliveryStatus: "queued" | "sent" | "failed";
   error?: string;
 }
 

--- a/web/app/routes/api.session.$id.test.ts
+++ b/web/app/routes/api.session.$id.test.ts
@@ -367,6 +367,9 @@ describe("api.session.$id", () => {
         tool: "apply_patch",
         state: {
           status: "completed",
+          input: { patch: "*** Begin Patch" },
+          output: "done",
+          error: "",
         },
       },
     ]);

--- a/web/app/routes/api.session.$id.test.ts
+++ b/web/app/routes/api.session.$id.test.ts
@@ -299,7 +299,7 @@ describe("api.session.$id", () => {
     expect(data.messages[1]?.info.selectionAdjustment).toBeUndefined();
   });
 
-  it("returns summary-mode session parts while preserving inspectable session content", async () => {
+  it("returns full session parts for transcript-first history responses", async () => {
     process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
     sessionMessagesMock.mockResolvedValue({
       data: [
@@ -350,13 +350,14 @@ describe("api.session.$id", () => {
       messages: Array<{
         detailState?: string;
         parts: unknown[];
-        summary?: {
-          content?: string;
-        };
       }>;
     }>(response);
-    expect(data.messages[0]?.detailState).toBe("summary");
+    expect(data.messages[0]?.detailState).toBe("full");
     expect(data.messages[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: '<team-message from="noctis" to="user">Visible reply.</team-message>',
+      },
       {
         type: "reasoning",
         text: "Need a follow-up.",
@@ -369,8 +370,46 @@ describe("api.session.$id", () => {
         },
       },
     ]);
-    expect(data.messages[0]?.summary).toMatchObject({
-      content: "Visible reply.",
+  });
+
+  it("preserves routed worker report envelopes in initial session history", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    sessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "worker-report-1",
+            role: "user",
+            agent: "noctis",
+            time: { created: Date.parse("2026-04-29T12:14:00.000Z") },
+          },
+          parts: [
+            {
+              type: "text",
+              text: [
+                "<operation-prompt>",
+                '<worker-report from="ignis" to="noctis" next="COMPLETE">',
+                "Implemented the requested change.",
+                "</worker-report>",
+                "</operation-prompt>",
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
     });
+
+    const response = await loader({ params: { id: "session-worker-report" } } as never);
+    expect(response.status).toBe(200);
+
+    const data = await readJson<{
+      messages: Array<{
+        detailState?: string;
+        parts: Array<{ type: string; text?: string }>;
+      }>;
+    }>(response);
+
+    expect(data.messages[0]?.detailState).toBe("full");
+    expect(data.messages[0]?.parts[0]?.text).toContain('<worker-report from="ignis" to="noctis"');
   });
 });

--- a/web/app/routes/api.session.$id.ts
+++ b/web/app/routes/api.session.$id.ts
@@ -24,11 +24,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
     }
 
     const anchors = listSessionRequestAnchors(sessionId);
-    const messages = sanitizeSessionMessages(
-      (result.data ?? []) as RawSessionMessage[],
-      anchors,
-      { detailState: "summary" },
-    );
+    const messages = sanitizeSessionMessages((result.data ?? []) as RawSessionMessage[], anchors);
 
     return Response.json({ executionContext, messages });
   } catch {


### PR DESCRIPTION
## Summary

- route worker task dispatches through the tmux outbox and dispatcher with lazy worker-session creation on the owning agent endpoint
- send Noctis team messages and worker reports through the same durable tmux transport path instead of the inline app-owned prompt flow
- add mission transport lifecycle helpers, queued-item reconciliation, and a short dispatcher cooldown between queued writes

## Motivation

Issue #59 moves the worker write path onto the same tmux transport model as the primary-agent flow. The goal is to keep delegation, team messaging, and report returns durable while preserving lazy worker sessions for Ignis, Gladiolus, and Prompto.

## Changes Overview

- add worker-targeted outbox lifecycle helpers and mission transport metadata so queued, leased, and submitted items can be tracked consistently
- update worker dispatch, session-owner routing, and team-message delivery to enqueue tmux transport items on the correct owner endpoint
- preserve Noctis-team orchestration behavior for delegated tasks, worker replies, and Prompto participation without falling back to app-owned transport
- add runtime and regression coverage around queued dispatch state, worker-session ownership, team-message delivery, and dispatcher pacing

## Testing

- [x] `npm run web:typecheck`
- [x] `node --test scripts/tmux_transport_runtime.test.mjs`
- [x] Updated regression coverage in `web/app/lib/execution-workspace-sessions.test.ts`, `web/app/lib/mission-primary-agent-outbox.server.test.ts`, and `web/app/lib/primary-agent-outbox-dispatch.server.test.ts`
- [ ] Focused Vitest execution for the updated web helper tests is still blocked in this environment by the local `ENOSPC` watcher limit

## Related Issues

Closes #59

## Notes

- No screenshots are included because this change is transport and runtime focused.
- The branch also includes a follow-up cooldown between queued tmux dispatches to reduce write contention when multiple worker items are submitted back-to-back.
