### PR TITLE
Implement tmux transport recovery and mission visibility flows

### DIFF
--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -3,6 +3,8 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 
 const AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto", "lunafreya", "iris"] as const;
+const ABORT_REQUEST_DIR = "tmux-transport-aborts";
+const CURRENT_DISPATCH_FILE = "tmux-transport-current-dispatch.json";
 const DISPATCHER_STATE_FILE = "tmux-transport-dispatcher.json";
 const LOOP_INTERVAL_MS = 200;
 const NEXT_DISPATCH_DELAY_MS = 3_000;
@@ -12,7 +14,30 @@ const STALE_LEASE_MS = 5_000;
 const TMUX_INTERACTION_DELAY_SECONDS = "0.5";
 
 type AgentId = (typeof AGENT_IDS)[number];
+type TmuxDispatchPhase =
+  | "switch-session"
+  | "switch-model"
+  | "switch-variant"
+  | "typing-payload"
+  | "submit-payload";
 type TmuxDispatchStatus = "pending" | "leased" | "submitted" | "failed" | "cancelled";
+
+type AbortRequestRecord = {
+  missionId: string;
+  requestedAt: string;
+  requestedBy: string;
+  sessionId: string;
+};
+
+type CurrentDispatchRecord = {
+  agent: AgentId;
+  itemId: string;
+  missionId: string;
+  phase: TmuxDispatchPhase;
+  sessionId: string;
+  target: string;
+  updatedAt: string;
+};
 
 type TmuxDispatchItem = {
   createdAt: string;
@@ -57,8 +82,25 @@ type TmuxDispatchItem = {
     failedBy: string;
     reason: string;
   };
+  cancellation?: {
+    cancelledAt: string;
+    cancelledBy: string;
+    reason: string;
+  };
   updatedAt: string;
 };
+
+class DispatchAbortError extends Error {
+  cancelledAt: string;
+  cancelledBy: string;
+
+  constructor(input: { cancelledAt: string; cancelledBy: string; phase: TmuxDispatchPhase }) {
+    super(`Managed session abort requested during ${input.phase}`);
+    this.name = "DispatchAbortError";
+    this.cancelledAt = input.cancelledAt;
+    this.cancelledBy = input.cancelledBy;
+  }
+}
 
 function parseRoot(argv: string[]): string {
   const rootIndex = argv.indexOf("--root");
@@ -71,6 +113,18 @@ function parseRoot(argv: string[]): string {
 
 function getDispatcherStatePath(root: string): string {
   return join(root, "runtime", DISPATCHER_STATE_FILE);
+}
+
+function getAbortRequestDir(root: string): string {
+  return join(root, "runtime", ABORT_REQUEST_DIR);
+}
+
+function getAbortRequestPath(root: string, sessionId: string): string {
+  return join(getAbortRequestDir(root), `${sessionId}.json`);
+}
+
+function getCurrentDispatchPath(root: string): string {
+  return join(root, "runtime", CURRENT_DISPATCH_FILE);
 }
 
 function getMissionStorePath(root: string): string {
@@ -116,6 +170,7 @@ function writeState(root: string, extra: Record<string, unknown> = {}): void {
 
 function cleanup(root: string): void {
   rmSync(getDispatcherStatePath(root), { force: true });
+  rmSync(getCurrentDispatchPath(root), { force: true });
 }
 
 function isOutboxStatus(value: unknown): value is TmuxDispatchStatus {
@@ -130,6 +185,67 @@ function isOutboxStatus(value: unknown): value is TmuxDispatchStatus {
 
 function isAgentId(value: unknown): value is AgentId {
   return AGENT_IDS.some((agentId) => agentId === value);
+}
+
+function isDispatchPhase(value: unknown): value is TmuxDispatchPhase {
+  return (
+    value === "switch-session" ||
+    value === "switch-model" ||
+    value === "switch-variant" ||
+    value === "typing-payload" ||
+    value === "submit-payload"
+  );
+}
+
+function normalizeAbortRequest(value: unknown): AbortRequestRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.missionId !== "string" ||
+    typeof record.requestedAt !== "string" ||
+    typeof record.requestedBy !== "string" ||
+    typeof record.sessionId !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    missionId: record.missionId,
+    requestedAt: record.requestedAt,
+    requestedBy: record.requestedBy,
+    sessionId: record.sessionId,
+  };
+}
+
+function readAbortRequest(root: string, sessionId: string): AbortRequestRecord | null {
+  const path = getAbortRequestPath(root, sessionId);
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    return normalizeAbortRequest(JSON.parse(readFileSync(path, "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+function clearAbortRequest(root: string, sessionId: string): void {
+  rmSync(getAbortRequestPath(root, sessionId), { force: true });
+}
+
+function writeCurrentDispatch(root: string, record: CurrentDispatchRecord | null): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+
+  if (!record) {
+    rmSync(getCurrentDispatchPath(root), { force: true });
+    return;
+  }
+
+  writeFileSync(getCurrentDispatchPath(root), `${JSON.stringify(record, null, 2)}\n`, "utf-8");
 }
 
 function normalizeItem(value: unknown): TmuxDispatchItem | null {
@@ -301,15 +417,58 @@ function waitForTmuxInteraction(root: string): void {
   }
 }
 
+function maybeAbortDispatch(input: {
+  root: string;
+  item: TmuxDispatchItem;
+  target: string;
+  phase: TmuxDispatchPhase;
+  interactionState: { hasSentInput: boolean };
+}): void {
+  writeCurrentDispatch(input.root, {
+    agent: input.item.payload.agent,
+    itemId: input.item.id,
+    missionId: input.item.missionId,
+    phase: input.phase,
+    sessionId: input.item.payload.sessionId,
+    target: input.target,
+    updatedAt: new Date().toISOString(),
+  });
+
+  const abortRequest = readAbortRequest(input.root, input.item.payload.sessionId);
+  if (!abortRequest || abortRequest.missionId !== input.item.missionId) {
+    return;
+  }
+
+  clearAbortRequest(input.root, input.item.payload.sessionId);
+
+  if (input.interactionState.hasSentInput) {
+    const result = runTmux(input.root, ["send-keys", "-t", input.target, "C-c"]);
+    if (result.code !== 0) {
+      throw new Error(result.stderr || `Failed to cancel tmux dispatch for ${input.target}`);
+    }
+  }
+
+  throw new DispatchAbortError({
+    cancelledAt: abortRequest.requestedAt,
+    cancelledBy: abortRequest.requestedBy,
+    phase: input.phase,
+  });
+}
+
 function sendTmuxKeys(
   root: string,
+  item: TmuxDispatchItem,
   target: string,
   args: string[],
+  phase: TmuxDispatchPhase,
   errorMessage: string,
   interactionState: { hasSentInput: boolean },
 ): void {
+  maybeAbortDispatch({ root, item, target, phase, interactionState });
+
   if (interactionState.hasSentInput) {
     waitForTmuxInteraction(root);
+    maybeAbortDispatch({ root, item, target, phase, interactionState });
   }
 
   const result = runTmux(root, ["send-keys", "-t", target, ...args]);
@@ -376,26 +535,40 @@ function activateManagedSession(
   interactionState: { hasSentInput: boolean },
 ): void {
   const sessionTitle = resolveManagedSessionTitle(item);
-  sendTmuxKeys(root, target, ["C-p"], `Failed to open command palette for ${target}`, interactionState);
+  sendTmuxKeys(root, item, target, ["C-p"], "switch-session", `Failed to open command palette for ${target}`, interactionState);
   sendTmuxKeys(
     root,
+    item,
     target,
     ["-l", "Switch session"],
+    "switch-session",
     `Failed to queue session switch command for ${target}`,
     interactionState,
   );
-  sendTmuxKeys(root, target, ["Enter"], `Failed to submit session switch command for ${target}`, interactionState);
   sendTmuxKeys(
     root,
+    item,
+    target,
+    ["Enter"],
+    "switch-session",
+    `Failed to submit session switch command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    item,
     target,
     ["-l", sessionTitle],
+    "switch-session",
     `Failed to select session ${sessionTitle} for ${target}`,
     interactionState,
   );
   sendTmuxKeys(
     root,
+    item,
     target,
     ["Enter"],
+    "switch-session",
     `Failed to confirm session ${sessionTitle} for ${target}`,
     interactionState,
   );
@@ -413,26 +586,40 @@ function applyModelSelection(
 
   const modelRef = `${item.payload.model.providerID}/${item.payload.model.modelID}`;
   const selectionText = readCatalogModelSelectionText(root, item.payload.model) ?? modelRef;
-  sendTmuxKeys(root, target, ["C-p"], `Failed to open command palette for ${target}`, interactionState);
+  sendTmuxKeys(root, item, target, ["C-p"], "switch-model", `Failed to open command palette for ${target}`, interactionState);
   sendTmuxKeys(
     root,
+    item,
     target,
     ["-l", "Switch model"],
+    "switch-model",
     `Failed to queue model command for ${target}`,
     interactionState,
   );
-  sendTmuxKeys(root, target, ["Enter"], `Failed to submit model command for ${target}`, interactionState);
   sendTmuxKeys(
     root,
+    item,
+    target,
+    ["Enter"],
+    "switch-model",
+    `Failed to submit model command for ${target}`,
+    interactionState,
+  );
+  sendTmuxKeys(
+    root,
+    item,
     target,
     ["-l", selectionText],
+    "switch-model",
     `Failed to select model ${selectionText} for ${target}`,
     interactionState,
   );
   sendTmuxKeys(
     root,
+    item,
     target,
     ["Enter"],
+    "switch-model",
     `Failed to confirm model ${selectionText} for ${target}`,
     interactionState,
   );
@@ -441,32 +628,40 @@ function applyModelSelection(
     return;
   }
 
-  sendTmuxKeys(root, target, ["C-p"], `Failed to reopen command palette for ${target}`, interactionState);
+  sendTmuxKeys(root, item, target, ["C-p"], "switch-variant", `Failed to reopen command palette for ${target}`, interactionState);
   sendTmuxKeys(
     root,
+    item,
     target,
     ["-l", "Switch model variant"],
+    "switch-variant",
     `Failed to queue model variant command for ${target}`,
     interactionState,
   );
   sendTmuxKeys(
     root,
+    item,
     target,
     ["Enter"],
+    "switch-variant",
     `Failed to submit model variant command for ${target}`,
     interactionState,
   );
   sendTmuxKeys(
     root,
+    item,
     target,
     ["-l", item.payload.variant],
+    "switch-variant",
     `Failed to select variant ${item.payload.variant} for ${target}`,
     interactionState,
   );
   sendTmuxKeys(
     root,
+    item,
     target,
     ["Enter"],
+    "switch-variant",
     `Failed to confirm variant ${item.payload.variant} for ${target}`,
     interactionState,
   );
@@ -481,21 +676,42 @@ function submitClaimedItem(root: string, item: TmuxDispatchItem): void {
   const target = `${SESSION_NAME}:main.${paneIndex}`;
   const payload = buildDispatchText(item);
   const interactionState = { hasSentInput: false };
-  activateManagedSession(root, target, item, interactionState);
-  applyModelSelection(root, target, item, interactionState);
-  sendTmuxKeys(root, target, ["-l", payload], `Failed to send outbox payload to ${target}`, interactionState);
-  sendTmuxKeys(root, target, ["Enter"], `Failed to submit outbox payload to ${target}`, interactionState);
+  try {
+    activateManagedSession(root, target, item, interactionState);
+    applyModelSelection(root, target, item, interactionState);
+    sendTmuxKeys(
+      root,
+      item,
+      target,
+      ["-l", payload],
+      "typing-payload",
+      `Failed to send outbox payload to ${target}`,
+      interactionState,
+    );
+    sendTmuxKeys(
+      root,
+      item,
+      target,
+      ["Enter"],
+      "submit-payload",
+      `Failed to submit outbox payload to ${target}`,
+      interactionState,
+    );
 
-  writeItem(root, {
-    ...item,
-    status: "submitted",
-    updatedAt: new Date().toISOString(),
-    submission: {
-      dispatcherPid: process.pid,
-      submittedAt: new Date().toISOString(),
-      submittedBy: `dispatcher:${process.pid}`,
-    },
-  });
+    const submittedAt = new Date().toISOString();
+    writeItem(root, {
+      ...item,
+      status: "submitted",
+      updatedAt: submittedAt,
+      submission: {
+        dispatcherPid: process.pid,
+        submittedAt,
+        submittedBy: `dispatcher:${process.pid}`,
+      },
+    });
+  } finally {
+    writeCurrentDispatch(root, null);
+  }
 }
 
 function countQueuedItems(root: string): number {
@@ -530,18 +746,31 @@ const tick = () => {
     });
   } catch (error) {
     if (claimed) {
-      const failedAt = new Date().toISOString();
-      writeItem(root, {
-        ...claimed,
-        status: "failed",
-        updatedAt: failedAt,
-        failure: {
-          dispatcherPid: process.pid,
-          failedAt,
-          failedBy: `dispatcher:${process.pid}`,
-          reason: error instanceof Error ? error.message : String(error),
-        },
-      });
+      if (error instanceof DispatchAbortError) {
+        writeItem(root, {
+          ...claimed,
+          status: "cancelled",
+          updatedAt: error.cancelledAt,
+          cancellation: {
+            cancelledAt: error.cancelledAt,
+            cancelledBy: error.cancelledBy,
+            reason: error.message,
+          },
+        });
+      } else {
+        const failedAt = new Date().toISOString();
+        writeItem(root, {
+          ...claimed,
+          status: "failed",
+          updatedAt: failedAt,
+          failure: {
+            dispatcherPid: process.pid,
+            failedAt,
+            failedBy: `dispatcher:${process.pid}`,
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
     }
 
     writeState(root, {

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -12,7 +12,7 @@ const STALE_LEASE_MS = 5_000;
 const TMUX_INTERACTION_DELAY_SECONDS = "0.5";
 
 type AgentId = (typeof AGENT_IDS)[number];
-type TmuxDispatchStatus = "pending" | "leased" | "submitted";
+type TmuxDispatchStatus = "pending" | "leased" | "submitted" | "failed" | "cancelled";
 
 type TmuxDispatchItem = {
   createdAt: string;
@@ -50,6 +50,12 @@ type TmuxDispatchItem = {
     dispatcherPid?: number;
     submittedAt: string;
     submittedBy: string;
+  };
+  failure?: {
+    dispatcherPid?: number;
+    failedAt: string;
+    failedBy: string;
+    reason: string;
   };
   updatedAt: string;
 };
@@ -113,7 +119,13 @@ function cleanup(root: string): void {
 }
 
 function isOutboxStatus(value: unknown): value is TmuxDispatchStatus {
-  return value === "pending" || value === "leased" || value === "submitted";
+  return (
+    value === "pending" ||
+    value === "leased" ||
+    value === "submitted" ||
+    value === "failed" ||
+    value === "cancelled"
+  );
 }
 
 function isAgentId(value: unknown): value is AgentId {
@@ -213,7 +225,7 @@ function isStale(item: TmuxDispatchItem, now: string): boolean {
 }
 
 function writeItem(root: string, item: TmuxDispatchItem): void {
-  for (const status of ["pending", "leased", "submitted"] as const) {
+  for (const status of ["pending", "leased", "submitted", "failed", "cancelled"] as const) {
     mkdirSync(getOutboxStateDir(root, item.missionId, status), { recursive: true });
     rmSync(getOutboxItemPath(root, item.missionId, status, item.id), { force: true });
   }
@@ -498,10 +510,12 @@ let nextDispatchNotBefore = 0;
 const dispatcherStartedAt = new Date().toISOString();
 
 const tick = () => {
+  let claimed: TmuxDispatchItem | null = null;
+
   try {
     const nowDate = new Date();
     const now = nowDate.toISOString();
-    const claimed = nowDate.getTime() >= nextDispatchNotBefore ? claimNextItem(root, now) : null;
+    claimed = nowDate.getTime() >= nextDispatchNotBefore ? claimNextItem(root, now) : null;
     if (claimed) {
       submitClaimedItem(root, claimed);
       processedCount += 1;
@@ -515,6 +529,21 @@ const tick = () => {
       startedAt: dispatcherStartedAt,
     });
   } catch (error) {
+    if (claimed) {
+      const failedAt = new Date().toISOString();
+      writeItem(root, {
+        ...claimed,
+        status: "failed",
+        updatedAt: failedAt,
+        failure: {
+          dispatcherPid: process.pid,
+          failedAt,
+          failedBy: `dispatcher:${process.pid}`,
+          reason: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+
     writeState(root, {
       lastActivityAt: new Date().toISOString(),
       lastError: error instanceof Error ? error.message : String(error),

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -38,6 +38,15 @@ if [ -n "\${TMUX_STUB_FAIL_ON:-}" ] && [[ "\$*" == *"\${TMUX_STUB_FAIL_ON}"* ]];
   exit 1
 fi
 
+if [ -n "\${TMUX_STUB_PAUSE_ON:-}" ] && [[ "$*" == *"\${TMUX_STUB_PAUSE_ON}"* ]]; then
+  SIGNAL_FILE="\${TMUX_STUB_PAUSE_SIGNAL_FILE:-\${ROOT}/tmux-pause-signal}"
+  RESUME_FILE="\${TMUX_STUB_RESUME_FILE:-\${ROOT}/tmux-pause-resume}"
+  : > "$SIGNAL_FILE"
+  while [ ! -f "$RESUME_FILE" ]; do
+    /bin/sleep 0.05
+  done
+fi
+
 case "\${1:-}" in
   has-session)
     if [ -f "\$SESSION_FILE" ]; then
@@ -219,6 +228,9 @@ function seedStaleLeasedPrimaryAgentOutbox(root, missionId) {
 
 test.afterEach(() => {
   delete process.env.TMUX_STUB_FAIL_ON;
+  delete process.env.TMUX_STUB_PAUSE_ON;
+  delete process.env.TMUX_STUB_PAUSE_SIGNAL_FILE;
+  delete process.env.TMUX_STUB_RESUME_FILE;
 
   while (tempRoots.length > 0) {
     const root = tempRoots.pop();
@@ -327,6 +339,91 @@ test("dispatcher retains failed artifacts when tmux submission fails", async () 
   assert.equal(failed.status, "failed");
   assert.equal(failed.failure.failedBy.startsWith("dispatcher:"), true);
   assert.match(failed.failure.reason, /forced tmux failure/);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher cancels a claimed dispatch when an abort request arrives mid-flight", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedPrimaryAgentOutbox(root, "mission-dispatch-abort", {
+    itemId: "item-dispatch-abort-1",
+    model: {
+      providerID: "github-copilot",
+      modelID: "gpt-5-mini",
+    },
+    sessionId: "session-dispatch-abort-1",
+  });
+
+  const pauseSignalPath = join(root, "tmux-pause-signal");
+  const pauseResumePath = join(root, "tmux-pause-resume");
+  const currentDispatchPath = join(root, "runtime", "tmux-transport-current-dispatch.json");
+  const abortRequestDir = join(root, "runtime", "tmux-transport-aborts");
+  const abortRequestPath = join(abortRequestDir, "session-dispatch-abort-1.json");
+  process.env.TMUX_STUB_PAUSE_ON = "Switch model";
+  process.env.TMUX_STUB_PAUSE_SIGNAL_FILE = pauseSignalPath;
+  process.env.TMUX_STUB_RESUME_FILE = pauseResumePath;
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  assert.equal(await waitFor(() => existsSync(pauseSignalPath), 3_000), true);
+  assert.equal(await waitFor(() => existsSync(currentDispatchPath), 3_000), true);
+
+  const currentDispatch = JSON.parse(readFileSync(currentDispatchPath, "utf-8"));
+  assert.equal(currentDispatch.sessionId, "session-dispatch-abort-1");
+  assert.equal(currentDispatch.itemId, "item-dispatch-abort-1");
+  assert.equal(currentDispatch.phase, "switch-model");
+
+  mkdirSync(abortRequestDir, { recursive: true });
+  writeFileSync(
+    abortRequestPath,
+    `${JSON.stringify(
+      {
+        missionId: "mission-dispatch-abort",
+        sessionId: "session-dispatch-abort-1",
+        requestedAt: "2026-04-30T10:00:00.000Z",
+        requestedBy: "test-suite",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  writeFileSync(pauseResumePath, "resume\n", "utf-8");
+
+  const cancelledPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch-abort",
+    "transport",
+    "primary-agent-outbox",
+    "cancelled",
+    "item-dispatch-abort-1.json",
+  );
+  const submittedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch-abort",
+    "transport",
+    "primary-agent-outbox",
+    "submitted",
+    "item-dispatch-abort-1.json",
+  );
+
+  assert.equal(await waitFor(() => existsSync(cancelledPath), 3_000), true);
+  assert.equal(existsSync(submittedPath), false);
+
+  const cancelled = JSON.parse(readFileSync(cancelledPath, "utf-8"));
+  assert.equal(cancelled.status, "cancelled");
+  assert.match(cancelled.cancellation.reason, /abort/i);
+
+  const tmuxLog = readFileSync(join(root, "tmux.log"), "utf-8");
+  assert.match(tmuxLog, /send-keys -t ff15:main\.4 C-c/);
+  assert.doesNotMatch(tmuxLog, /queued prompt body/);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/scripts/tmux_transport_runtime.test.mjs
+++ b/scripts/tmux_transport_runtime.test.mjs
@@ -33,6 +33,11 @@ LOG="\${ROOT}/tmux.log"
 SESSION_FILE="\${ROOT}/tmux-session"
 printf '%s\n' "\$*" >> "\$LOG"
 
+if [ -n "\${TMUX_STUB_FAIL_ON:-}" ] && [[ "\$*" == *"\${TMUX_STUB_FAIL_ON}"* ]]; then
+  printf '%s\n' "forced tmux failure: \$*" >&2
+  exit 1
+fi
+
 case "\${1:-}" in
   has-session)
     if [ -f "\$SESSION_FILE" ]; then
@@ -213,6 +218,8 @@ function seedStaleLeasedPrimaryAgentOutbox(root, missionId) {
 }
 
 test.afterEach(() => {
+  delete process.env.TMUX_STUB_FAIL_ON;
+
   while (tempRoots.length > 0) {
     const root = tempRoots.pop();
     if (root) {
@@ -290,6 +297,36 @@ test("dispatcher submits queued primary-agent outbox items and retains submitted
   assert.match(tmuxLog, /queued prompt body/);
   assert.match(tmuxLog, /queued system body/);
   assert.match(tmuxLog, /send-keys -t ff15:main\.4 -l/);
+
+  const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
+  assert.equal(stopResult.code, 0, stopResult.stderr);
+});
+
+test("dispatcher retains failed artifacts when tmux submission fails", async () => {
+  const root = createTempRoot();
+  installFakeTmux(root);
+  seedPrimaryAgentOutbox(root, "mission-dispatch-failed");
+  process.env.TMUX_STUB_FAIL_ON = "[tmux-dispatch]";
+
+  const startResult = await runRuntimeControl(root, ["start", "--root", root]);
+  assert.equal(startResult.code, 0, startResult.stderr);
+
+  const failedPath = join(
+    root,
+    "runtime",
+    "noctis-missions",
+    "mission-dispatch-failed",
+    "transport",
+    "primary-agent-outbox",
+    "failed",
+    "item-dispatch-1.json",
+  );
+  assert.equal(await waitFor(() => existsSync(failedPath), 3_000), true);
+
+  const failed = JSON.parse(readFileSync(failedPath, "utf-8"));
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.failure.failedBy.startsWith("dispatcher:"), true);
+  assert.match(failed.failure.reason, /forced tmux failure/);
 
   const stopResult = await runRuntimeControl(root, ["stop", "--root", root]);
   assert.equal(stopResult.code, 0, stopResult.stderr);

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -367,6 +367,45 @@ export interface MissionSummary {
   activitySessionIds: string[];
 }
 
+export type MissionTransportStatus = "pending" | "submitted" | "failed" | "cancelled";
+
+export type MissionTransportSummary = {
+  pending: number;
+  submitted: number;
+  failed: number;
+  cancelled: number;
+  blocked: number;
+};
+
+export type MissionTransportArtifact = {
+  id: string;
+  missionId: string;
+  createdAt: string;
+  updatedAt: string;
+  status: MissionTransportStatus;
+  payload: {
+    agent: string;
+    sessionId: string;
+    sessionTitle?: string;
+  };
+  failure?: {
+    failedAt: string;
+    failedBy: string;
+    reason: string;
+  };
+  cancellation?: {
+    cancelledAt: string;
+    cancelledBy: string;
+    reason: string;
+  };
+  replay?: {
+    replayedAt: string;
+    replayedBy: string;
+    sourceItemId?: string;
+    supersededByItemId?: string;
+  };
+};
+
 export type MissionResumePayload = {
   missionId: string;
   schemaVersion?: number | null;
@@ -401,6 +440,8 @@ export type MissionResumePayload = {
   operationState?: OperationState | null;
   workflowProgress?: MissionWorkflowProgress | null;
   lunafreyaFacetSelection?: LunafreyaFacetSelection | null;
+  primaryAgentOutbox?: MissionTransportArtifact[];
+  transportSummary?: MissionTransportSummary;
   activityLog?: MissionActivityLogEntry[];
 };
 

--- a/web/app/lib/mission-api.server.ts
+++ b/web/app/lib/mission-api.server.ts
@@ -20,8 +20,60 @@ import {
 import { getMissionSurfaceForMission } from "./mission-surface";
 import { buildMissionWorkflowProgress } from "./mission-workflow-progress.server";
 
+function toMissionTransportStatus(status: string): "pending" | "submitted" | "failed" | "cancelled" {
+  switch (status) {
+    case "submitted":
+      return "submitted";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "pending";
+  }
+}
+
+function toMissionDeliveryStatus(status: string): "queued" | "sent" | "failed" | "cancelled" {
+  switch (status) {
+    case "submitted":
+      return "sent";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "queued";
+  }
+}
+
+function normalizeMissionPrimaryAgentOutbox(mission: Mission) {
+  return listPrimaryAgentOutboxItems(mission.id).map((item) => ({
+    ...item,
+    status: toMissionTransportStatus(item.status),
+  }));
+}
+
+function buildMissionTransportSummary(
+  primaryAgentOutbox: Array<{ status: "pending" | "submitted" | "failed" | "cancelled" }>,
+  blockedCount: number,
+) {
+  return primaryAgentOutbox.reduce(
+    (summary, item) => {
+      summary[item.status] += 1;
+      return summary;
+    },
+    {
+      pending: 0,
+      submitted: 0,
+      failed: 0,
+      cancelled: 0,
+      blocked: blockedCount,
+    },
+  );
+}
+
 function reconcileQueuedDispatchState(mission: Mission) {
-  const primaryAgentOutbox = listPrimaryAgentOutboxItems(mission.id);
+  const primaryAgentOutbox = normalizeMissionPrimaryAgentOutbox(mission);
   const updates = primaryAgentOutbox
     .map((item) => {
       const recordLinks = item.payload.recordLinks;
@@ -31,7 +83,7 @@ function reconcileQueuedDispatchState(mission: Mission) {
 
       return {
         ...recordLinks,
-        deliveryStatus: item.status === "submitted" ? ("sent" as const) : ("queued" as const),
+        deliveryStatus: toMissionDeliveryStatus(item.status),
         sessionId: item.payload.sessionId,
       };
     })
@@ -92,6 +144,7 @@ export function buildMissionResumePayload(mission: Mission) {
   const primarySessionId = getMissionPrimarySessionId(mission);
   const resumeBlock = getMissionResumeBlock(mission);
   const primaryAgentOutbox = reconcileQueuedDispatchState(mission);
+  const transportSummary = buildMissionTransportSummary(primaryAgentOutbox, resumeBlock ? 1 : 0);
 
   return {
     missionId: mission.id,
@@ -122,6 +175,7 @@ export function buildMissionResumePayload(mission: Mission) {
     workflowProgress: buildMissionWorkflowProgress(mission.operationState),
     lunafreyaFacetSelection: mission.lunafreyaFacetSelection ?? null,
     primaryAgentOutbox,
+    transportSummary,
     activityLog: mission.activityLog,
   };
 }

--- a/web/app/lib/mission-primary-agent-outbox.server.test.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.test.ts
@@ -11,8 +11,11 @@ import {
   leaseTmuxDispatchItem,
   listPrimaryAgentOutboxItems,
   listTmuxDispatchItems,
+  markTmuxDispatchItemCancelled,
+  markTmuxDispatchItemFailed,
   markPrimaryAgentOutboxItemSubmitted,
   markTmuxDispatchItemSubmitted,
+  replayTmuxDispatchItem,
   updateTmuxDispatchItemRecordLinks,
 } from "./mission-primary-agent-outbox.server";
 
@@ -243,6 +246,188 @@ describe("mission primary-agent outbox", () => {
 
     expect(submitted.status).toBe("submitted");
     expect(listTmuxDispatchItems(mission.id)).toEqual([submitted]);
+  });
+
+  it("retains failed tmux dispatch artifacts with failure metadata", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-failed", "session-primary-failed", {
+      title: "Failed Dispatch Mission",
+      objective: "Verify failed artifact retention",
+    });
+    missionIds.push(mission.id);
+
+    enqueueTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-failed-1",
+      createdAt: "2026-04-28T00:25:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis-failed",
+        parts: [{ type: "text", text: "generic failed prompt" }],
+      },
+    });
+
+    const leased = leaseTmuxDispatchItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-failed",
+      leasedAt: "2026-04-28T00:26:00.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    expect(leased?.status).toBe("leased");
+
+    const failed = markTmuxDispatchItemFailed({
+      missionId: mission.id,
+      itemId: "item-failed-1",
+      failedAt: "2026-04-28T00:27:00.000Z",
+      failedBy: "dispatcher-failed",
+      reason: "tmux submit failed",
+      dispatcherPid: 8181,
+    });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.failure).toEqual({
+      dispatcherPid: 8181,
+      failedAt: "2026-04-28T00:27:00.000Z",
+      failedBy: "dispatcher-failed",
+      reason: "tmux submit failed",
+    });
+
+    const failedPath = join(
+      getMissionDir(mission.id),
+      "transport",
+      "primary-agent-outbox",
+      "failed",
+      "item-failed-1.json",
+    );
+    expect(existsSync(failedPath)).toBe(true);
+    expect(listTmuxDispatchItems(mission.id)).toEqual([failed]);
+  });
+
+  it("retains cancelled tmux dispatch artifacts with cancellation metadata", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-cancelled", "session-primary-cancelled", {
+      title: "Cancelled Dispatch Mission",
+      objective: "Verify cancelled artifact retention",
+    });
+    missionIds.push(mission.id);
+
+    enqueueTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-cancelled-1",
+      createdAt: "2026-04-28T00:28:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis-cancelled",
+        parts: [{ type: "text", text: "generic cancelled prompt" }],
+      },
+    });
+
+    const leased = leaseTmuxDispatchItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-cancelled",
+      leasedAt: "2026-04-28T00:29:00.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    expect(leased?.status).toBe("leased");
+
+    const cancelled = markTmuxDispatchItemCancelled({
+      missionId: mission.id,
+      itemId: "item-cancelled-1",
+      cancelledAt: "2026-04-28T00:29:30.000Z",
+      cancelledBy: "abort-route",
+      reason: "mission abort requested",
+    });
+
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.cancellation).toEqual({
+      cancelledAt: "2026-04-28T00:29:30.000Z",
+      cancelledBy: "abort-route",
+      reason: "mission abort requested",
+    });
+
+    const cancelledPath = join(
+      getMissionDir(mission.id),
+      "transport",
+      "primary-agent-outbox",
+      "cancelled",
+      "item-cancelled-1.json",
+    );
+    expect(existsSync(cancelledPath)).toBe(true);
+    expect(listTmuxDispatchItems(mission.id)).toEqual([cancelled]);
+  });
+
+  it("creates an exact-replay tmux dispatch attempt without mutating the failed artifact", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-outbox-replay", "session-primary-replay", {
+      title: "Replay Dispatch Mission",
+      objective: "Verify exact replay retention",
+    });
+    missionIds.push(mission.id);
+
+    enqueueTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-replay-source",
+      createdAt: "2026-04-28T00:31:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis-replay",
+        sessionTitle: `mission:${mission.id}:ignis`,
+        parts: [{ type: "text", text: "generic replay prompt" }],
+        variant: "fast",
+      },
+    });
+
+    leaseTmuxDispatchItem({
+      missionId: mission.id,
+      leaseOwner: "dispatcher-replay",
+      leasedAt: "2026-04-28T00:32:00.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    const failed = markTmuxDispatchItemFailed({
+      missionId: mission.id,
+      itemId: "item-replay-source",
+      failedAt: "2026-04-28T00:33:00.000Z",
+      failedBy: "dispatcher-replay",
+      reason: "tmux submit failed",
+    });
+
+    const replay = replayTmuxDispatchItem({
+      missionId: mission.id,
+      itemId: "item-replay-source",
+      replayItemId: "item-replay-attempt-2",
+      replayedAt: "2026-04-28T00:34:00.000Z",
+      replayedBy: "user-manual-resend",
+    });
+
+    expect(replay).toMatchObject({
+      id: "item-replay-attempt-2",
+      status: "pending",
+      payload: failed.payload,
+      replay: {
+        sourceItemId: "item-replay-source",
+        replayedAt: "2026-04-28T00:34:00.000Z",
+        replayedBy: "user-manual-resend",
+      },
+    });
+
+    expect(listTmuxDispatchItems(mission.id)).toEqual([
+      {
+        ...failed,
+        updatedAt: "2026-04-28T00:34:00.000Z",
+        replay: {
+          replayedAt: "2026-04-28T00:34:00.000Z",
+          replayedBy: "user-manual-resend",
+          supersededByItemId: "item-replay-attempt-2",
+        },
+      },
+      replay,
+    ]);
   });
 
   it("stores record links on queued tmux dispatch items", () => {

--- a/web/app/lib/mission-primary-agent-outbox.server.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.ts
@@ -7,7 +7,7 @@ import type { TextPromptPart } from "./prompt-parts";
 import type { AgentId, ModelSelection } from "./types/mission";
 
 const PRIMARY_AGENT_OUTBOX_DIR = "primary-agent-outbox";
-const OUTBOX_STATUSES = ["pending", "leased", "submitted"] as const;
+const OUTBOX_STATUSES = ["pending", "leased", "submitted", "failed", "cancelled"] as const;
 
 export type PrimaryAgentOutboxStatus = (typeof OUTBOX_STATUSES)[number];
 export type TmuxDispatchStatus = PrimaryAgentOutboxStatus;
@@ -35,6 +35,29 @@ export interface PrimaryAgentOutboxSubmission {
   submittedBy: string;
 }
 export type TmuxDispatchSubmission = PrimaryAgentOutboxSubmission;
+
+export interface PrimaryAgentOutboxFailure {
+  dispatcherPid?: number;
+  failedAt: string;
+  failedBy: string;
+  reason: string;
+}
+export type TmuxDispatchFailure = PrimaryAgentOutboxFailure;
+
+export interface PrimaryAgentOutboxCancellation {
+  cancelledAt: string;
+  cancelledBy: string;
+  reason: string;
+}
+export type TmuxDispatchCancellation = PrimaryAgentOutboxCancellation;
+
+export interface PrimaryAgentOutboxReplay {
+  replayedAt: string;
+  replayedBy: string;
+  sourceItemId?: string;
+  supersededByItemId?: string;
+}
+export type TmuxDispatchReplay = PrimaryAgentOutboxReplay;
 
 export interface PrimaryAgentOutboxRecordLinks {
   activityEntryId?: string;
@@ -64,6 +87,9 @@ export interface PrimaryAgentOutboxItem {
   payload: PrimaryAgentOutboxPayload;
   lease?: PrimaryAgentOutboxLease;
   submission?: PrimaryAgentOutboxSubmission;
+  failure?: PrimaryAgentOutboxFailure;
+  cancellation?: PrimaryAgentOutboxCancellation;
+  replay?: PrimaryAgentOutboxReplay;
 }
 export type TmuxDispatchItem = PrimaryAgentOutboxItem;
 
@@ -234,6 +260,73 @@ function normalizeSubmission(value: unknown): PrimaryAgentOutboxSubmission | und
   };
 }
 
+function normalizeFailure(value: unknown): PrimaryAgentOutboxFailure | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.failedAt !== "string" ||
+    typeof record.failedBy !== "string" ||
+    typeof record.reason !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    failedAt: record.failedAt,
+    failedBy: record.failedBy,
+    reason: record.reason,
+    ...(typeof record.dispatcherPid === "number" ? { dispatcherPid: record.dispatcherPid } : {}),
+  };
+}
+
+function normalizeCancellation(value: unknown): PrimaryAgentOutboxCancellation | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.cancelledAt !== "string" ||
+    typeof record.cancelledBy !== "string" ||
+    typeof record.reason !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    cancelledAt: record.cancelledAt,
+    cancelledBy: record.cancelledBy,
+    reason: record.reason,
+  };
+}
+
+function normalizeReplay(value: unknown): PrimaryAgentOutboxReplay | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.replayedAt !== "string" || typeof record.replayedBy !== "string") {
+    return undefined;
+  }
+
+  const sourceItemId = normalizeString(record.sourceItemId);
+  const supersededByItemId = normalizeString(record.supersededByItemId);
+  if (!sourceItemId && !supersededByItemId) {
+    return undefined;
+  }
+
+  return {
+    replayedAt: record.replayedAt,
+    replayedBy: record.replayedBy,
+    ...(sourceItemId ? { sourceItemId } : {}),
+    ...(supersededByItemId ? { supersededByItemId } : {}),
+  };
+}
+
 function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -261,6 +354,11 @@ function normalizeItem(value: unknown): PrimaryAgentOutboxItem | null {
     ...(normalizeSubmission(record.submission)
       ? { submission: normalizeSubmission(record.submission) }
       : {}),
+    ...(normalizeFailure(record.failure) ? { failure: normalizeFailure(record.failure) } : {}),
+    ...(normalizeCancellation(record.cancellation)
+      ? { cancellation: normalizeCancellation(record.cancellation) }
+      : {}),
+    ...(normalizeReplay(record.replay) ? { replay: normalizeReplay(record.replay) } : {}),
   };
 }
 
@@ -493,6 +591,167 @@ export function markTmuxDispatchItemSubmitted(input: {
   dispatcherPid?: number;
 }): TmuxDispatchItem {
   return markPrimaryAgentOutboxItemSubmitted(input);
+}
+
+export function markPrimaryAgentOutboxItemFailed(input: {
+  missionId: string;
+  itemId: string;
+  failedAt?: string;
+  failedBy: string;
+  reason: string;
+  dispatcherPid?: number;
+}): PrimaryAgentOutboxItem {
+  const record = findItem(input.missionId, input.itemId);
+  if (!record) {
+    throw new Error(`Primary-agent outbox item not found: ${input.itemId}`);
+  }
+
+  const failedAt = input.failedAt ?? new Date().toISOString();
+  const item: PrimaryAgentOutboxItem = {
+    ...record.item,
+    status: "failed",
+    updatedAt: failedAt,
+    failure: {
+      failedAt,
+      failedBy: input.failedBy,
+      reason: input.reason,
+      ...(typeof input.dispatcherPid === "number" ? { dispatcherPid: input.dispatcherPid } : {}),
+    },
+  };
+
+  writeItem(item, record.status);
+  return item;
+}
+
+export function markTmuxDispatchItemFailed(input: {
+  missionId: string;
+  itemId: string;
+  failedAt: string;
+  failedBy: string;
+  reason: string;
+  dispatcherPid?: number;
+}): TmuxDispatchItem {
+  return markPrimaryAgentOutboxItemFailed(input);
+}
+
+export function markPrimaryAgentOutboxItemCancelled(input: {
+  missionId: string;
+  itemId: string;
+  cancelledAt?: string;
+  cancelledBy: string;
+  reason: string;
+}): PrimaryAgentOutboxItem {
+  const record = findItem(input.missionId, input.itemId);
+  if (!record) {
+    throw new Error(`Primary-agent outbox item not found: ${input.itemId}`);
+  }
+
+  const cancelledAt = input.cancelledAt ?? new Date().toISOString();
+  const item: PrimaryAgentOutboxItem = {
+    ...record.item,
+    status: "cancelled",
+    updatedAt: cancelledAt,
+    cancellation: {
+      cancelledAt,
+      cancelledBy: input.cancelledBy,
+      reason: input.reason,
+    },
+  };
+
+  writeItem(item, record.status);
+  return item;
+}
+
+export function markTmuxDispatchItemCancelled(input: {
+  missionId: string;
+  itemId: string;
+  cancelledAt: string;
+  cancelledBy: string;
+  reason: string;
+}): TmuxDispatchItem {
+  return markPrimaryAgentOutboxItemCancelled(input);
+}
+
+export function replayPrimaryAgentOutboxItem(input: {
+  missionId: string;
+  itemId: string;
+  replayItemId?: string;
+  replayedAt?: string;
+  replayedBy: string;
+}): PrimaryAgentOutboxItem {
+  const record = findItem(input.missionId, input.itemId);
+  if (!record) {
+    throw new Error(`Primary-agent outbox item not found: ${input.itemId}`);
+  }
+
+  if (record.item.status !== "failed") {
+    throw new Error(`Only failed tmux dispatch items can be replayed: ${input.itemId}`);
+  }
+
+  const replayedAt = input.replayedAt ?? new Date().toISOString();
+  const replayItem: PrimaryAgentOutboxItem = {
+    ...enqueuePrimaryAgentOutboxItem({
+      missionId: input.missionId,
+      itemId: input.replayItemId,
+      createdAt: replayedAt,
+      payload: record.item.payload,
+    }),
+    replay: {
+      replayedAt,
+      replayedBy: input.replayedBy,
+      sourceItemId: record.item.id,
+    },
+  };
+  writeItem(replayItem, "pending");
+
+  const supersededItem: PrimaryAgentOutboxItem = {
+    ...record.item,
+    updatedAt: replayedAt,
+    replay: {
+      replayedAt,
+      replayedBy: input.replayedBy,
+      supersededByItemId: replayItem.id,
+    },
+  };
+  writeItem(supersededItem, record.status);
+
+  return replayItem;
+}
+
+export function replayTmuxDispatchItem(input: {
+  missionId: string;
+  itemId: string;
+  replayItemId?: string;
+  replayedAt?: string;
+  replayedBy: string;
+}): TmuxDispatchItem {
+  return replayPrimaryAgentOutboxItem(input);
+}
+
+export function cancelTmuxDispatchItemsForSession(input: {
+  missionId: string;
+  sessionId: string;
+  cancelledAt?: string;
+  cancelledBy: string;
+  reason: string;
+}): TmuxDispatchItem[] {
+  const cancelledAt = input.cancelledAt ?? new Date().toISOString();
+
+  return listTmuxDispatchItems(input.missionId)
+    .filter(
+      (item) =>
+        item.payload.sessionId === input.sessionId &&
+        (item.status === "pending" || item.status === "leased"),
+    )
+    .map((item) =>
+      markTmuxDispatchItemCancelled({
+        missionId: input.missionId,
+        itemId: item.id,
+        cancelledAt,
+        cancelledBy: input.cancelledBy,
+        reason: input.reason,
+      }),
+    );
 }
 
 export function updateTmuxDispatchItemRecordLinks(input: {

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -968,7 +968,7 @@ export function reconcileMissionTmuxDispatchStatuses(
   updates: Array<{
     activityEntryId?: string;
     conversationEntryIds?: string[];
-    deliveryStatus: "queued" | "sent";
+    deliveryStatus: "queued" | "sent" | "failed" | "cancelled" | "blocked";
     messageLogEntryId?: string;
     sessionId: string;
   }>,

--- a/web/app/lib/tmux-transport-abort.server.test.ts
+++ b/web/app/lib/tmux-transport-abort.server.test.ts
@@ -1,0 +1,153 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  interruptManagedTmuxSession,
+  requestTmuxDispatchAbortForSession,
+  TMUX_TRANSPORT_ABORT_REQUEST_DIR,
+  TMUX_TRANSPORT_CURRENT_DISPATCH_FILE,
+} from "./tmux-transport-abort.server";
+
+const originalPath = process.env.PATH ?? "";
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-tmux-abort-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  mkdirSync(join(root, "bin"), { recursive: true });
+  return root;
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content, { encoding: "utf-8", mode: 0o755 });
+}
+
+function installFakeTmux(root: string): string {
+  const binDir = join(root, "bin");
+  const logPath = join(root, "tmux.log");
+  writeExecutable(
+    join(binDir, "tmux"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${logPath}"
+`,
+  );
+  process.env.PATH = `${binDir}:${originalPath}`;
+  return logPath;
+}
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("tmux transport abort helper", () => {
+  it("writes an abort request when the current dispatch matches the managed session", () => {
+    const root = createTempRoot();
+    writeFileSync(
+      join(root, "runtime", TMUX_TRANSPORT_CURRENT_DISPATCH_FILE),
+      `${JSON.stringify(
+        {
+          agent: "ignis",
+          itemId: "item-1",
+          missionId: "mission-1",
+          phase: "switch-model",
+          sessionId: "session-1",
+          target: "ff15:main.1",
+          updatedAt: "2026-04-30T10:00:00.000Z",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    const result = requestTmuxDispatchAbortForSession({
+      missionId: "mission-1",
+      requestedAt: "2026-04-30T10:00:05.000Z",
+      requestedBy: "abort-route",
+      root,
+      sessionId: "session-1",
+    });
+
+    expect(result).toEqual({
+      currentDispatch: expect.objectContaining({
+        itemId: "item-1",
+        phase: "switch-model",
+      }),
+      requested: true,
+    });
+
+    const abortRequestPath = join(
+      root,
+      "runtime",
+      TMUX_TRANSPORT_ABORT_REQUEST_DIR,
+      "session-1.json",
+    );
+    expect(existsSync(abortRequestPath)).toBe(true);
+    expect(JSON.parse(readFileSync(abortRequestPath, "utf-8"))).toEqual({
+      missionId: "mission-1",
+      requestedAt: "2026-04-30T10:00:05.000Z",
+      requestedBy: "abort-route",
+      sessionId: "session-1",
+    });
+  });
+
+  it("ignores abort requests for other managed sessions", () => {
+    const root = createTempRoot();
+    writeFileSync(
+      join(root, "runtime", TMUX_TRANSPORT_CURRENT_DISPATCH_FILE),
+      `${JSON.stringify(
+        {
+          agent: "ignis",
+          itemId: "item-2",
+          missionId: "mission-2",
+          phase: "typing-payload",
+          sessionId: "session-2",
+          target: "ff15:main.1",
+          updatedAt: "2026-04-30T10:01:00.000Z",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    const result = requestTmuxDispatchAbortForSession({
+      missionId: "mission-1",
+      requestedBy: "abort-route",
+      root,
+      sessionId: "session-1",
+    });
+
+    expect(result).toEqual({
+      currentDispatch: expect.objectContaining({ itemId: "item-2" }),
+      requested: false,
+    });
+    expect(
+      existsSync(join(root, "runtime", TMUX_TRANSPORT_ABORT_REQUEST_DIR, "session-1.json")),
+    ).toBe(false);
+  });
+
+  it("sends Escape to the owner pane for active tmux-managed responses", () => {
+    const root = createTempRoot();
+    const logPath = installFakeTmux(root);
+
+    interruptManagedTmuxSession({
+      method: "escape",
+      ownerAgent: "prompto",
+      root,
+    });
+
+    expect(readFileSync(logPath, "utf-8").trim()).toBe("send-keys -t ff15:main.3 Escape");
+  });
+});

--- a/web/app/lib/tmux-transport-abort.server.ts
+++ b/web/app/lib/tmux-transport-abort.server.ts
@@ -1,0 +1,174 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getProjectRoot } from "@/lib/get-project-root.server";
+import type { AgentId } from "@/lib/types/mission";
+
+export const TMUX_TRANSPORT_ABORT_REQUEST_DIR = "tmux-transport-aborts";
+export const TMUX_TRANSPORT_CURRENT_DISPATCH_FILE = "tmux-transport-current-dispatch.json";
+
+const TMUX_AGENT_PANE_INDEX: Record<AgentId, number> = {
+  noctis: 0,
+  ignis: 1,
+  gladiolus: 2,
+  prompto: 3,
+  lunafreya: 4,
+};
+const TMUX_SESSION_NAME = "ff15";
+
+export type TmuxDispatchPhase =
+  | "switch-session"
+  | "switch-model"
+  | "switch-variant"
+  | "typing-payload"
+  | "submit-payload";
+
+export type ManagedTmuxInterruptMethod = "ctrl-c" | "escape";
+
+export interface TmuxCurrentDispatchRecord {
+  agent: AgentId;
+  itemId: string;
+  missionId: string;
+  phase: TmuxDispatchPhase;
+  sessionId: string;
+  target: string;
+  updatedAt: string;
+}
+
+function getAbortRequestDir(root: string): string {
+  return join(root, "runtime", TMUX_TRANSPORT_ABORT_REQUEST_DIR);
+}
+
+function getAbortRequestPath(root: string, sessionId: string): string {
+  return join(getAbortRequestDir(root), `${sessionId}.json`);
+}
+
+function getCurrentDispatchPath(root: string): string {
+  return join(root, "runtime", TMUX_TRANSPORT_CURRENT_DISPATCH_FILE);
+}
+
+function isDispatchPhase(value: unknown): value is TmuxDispatchPhase {
+  return (
+    value === "switch-session" ||
+    value === "switch-model" ||
+    value === "switch-variant" ||
+    value === "typing-payload" ||
+    value === "submit-payload"
+  );
+}
+
+function isAgentId(value: unknown): value is AgentId {
+  return value === "noctis" || value === "ignis" || value === "gladiolus" || value === "prompto" || value === "lunafreya";
+}
+
+function normalizeCurrentDispatch(value: unknown): TmuxCurrentDispatchRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    !isAgentId(record.agent) ||
+    typeof record.itemId !== "string" ||
+    typeof record.missionId !== "string" ||
+    !isDispatchPhase(record.phase) ||
+    typeof record.sessionId !== "string" ||
+    typeof record.target !== "string" ||
+    typeof record.updatedAt !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    agent: record.agent,
+    itemId: record.itemId,
+    missionId: record.missionId,
+    phase: record.phase,
+    sessionId: record.sessionId,
+    target: record.target,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function toTmuxKey(method: ManagedTmuxInterruptMethod): "C-c" | "Escape" {
+  return method === "ctrl-c" ? "C-c" : "Escape";
+}
+
+export function readCurrentTmuxDispatch(root = getProjectRoot()): TmuxCurrentDispatchRecord | null {
+  const currentDispatchPath = getCurrentDispatchPath(root);
+  if (!existsSync(currentDispatchPath)) {
+    return null;
+  }
+
+  try {
+    return normalizeCurrentDispatch(JSON.parse(readFileSync(currentDispatchPath, "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+export function requestTmuxDispatchAbortForSession(input: {
+  missionId: string;
+  requestedAt?: string;
+  requestedBy: string;
+  root?: string;
+  sessionId: string;
+}): {
+  currentDispatch: TmuxCurrentDispatchRecord | null;
+  requested: boolean;
+} {
+  const root = input.root ?? getProjectRoot();
+  const currentDispatch = readCurrentTmuxDispatch(root);
+
+  if (
+    !currentDispatch ||
+    currentDispatch.missionId !== input.missionId ||
+    currentDispatch.sessionId !== input.sessionId
+  ) {
+    return {
+      currentDispatch,
+      requested: false,
+    };
+  }
+
+  const requestedAt = input.requestedAt ?? new Date().toISOString();
+  mkdirSync(getAbortRequestDir(root), { recursive: true });
+  writeFileSync(
+    getAbortRequestPath(root, input.sessionId),
+    `${JSON.stringify(
+      {
+        missionId: input.missionId,
+        requestedAt,
+        requestedBy: input.requestedBy,
+        sessionId: input.sessionId,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+
+  return {
+    currentDispatch,
+    requested: true,
+  };
+}
+
+export function interruptManagedTmuxSession(input: {
+  method: ManagedTmuxInterruptMethod;
+  ownerAgent: AgentId;
+  root?: string;
+}): void {
+  const root = input.root ?? getProjectRoot();
+  const target = `${TMUX_SESSION_NAME}:main.${TMUX_AGENT_PANE_INDEX[input.ownerAgent]}`;
+  const key = toTmuxKey(input.method);
+  const result = spawnSync("tmux", ["send-keys", "-t", target, key], {
+    cwd: root,
+    encoding: "utf-8",
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(result.stderr || `Failed to send ${key} to ${target}`);
+  }
+}

--- a/web/app/lib/types/mission.ts
+++ b/web/app/lib/types/mission.ts
@@ -220,7 +220,7 @@ export interface MissionActivitySource {
   taskId?: string;
   next?: WorkflowNext;
   reportStatus?: ReportStatus;
-  deliveryStatus?: "queued" | "sent" | "failed";
+  deliveryStatus?: "queued" | "sent" | "failed" | "cancelled" | "blocked";
   lunafreyaFacetSnapshot?: LunafreyaFacetSnapshot;
 }
 
@@ -249,7 +249,7 @@ export interface BanterEntryPayload {
 
 export interface BanterTransport {
   deliveredToSessionId?: string;
-  deliveryStatus?: "queued" | "sent" | "failed";
+  deliveryStatus?: "queued" | "sent" | "failed" | "cancelled" | "blocked";
   error?: string;
   sessionId?: string;
 }
@@ -297,7 +297,7 @@ export interface TeamMessage {
 
 export interface MissionMessageLogEntry extends TeamMessage {
   deliveredToSessionId: string;
-  deliveryStatus: "queued" | "sent" | "failed";
+  deliveryStatus: "queued" | "sent" | "failed" | "cancelled" | "blocked";
   error?: string;
 }
 

--- a/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
@@ -578,6 +578,63 @@ describe("chat-area", () => {
     expect(markup).toContain("Guided mission flow.");
   });
 
+  it("shows a retry bubble for the latest failed delivery above the composer", () => {
+    const markup = renderToStaticMarkup(
+      <ChatArea
+        messages={[]}
+        historyPhase="ready"
+        isResponding={false}
+        missionExecutionLabel="Core Repo"
+        contextProjects={[]}
+        availableOperations={[]}
+        selectedOperation={null}
+        activeOperationState={null}
+        isOperationSelectionLocked={true}
+        failedDeliveryNotice={{
+          failedAt: "2026-04-29T09:15:00.000Z",
+          itemId: "item-failed-latest",
+          isResending: false,
+          onResend: () => undefined,
+          reason: "tmux submit failed",
+        }}
+        onSelectedOperationChange={() => undefined}
+        onSend={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Delivery failed");
+    expect(markup).toContain("tmux submit failed");
+    expect(markup).toContain("Resend");
+  });
+
+  it("disables resend while a failed delivery is being replayed", () => {
+    const markup = renderToStaticMarkup(
+      <ChatArea
+        messages={[]}
+        historyPhase="ready"
+        isResponding={false}
+        missionExecutionLabel="Core Repo"
+        contextProjects={[]}
+        availableOperations={[]}
+        selectedOperation={null}
+        activeOperationState={null}
+        isOperationSelectionLocked={true}
+        failedDeliveryNotice={{
+          failedAt: "2026-04-29T09:15:00.000Z",
+          itemId: "item-failed-latest",
+          isResending: true,
+          onResend: () => undefined,
+          reason: "tmux submit failed",
+        }}
+        onSelectedOperationChange={() => undefined}
+        onSend={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Resending...");
+    expect(markup).toContain("disabled");
+  });
+
   it("shows a transcript error state distinct from an empty transcript", () => {
     const markup = renderToStaticMarkup(
       <ChatArea

--- a/web/app/routes/_layout.noctis-team/components/chat-area.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.tsx
@@ -120,6 +120,13 @@ interface ChatAreaProps {
   primaryAgentId?: ActivityActorId;
   primaryAgentAvatarSrc?: string;
   primaryAgentLabel?: string;
+  failedDeliveryNotice?: {
+    itemId: string;
+    failedAt: string;
+    reason: string;
+    isResending: boolean;
+    onResend: () => void;
+  } | null;
   composerStatusLabel?: string | null;
   composerPlaceholder?: string;
   startingMissionDescription?: string;
@@ -799,6 +806,7 @@ export const ChatArea = ({
   primaryAgentId = "noctis",
   primaryAgentAvatarSrc = "/images/noctis.png",
   primaryAgentLabel = "Noctis",
+  failedDeliveryNotice = null,
   composerStatusLabel = null,
   composerPlaceholder,
   startingMissionDescription = "Preparing mission and briefing Noctis.",
@@ -1014,6 +1022,27 @@ export const ChatArea = ({
       </p>
     </div>
   ) : null;
+  const failedDeliveryCallout = failedDeliveryNotice ? (
+    <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2.5" role="status">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-rose-100/90">
+            Delivery failed
+          </p>
+          <p className="text-xs leading-relaxed text-foreground/85">{failedDeliveryNotice.reason}</p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={failedDeliveryNotice.isResending}
+          onClick={failedDeliveryNotice.onResend}
+        >
+          {failedDeliveryNotice.isResending ? "Resending..." : "Resend"}
+        </Button>
+      </div>
+    </div>
+  ) : null;
   const workflowSelector = (
     <Select
       disabled={isOperationSelectionLocked || isMissionStartPending}
@@ -1079,6 +1108,7 @@ export const ChatArea = ({
           topSlot={
             <div className="space-y-3">
               {abortSettlementCallout}
+              {failedDeliveryCallout}
               {showExecutionProjectSelector ? (
                 <div className="space-y-3">
                   {missionStartPendingCallout}

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
@@ -119,6 +119,7 @@ vi.mock("./chat-area", () => ({
     primaryAgentId,
     headerTitle,
     composerStatusLabel,
+    failedDeliveryNotice,
   }: {
     showExecutionProjectSelector?: boolean;
     selectedExecutionProjectId?: string | null;
@@ -139,6 +140,11 @@ vi.mock("./chat-area", () => ({
     primaryAgentId?: string | null;
     headerTitle?: string | null;
     composerStatusLabel?: string | null;
+    failedDeliveryNotice?: {
+      itemId: string;
+      isResending: boolean;
+      reason: string;
+    } | null;
     workflowProgress?: {
       currentStepIndex: number;
       totalSteps: number;
@@ -158,6 +164,11 @@ vi.mock("./chat-area", () => ({
       <div>{`primary-agent:${primaryAgentId ?? "none"}`}</div>
       {headerTitle ? <div>{`header:${headerTitle}`}</div> : null}
       {composerStatusLabel ? <div>{`composer-status:${composerStatusLabel}`}</div> : null}
+      {failedDeliveryNotice ? (
+        <div>
+          {`failed-delivery:${failedDeliveryNotice.itemId}:${failedDeliveryNotice.reason}:${failedDeliveryNotice.isResending ? "resending" : "idle"}`}
+        </div>
+      ) : null}
       {workflowProgress ? (
         <div>{`workflow-progress:${workflowProgress.currentStepIndex}/${workflowProgress.totalSteps}:${workflowProgress.status}:${workflowProgress.currentStep}`}</div>
       ) : null}
@@ -352,6 +363,79 @@ describe("noctis-team-screen", () => {
 
     expect(markup).toContain("cannot resume until an execution project is assigned");
     expect(markup).toContain("Assign Execution Project");
+  });
+
+  it("passes only the latest retryable failed delivery into the chat area", () => {
+    paramsMock.mockReturnValue({ id: "mission-1" });
+
+    const markup = renderToStaticMarkup(
+      <NoctisTeamScreen
+        activeMissionId="mission-1"
+        initialMissionData={buildMission({
+          primaryAgentOutbox: [
+            {
+              id: "item-old-failed",
+              missionId: "mission-1",
+              createdAt: "2026-04-28T00:00:00.000Z",
+              updatedAt: "2026-04-28T00:00:00.000Z",
+              status: "failed",
+              payload: {
+                agent: "noctis",
+                sessionId: "session-1",
+              },
+              failure: {
+                failedAt: "2026-04-28T00:00:00.000Z",
+                failedBy: "dispatcher:test",
+                reason: "older failure",
+              },
+            },
+            {
+              id: "item-superseded-failed",
+              missionId: "mission-1",
+              createdAt: "2026-04-28T00:10:00.000Z",
+              updatedAt: "2026-04-28T00:10:00.000Z",
+              status: "failed",
+              payload: {
+                agent: "noctis",
+                sessionId: "session-1",
+              },
+              failure: {
+                failedAt: "2026-04-28T00:10:00.000Z",
+                failedBy: "dispatcher:test",
+                reason: "superseded failure",
+              },
+              replay: {
+                replayedAt: "2026-04-28T00:11:00.000Z",
+                replayedBy: "mission-route",
+                supersededByItemId: "item-replay-2",
+              },
+            },
+            {
+              id: "item-latest-failed",
+              missionId: "mission-1",
+              createdAt: "2026-04-28T00:20:00.000Z",
+              updatedAt: "2026-04-28T00:21:00.000Z",
+              status: "failed",
+              payload: {
+                agent: "noctis",
+                sessionId: "session-1",
+              },
+              failure: {
+                failedAt: "2026-04-28T00:21:00.000Z",
+                failedBy: "dispatcher:test",
+                reason: "latest failure",
+              },
+            },
+          ],
+        })}
+        language="other"
+      />,
+    );
+
+    expect(markup).toContain("failed-delivery:item-latest-failed:latest failure:idle");
+    expect(markup).not.toContain("failed-delivery:item-old-failed:older failure:idle");
+    expect(markup).not.toContain("item-superseded-failed");
+    expect(markup).not.toContain("transport-panel:");
   });
 
   it("shows an unsupported runtime alert for incompatible missions", () => {

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -181,6 +181,8 @@ export function NoctisTeamScreen({
   const [isDeleteWorkspaceDialogOpen, setIsDeleteWorkspaceDialogOpen] = useState(false);
   const [isSavingContext, setIsSavingContext] = useState(false);
   const [isDeletingWorkspace, setIsDeletingWorkspace] = useState(false);
+  const [replayingTransportItemId, setReplayingTransportItemId] = useState<string | null>(null);
+  const [dismissedFailedDeliveryItemId, setDismissedFailedDeliveryItemId] = useState<string | null>(null);
   const [lunafreyaJobOptions, setLunafreyaJobOptions] = useState<LunafreyaFacetOption[]>([]);
   const [lunafreyaSkillOptions, setLunafreyaSkillOptions] = useState<LunafreyaFacetOption[]>([]);
   const [selectedLunafreyaJobId, setSelectedLunafreyaJobId] = useState<string | null>(
@@ -334,6 +336,24 @@ export function NoctisTeamScreen({
             actionLabel: "Mission Details",
           }
         : null;
+  const latestRetryableFailedDelivery = useMemo(() => {
+    if (!effectiveMissionId) {
+      return null;
+    }
+
+    const entries = missionDetail?.primaryAgentOutbox ?? [];
+    return (
+      [...entries]
+        .filter(
+          (entry) =>
+            entry.status === "failed" &&
+            entry.payload.agent === primaryAgentId &&
+            !entry.replay?.supersededByItemId &&
+            entry.id !== dismissedFailedDeliveryItemId,
+        )
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0] ?? null
+    );
+  }, [dismissedFailedDeliveryItemId, effectiveMissionId, missionDetail?.primaryAgentOutbox, primaryAgentId]);
   const isWorkspaceDeleteDisabled =
     isDirectExecutionMission ||
     !effectiveMissionId ||
@@ -621,6 +641,7 @@ export function NoctisTeamScreen({
   }, [loadMissionOutputs]);
 
   useEffect(() => {
+    setDismissedFailedDeliveryItemId(null);
     void loadMissionDetail();
   }, [loadMissionDetail]);
 
@@ -1024,6 +1045,39 @@ export function NoctisTeamScreen({
     }
   }, [effectiveMissionId, loadMissionDetail, loadMissions, missionApiBase]);
 
+  const handleReplayTransportItem = useCallback(
+    async (itemId: string) => {
+      if (!effectiveMissionId) {
+        return;
+      }
+
+      setReplayingTransportItemId(itemId);
+      try {
+        const response = await fetch(`${missionApiBase}/${effectiveMissionId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "replay_tmux_dispatch", itemId }),
+        });
+        const result = (await response.json().catch(() => ({}))) as { error?: string };
+
+        if (!response.ok) {
+          throw new Error(result.error ?? `transport replay failed: ${response.status}`);
+        }
+
+        setDismissedFailedDeliveryItemId(itemId);
+        await loadMissionDetail();
+        toast.success("Queued exact replay resend");
+      } catch (error) {
+        toast.error("Unable to resend transport attempt", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        setReplayingTransportItemId(null);
+      }
+    },
+    [effectiveMissionId, loadMissionDetail, missionApiBase],
+  );
+
   const handleSelectOutput = useCallback((output: MissionOutputSummary) => {
     if (!effectiveMissionId) {
       return;
@@ -1235,6 +1289,22 @@ export function NoctisTeamScreen({
               primaryAgentId={primaryAgentId}
               primaryAgentAvatarSrc={surface.portraitSrc}
               primaryAgentLabel={primaryAgentLabel}
+              failedDeliveryNotice={
+                latestRetryableFailedDelivery
+                  ? {
+                      itemId: latestRetryableFailedDelivery.id,
+                      failedAt:
+                        latestRetryableFailedDelivery.failure?.failedAt ?? latestRetryableFailedDelivery.updatedAt,
+                      reason:
+                        latestRetryableFailedDelivery.failure?.reason ??
+                        "Unable to deliver the tmux request.",
+                      isResending: replayingTransportItemId === latestRetryableFailedDelivery.id,
+                      onResend: () => {
+                        void handleReplayTransportItem(latestRetryableFailedDelivery.id);
+                      },
+                    }
+                  : null
+              }
               composerStatusLabel={isLunafreyaSurface ? "Solo mission surface" : null}
               composerPlaceholder={`Send a message to ${primaryAgentLabel}`}
               startingMissionDescription={`Preparing mission and briefing ${primaryAgentLabel}.`}

--- a/web/app/routes/api.noctis.missions.$missionId.test.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.test.ts
@@ -4,14 +4,20 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createMission, deleteMission } from "@/lib/mission-store";
-import { enqueuePrimaryAgentOutboxItem } from "@/lib/mission-primary-agent-outbox.server";
+import {
+  enqueuePrimaryAgentOutboxItem,
+  leaseTmuxDispatchItem,
+  markTmuxDispatchItemCancelled,
+  markTmuxDispatchItemFailed,
+  markTmuxDispatchItemSubmitted,
+} from "@/lib/mission-primary-agent-outbox.server";
 import { createOperationState, saveOperationState } from "@/lib/operation-runtime/state";
 import {
   REVIEW_CYCLE_TEST_OPERATION_NAME,
   REVIEW_CYCLE_TEST_OPERATION_REF,
   writeReviewCycleTestOperation,
 } from "@/lib/test-fixtures/operation-fixtures";
-import { loader } from "./api.noctis.missions.$missionId";
+import { action, loader } from "./api.noctis.missions.$missionId";
 
 const tempRoots: string[] = [];
 const missionIds: string[] = [];
@@ -222,6 +228,183 @@ describe("api.noctis.missions.$missionId", () => {
             }),
           }),
         ],
+      }),
+    );
+  });
+
+  it("returns a high-level transport summary alongside retained outbox artifacts", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-transport-summary-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", {
+      title: "Transport summary mission",
+      objective: "Inspect transport summary state",
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-summary-pending",
+      createdAt: "2026-04-28T00:00:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "pending payload" }],
+      },
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-summary-submitted",
+      createdAt: "2026-04-28T00:01:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "submitted payload" }],
+      },
+    });
+    leaseTmuxDispatchItem({
+      missionId,
+      leaseOwner: "dispatcher-summary",
+      leasedAt: "2026-04-28T00:01:30.000Z",
+      staleAfterMs: 30_000,
+    });
+    markTmuxDispatchItemSubmitted({
+      missionId,
+      itemId: "item-summary-submitted",
+      submittedAt: "2026-04-28T00:02:00.000Z",
+      submittedBy: "dispatcher-summary",
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-summary-failed",
+      createdAt: "2026-04-28T00:03:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "failed payload" }],
+      },
+    });
+    markTmuxDispatchItemFailed({
+      missionId,
+      itemId: "item-summary-failed",
+      failedAt: "2026-04-28T00:03:30.000Z",
+      failedBy: "dispatcher-summary",
+      reason: "submit failed",
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-summary-cancelled",
+      createdAt: "2026-04-28T00:04:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "cancelled payload" }],
+      },
+    });
+    markTmuxDispatchItemCancelled({
+      missionId,
+      itemId: "item-summary-cancelled",
+      cancelledAt: "2026-04-28T00:04:30.000Z",
+      cancelledBy: "abort-route",
+      reason: "Managed session abort requested",
+    });
+
+    const response = await loader({ params: { missionId } } as never);
+    expect(response.status).toBe(200);
+
+    await expect(
+      readJson<{
+        transportSummary: {
+          blocked: number;
+          cancelled: number;
+          failed: number;
+          pending: number;
+          submitted: number;
+        };
+        primaryAgentOutbox: Array<{ id: string; status: string }>;
+      }>(response),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        transportSummary: {
+          pending: 1,
+          submitted: 1,
+          failed: 1,
+          cancelled: 1,
+          blocked: 1,
+        },
+        primaryAgentOutbox: [
+          expect.objectContaining({ id: "item-summary-pending", status: "pending" }),
+          expect.objectContaining({ id: "item-summary-submitted", status: "submitted" }),
+          expect.objectContaining({ id: "item-summary-failed", status: "failed" }),
+          expect.objectContaining({ id: "item-summary-cancelled", status: "cancelled" }),
+        ],
+      }),
+    );
+  });
+
+  it("creates an exact replay attempt for failed tmux dispatch artifacts", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-transport-replay-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", {
+      title: "Transport replay mission",
+      objective: "Replay failed transport artifact",
+      executionProjectId: "alpha",
+    });
+
+    enqueuePrimaryAgentOutboxItem({
+      missionId,
+      itemId: "item-replay-source",
+      createdAt: "2026-04-28T00:10:00.000Z",
+      payload: {
+        agent: "noctis",
+        sessionId: "session-noctis",
+        parts: [{ type: "text", text: "failed replay payload" }],
+      },
+    });
+    markTmuxDispatchItemFailed({
+      missionId,
+      itemId: "item-replay-source",
+      failedAt: "2026-04-28T00:10:30.000Z",
+      failedBy: "dispatcher-summary",
+      reason: "submit failed",
+    });
+
+    const response = await action({
+      params: { missionId },
+      request: new Request(`http://localhost/api/noctis/missions/${missionId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "replay_tmux_dispatch", itemId: "item-replay-source" }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+
+    await expect(
+      readJson<{
+        item: {
+          id: string;
+          replay: { sourceItemId: string };
+          status: string;
+        };
+        ok: boolean;
+      }>(response),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        item: expect.objectContaining({
+          status: "pending",
+          replay: expect.objectContaining({
+            sourceItemId: "item-replay-source",
+          }),
+        }),
       }),
     );
   });

--- a/web/app/routes/api.noctis.missions.$missionId.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.ts
@@ -1,5 +1,6 @@
 import { buildMissionResumePayload, missionMatchesSurface } from "@/lib/mission-api.server";
-import { getMission } from "@/lib/mission-store";
+import { replayTmuxDispatchItem } from "@/lib/mission-primary-agent-outbox.server";
+import { appendMissionActivity, getMission } from "@/lib/mission-store";
 import type { Route } from "./+types/api.noctis.missions.$missionId";
 
 export const loader = async ({ params }: Route.LoaderArgs) => {
@@ -14,4 +15,65 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
   }
 
   return Response.json(buildMissionResumePayload(mission));
+};
+
+export const action = async ({ params, request }: Route.ActionArgs) => {
+  const missionId = params.missionId;
+  if (!missionId) {
+    return Response.json({ error: "Missing missionId" }, { status: 400 });
+  }
+
+  const mission = getMission(missionId);
+  if (!mission || !missionMatchesSurface(mission, "noctis_team")) {
+    return Response.json({ error: "Mission not found" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const actionName =
+    body && typeof body === "object" && "action" in body ? (body as { action?: unknown }).action : null;
+  if (actionName !== "replay_tmux_dispatch") {
+    return Response.json({ error: "Unsupported mission action" }, { status: 400 });
+  }
+
+  const itemId =
+    body && typeof body === "object" && "itemId" in body ? (body as { itemId?: unknown }).itemId : null;
+  if (typeof itemId !== "string" || itemId.length === 0) {
+    return Response.json({ error: "Missing itemId" }, { status: 400 });
+  }
+
+  try {
+    const replayedAt = new Date().toISOString();
+    const item = replayTmuxDispatchItem({
+      missionId,
+      itemId,
+      replayedAt,
+      replayedBy: "mission-route",
+    });
+
+    appendMissionActivity(missionId, {
+      id: `activity_${crypto.randomUUID()}`,
+      actor: "system",
+      speaker: "system",
+      kind: "system_event",
+      body: "Queued exact-replay tmux resend for a failed transport attempt.",
+      createdAt: replayedAt,
+      source: {
+        type: "system",
+        sessionId: item.payload.sessionId,
+      },
+    });
+
+    return Response.json({ ok: true, item });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
 };

--- a/web/app/routes/api.session.$id.abort.test.ts
+++ b/web/app/routes/api.session.$id.abort.test.ts
@@ -4,6 +4,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createMission, deleteMission, getMission, setWorkerSession } from "@/lib/mission-store";
+import {
+  enqueueTmuxDispatchItem,
+  leaseTmuxDispatchItem,
+  listTmuxDispatchItems,
+} from "@/lib/mission-primary-agent-outbox.server";
 
 const {
   abortMock,
@@ -182,5 +187,84 @@ describe("api.session.$id.abort", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("cancels queued tmux work for the managed session before forwarding abort", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const missionId = `mission-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", { executionProjectId: "alpha" });
+    setWorkerSession(missionId, "ignis", "session-ignis");
+
+    enqueueTmuxDispatchItem({
+      missionId,
+      itemId: "item-abort-pending",
+      createdAt: "2026-04-28T01:00:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis",
+        parts: [{ type: "text", text: "pending worker payload" }],
+      },
+    });
+    enqueueTmuxDispatchItem({
+      missionId,
+      itemId: "item-abort-leased",
+      createdAt: "2026-04-28T01:01:00.000Z",
+      payload: {
+        agent: "ignis",
+        sessionId: "session-ignis",
+        parts: [{ type: "text", text: "leased worker payload" }],
+      },
+    });
+    leaseTmuxDispatchItem({
+      missionId,
+      leaseOwner: "dispatcher-abort",
+      leasedAt: "2026-04-28T01:01:30.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    resolvedSessionListMock.mockResolvedValue({
+      data: [{ id: "session-ignis", title: `mission:${missionId}:ignis` }],
+    });
+    resolvedAbortMock.mockResolvedValue({ data: { ok: true } });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          abort: resolvedAbortMock,
+          list: resolvedSessionListMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4403",
+      managedSession: {
+        missionId,
+        ownerAgent: "ignis",
+        ownerLabel: "Ignis",
+      },
+      mode: "managed",
+      ownerAgent: "ignis",
+    });
+
+    const response = await action({ params: { id: "session-ignis" } } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(listTmuxDispatchItems(missionId)).toEqual([
+      expect.objectContaining({
+        id: "item-abort-pending",
+        status: "cancelled",
+        cancellation: expect.objectContaining({
+          cancelledBy: "abort-route",
+          reason: "Managed session abort requested",
+        }),
+      }),
+      expect.objectContaining({
+        id: "item-abort-leased",
+        status: "cancelled",
+        cancellation: expect.objectContaining({
+          cancelledBy: "abort-route",
+          reason: "Managed session abort requested",
+        }),
+      }),
+    ]);
   });
 });

--- a/web/app/routes/api.session.$id.abort.test.ts
+++ b/web/app/routes/api.session.$id.abort.test.ts
@@ -13,6 +13,8 @@ import {
 const {
   abortMock,
   appendSessionPromptDebugLogMock,
+  interruptManagedTmuxSessionMock,
+  requestTmuxDispatchAbortForSessionMock,
   resolveSessionRouteTargetMock,
   resolvedAbortMock,
   resolvedSessionListMock,
@@ -20,6 +22,8 @@ const {
 } = vi.hoisted(() => ({
   abortMock: vi.fn(),
   appendSessionPromptDebugLogMock: vi.fn(),
+  interruptManagedTmuxSessionMock: vi.fn(),
+  requestTmuxDispatchAbortForSessionMock: vi.fn(),
   resolveSessionRouteTargetMock: vi.fn(),
   resolvedAbortMock: vi.fn(),
   resolvedSessionListMock: vi.fn(),
@@ -43,6 +47,11 @@ vi.mock("@/lib/session-owner-routing.server", () => ({
   resolveSessionRouteTarget: resolveSessionRouteTargetMock,
 }));
 
+vi.mock("@/lib/tmux-transport-abort.server", () => ({
+  interruptManagedTmuxSession: interruptManagedTmuxSessionMock,
+  requestTmuxDispatchAbortForSession: requestTmuxDispatchAbortForSessionMock,
+}));
+
 import { action } from "./api.session.$id.abort";
 
 const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
@@ -60,6 +69,8 @@ function createTempRoot(): string {
 afterEach(() => {
   abortMock.mockReset();
   appendSessionPromptDebugLogMock.mockReset();
+  interruptManagedTmuxSessionMock.mockReset();
+  requestTmuxDispatchAbortForSessionMock.mockReset();
   sessionListMock.mockReset();
 
   for (const missionId of missionIds.splice(0)) {
@@ -82,6 +93,10 @@ afterEach(() => {
 
 describe("api.session.$id.abort", () => {
   beforeEach(() => {
+    requestTmuxDispatchAbortForSessionMock.mockReturnValue({
+      currentDispatch: null,
+      requested: false,
+    });
     resolveSessionRouteTargetMock.mockImplementation(() => ({
       client: {
         session: {
@@ -266,5 +281,97 @@ describe("api.session.$id.abort", () => {
         }),
       }),
     ]);
+  });
+
+  it("requests dispatcher-side cancellation for pre-submit tmux dispatches", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const missionId = `mission-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", { executionProjectId: "alpha" });
+    getMission(missionId)!.transportMode = "tmux-resident";
+    setWorkerSession(missionId, "ignis", "session-ignis");
+
+    resolvedSessionListMock.mockResolvedValue({
+      data: [{ id: "session-ignis", title: `mission:${missionId}:ignis` }],
+    });
+    resolvedAbortMock.mockResolvedValue({ data: { ok: true } });
+    requestTmuxDispatchAbortForSessionMock.mockReturnValue({
+      currentDispatch: {
+        agent: "ignis",
+        itemId: "item-dispatch-1",
+        missionId,
+        phase: "switch-model",
+        sessionId: "session-ignis",
+        target: "ff15:main.1",
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      },
+      requested: true,
+    });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          abort: resolvedAbortMock,
+          list: resolvedSessionListMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4403",
+      managedSession: {
+        missionId,
+        ownerAgent: "ignis",
+        ownerLabel: "Ignis",
+      },
+      mode: "managed",
+      ownerAgent: "ignis",
+    });
+
+    const response = await action({ params: { id: "session-ignis" } } as never);
+
+    expect(response.status).toBe(200);
+    expect(requestTmuxDispatchAbortForSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        missionId,
+        requestedBy: "abort-route",
+        sessionId: "session-ignis",
+      }),
+    );
+    expect(interruptManagedTmuxSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("sends Escape for active tmux-managed responses when no pre-submit dispatch is in flight", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const missionId = `mission-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis", { executionProjectId: "alpha" });
+    getMission(missionId)!.transportMode = "tmux-resident";
+    setWorkerSession(missionId, "ignis", "session-ignis");
+
+    resolvedSessionListMock.mockResolvedValue({
+      data: [{ id: "session-ignis", title: `mission:${missionId}:ignis` }],
+    });
+    resolvedAbortMock.mockResolvedValue({ data: { ok: true } });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          abort: resolvedAbortMock,
+          list: resolvedSessionListMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4403",
+      managedSession: {
+        missionId,
+        ownerAgent: "ignis",
+        ownerLabel: "Ignis",
+      },
+      mode: "managed",
+      ownerAgent: "ignis",
+    });
+
+    const response = await action({ params: { id: "session-ignis" } } as never);
+
+    expect(response.status).toBe(200);
+    expect(interruptManagedTmuxSessionMock).toHaveBeenCalledWith({
+      method: "escape",
+      ownerAgent: "ignis",
+    });
   });
 });

--- a/web/app/routes/api.session.$id.abort.ts
+++ b/web/app/routes/api.session.$id.abort.ts
@@ -1,7 +1,11 @@
-import { appendMissionActivity } from "@/lib/mission-store";
+import { appendMissionActivity, getMission } from "@/lib/mission-store";
 import { cancelTmuxDispatchItemsForSession } from "@/lib/mission-primary-agent-outbox.server";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
 import { resolveSessionRouteTarget } from "@/lib/session-owner-routing.server";
+import {
+  interruptManagedTmuxSession,
+  requestTmuxDispatchAbortForSession,
+} from "@/lib/tmux-transport-abort.server";
 import type { Route } from "./+types/api.session.$id.abort";
 
 async function resolveSessionTitle(
@@ -32,8 +36,17 @@ export const action = async ({ params }: Route.ActionArgs) => {
   try {
     const { client, managedSession: resolvedManagedSession } = resolveSessionRouteTarget(sessionId);
     managedSession = resolvedManagedSession;
+    const managedMission = managedSession ? getMission(managedSession.missionId) : null;
+    const isTmuxManagedSession = managedMission?.transportMode === "tmux-resident";
     const rawSessionTitle = managedSession ? await resolveSessionTitle(client, sessionId) : null;
     const abortedAt = new Date().toISOString();
+    let tmuxAbortAction:
+      | {
+          error?: string | null;
+          mode: "dispatcher-cancel" | "escape" | "error";
+          phase?: string | null;
+        }
+      | null = null;
 
     appendSessionPromptDebugLog({
       route: "api.session.$id.abort",
@@ -59,6 +72,41 @@ export const action = async ({ params }: Route.ActionArgs) => {
         cancelledBy: "abort-route",
         reason: "Managed session abort requested",
       });
+
+      if (isTmuxManagedSession) {
+        try {
+          const dispatchAbort = requestTmuxDispatchAbortForSession({
+            missionId: managedSession.missionId,
+            requestedAt: abortedAt,
+            requestedBy: "abort-route",
+            sessionId,
+          });
+
+          if (dispatchAbort.requested) {
+            tmuxAbortAction = {
+              mode: "dispatcher-cancel",
+              phase: dispatchAbort.currentDispatch?.phase ?? null,
+            };
+          } else {
+            interruptManagedTmuxSession({
+              method: "escape",
+              ownerAgent: managedSession.ownerAgent,
+            });
+            tmuxAbortAction = {
+              mode: "escape",
+              phase: dispatchAbort.currentDispatch?.phase ?? null,
+            };
+          }
+        } catch (tmuxInterruptError) {
+          tmuxAbortAction = {
+            error:
+              tmuxInterruptError instanceof Error
+                ? tmuxInterruptError.message
+                : String(tmuxInterruptError),
+            mode: "error",
+          };
+        }
+      }
     }
 
     const result = await client.session.abort({ sessionID: sessionId });
@@ -77,6 +125,7 @@ export const action = async ({ params }: Route.ActionArgs) => {
               rawSessionTitle,
             }
           : null,
+        tmuxAbortAction,
       },
     });
 

--- a/web/app/routes/api.session.$id.abort.ts
+++ b/web/app/routes/api.session.$id.abort.ts
@@ -1,4 +1,5 @@
 import { appendMissionActivity } from "@/lib/mission-store";
+import { cancelTmuxDispatchItemsForSession } from "@/lib/mission-primary-agent-outbox.server";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
 import { resolveSessionRouteTarget } from "@/lib/session-owner-routing.server";
 import type { Route } from "./+types/api.session.$id.abort";
@@ -32,6 +33,7 @@ export const action = async ({ params }: Route.ActionArgs) => {
     const { client, managedSession: resolvedManagedSession } = resolveSessionRouteTarget(sessionId);
     managedSession = resolvedManagedSession;
     const rawSessionTitle = managedSession ? await resolveSessionTitle(client, sessionId) : null;
+    const abortedAt = new Date().toISOString();
 
     appendSessionPromptDebugLog({
       route: "api.session.$id.abort",
@@ -48,6 +50,16 @@ export const action = async ({ params }: Route.ActionArgs) => {
           : null,
       },
     });
+
+    if (managedSession) {
+      cancelTmuxDispatchItemsForSession({
+        missionId: managedSession.missionId,
+        sessionId,
+        cancelledAt: abortedAt,
+        cancelledBy: "abort-route",
+        reason: "Managed session abort requested",
+      });
+    }
 
     const result = await client.session.abort({ sessionID: sessionId });
 
@@ -79,7 +91,7 @@ export const action = async ({ params }: Route.ActionArgs) => {
         speaker: "system",
         kind: "system_event",
         body: `OpenCode manually aborted the managed ${managedSession.ownerLabel} session.`,
-        createdAt: new Date().toISOString(),
+        createdAt: abortedAt,
         source: {
           type: "system",
           sessionId,


### PR DESCRIPTION
## 📝 Summary

- Implement tmux dispatch abort handling and tests
- Add failure and cancellation handling for tmux dispatch items
- Diff scope: 18 files changed, 2032 insertions, 36 deletions

## 🎯 Motivation

This PR completes the tmux transport recovery slice for mission workflows.

It preserves failed and cancelled dispatch history, lets operators replay failed primary-agent deliveries without mutating the original record, and makes abort behavior work for both queued tmux dispatches and active tmux-managed responses.

## 🔧 Changes Overview

- Diff scope: 18 files changed, 2032 insertions, 36 deletions.
- Frontend: 10 file(s), including `web/app/hooks/use-agent-session.ts`, `web/app/lib/mission-api.server.ts`, and `web/app/lib/mission-primary-agent-outbox.server.ts`.
- Tests: 7 file(s), including `scripts/tmux_transport_runtime.test.mjs`, `web/app/lib/mission-primary-agent-outbox.server.test.ts`, and `web/app/lib/tmux-transport-abort.server.test.ts`.
- Scripts: 1 file(s), including `scripts/tmux_transport_dispatcher.mts`.

## ✅ Testing

- `node --test scripts/tmux_transport_runtime.test.mjs`
- `npm --prefix web run test -- 'app/lib/tmux-transport-abort.server.test.ts' 'app/routes/api.session.\$id.abort.test.ts'`
- `npm run web:typecheck`
- Manual verification completed for the tmux recovery, resend, and abort flows

- [x] Tested locally
- [x] Manual testing completed
- [x] Edge cases considered

## 📸 Screenshots

Not included. The UI change is limited to the inline failed-delivery resend affordance near the composer.

## 🔗 Related Issues

- Closes #60

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots added if useful

## 📌 Notes

- The mission UI now surfaces the latest retryable failed primary-agent delivery as a resend action near the composer instead of keeping a dedicated transport panel.
- Tmux abort handling is split between dispatcher-side pre-submit cancellation and pane-level Escape interruption for active responses.
