### PR TITLE
Add tmux mission parity and monitoring for Lunafreya-owned sessions

### DIFF
--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto", "lunafreya", "iris"] as const;
 const ABORT_REQUEST_DIR = "tmux-transport-aborts";
@@ -667,7 +668,7 @@ function applyModelSelection(
   );
 }
 
-function submitClaimedItem(root: string, item: TmuxDispatchItem): void {
+export function submitClaimedItem(root: string, item: TmuxDispatchItem): void {
   const paneIndex = AGENT_IDS.indexOf(item.payload.agent);
   if (paneIndex === -1) {
     throw new Error(`Unsupported tmux dispatch target: ${item.payload.agent}`);
@@ -720,86 +721,101 @@ function countQueuedItems(root: string): number {
   }, 0);
 }
 
-const root = parseRoot(process.argv.slice(2));
-let processedCount = 0;
-let nextDispatchNotBefore = 0;
-const dispatcherStartedAt = new Date().toISOString();
-
-const tick = () => {
-  let claimed: TmuxDispatchItem | null = null;
-
-  try {
-    const nowDate = new Date();
-    const now = nowDate.toISOString();
-    claimed = nowDate.getTime() >= nextDispatchNotBefore ? claimNextItem(root, now) : null;
-    if (claimed) {
-      submitClaimedItem(root, claimed);
-      processedCount += 1;
-      nextDispatchNotBefore = Date.now() + NEXT_DISPATCH_DELAY_MS;
-    }
-
-    writeState(root, {
-      lastActivityAt: now,
-      processedCount,
-      queuedCount: countQueuedItems(root),
-      startedAt: dispatcherStartedAt,
-    });
-  } catch (error) {
-    if (claimed) {
-      if (error instanceof DispatchAbortError) {
-        writeItem(root, {
-          ...claimed,
-          status: "cancelled",
-          updatedAt: error.cancelledAt,
-          cancellation: {
-            cancelledAt: error.cancelledAt,
-            cancelledBy: error.cancelledBy,
-            reason: error.message,
-          },
-        });
-      } else {
-        const failedAt = new Date().toISOString();
-        writeItem(root, {
-          ...claimed,
-          status: "failed",
-          updatedAt: failedAt,
-          failure: {
-            dispatcherPid: process.pid,
-            failedAt,
-            failedBy: `dispatcher:${process.pid}`,
-            reason: error instanceof Error ? error.message : String(error),
-          },
-        });
-      }
-    }
-
-    writeState(root, {
-      lastActivityAt: new Date().toISOString(),
-      lastError: error instanceof Error ? error.message : String(error),
-      processedCount,
-      queuedCount: countQueuedItems(root),
-      startedAt: dispatcherStartedAt,
-    });
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
   }
-};
 
-writeState(root, {
-  processedCount,
-  queuedCount: countQueuedItems(root),
-  startedAt: dispatcherStartedAt,
-});
-tick();
-const interval = setInterval(tick, LOOP_INTERVAL_MS);
+  return import.meta.url === pathToFileURL(entry).href;
+}
 
-const exitGracefully = () => {
-  clearInterval(interval);
-  cleanup(root);
-  process.exit(0);
-};
+export function main(argv = process.argv.slice(2)): void {
+  const root = parseRoot(argv);
+  let processedCount = 0;
+  let nextDispatchNotBefore = 0;
+  const dispatcherStartedAt = new Date().toISOString();
 
-process.on("SIGINT", exitGracefully);
-process.on("SIGTERM", exitGracefully);
-process.on("exit", () => {
-  clearInterval(interval);
-  cleanup(root);
-});
+  const tick = () => {
+    let claimed: TmuxDispatchItem | null = null;
+
+    try {
+      const nowDate = new Date();
+      const now = nowDate.toISOString();
+      claimed = nowDate.getTime() >= nextDispatchNotBefore ? claimNextItem(root, now) : null;
+      if (claimed) {
+        submitClaimedItem(root, claimed);
+        processedCount += 1;
+        nextDispatchNotBefore = Date.now() + NEXT_DISPATCH_DELAY_MS;
+      }
+
+      writeState(root, {
+        lastActivityAt: now,
+        processedCount,
+        queuedCount: countQueuedItems(root),
+        startedAt: dispatcherStartedAt,
+      });
+    } catch (error) {
+      if (claimed) {
+        if (error instanceof DispatchAbortError) {
+          writeItem(root, {
+            ...claimed,
+            status: "cancelled",
+            updatedAt: error.cancelledAt,
+            cancellation: {
+              cancelledAt: error.cancelledAt,
+              cancelledBy: error.cancelledBy,
+              reason: error.message,
+            },
+          });
+        } else {
+          const failedAt = new Date().toISOString();
+          writeItem(root, {
+            ...claimed,
+            status: "failed",
+            updatedAt: failedAt,
+            failure: {
+              dispatcherPid: process.pid,
+              failedAt,
+              failedBy: `dispatcher:${process.pid}`,
+              reason: error instanceof Error ? error.message : String(error),
+            },
+          });
+        }
+      }
+
+      writeState(root, {
+        lastActivityAt: new Date().toISOString(),
+        lastError: error instanceof Error ? error.message : String(error),
+        processedCount,
+        queuedCount: countQueuedItems(root),
+        startedAt: dispatcherStartedAt,
+      });
+    }
+  };
+
+  writeState(root, {
+    processedCount,
+    queuedCount: countQueuedItems(root),
+    startedAt: dispatcherStartedAt,
+  });
+  tick();
+  const interval = setInterval(tick, LOOP_INTERVAL_MS);
+
+  const exitGracefully = () => {
+    clearInterval(interval);
+    cleanup(root);
+    process.exit(0);
+  };
+
+  process.on("SIGINT", exitGracefully);
+  process.on("SIGTERM", exitGracefully);
+  process.on("exit", () => {
+    clearInterval(interval);
+    cleanup(root);
+  });
+}
+
+if (isMainModule()) {
+  main();
+}

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -15,6 +15,7 @@ import {
 type MockResponse = Pick<Response, "json" | "ok" | "status">;
 
 type HookProbeSnapshot = {
+  banterMessages: string[];
   liveDraft: {
     messageId: string | null;
     parts: Array<{ text?: string; type: string }>;
@@ -218,6 +219,7 @@ function HookProbe({
 
   useEffect(() => {
     onSnapshot({
+      banterMessages: state.banterEntries.map((entry) => entry.message),
       liveDraft: state.liveDraft,
       historyPhase: state.historyPhase,
       isSessionActive: state.isSessionActive,
@@ -233,6 +235,7 @@ function HookProbe({
     onSnapshot,
     state.abort,
     state.abortSettlementPhase,
+    state.banterEntries,
     state.historyPhase,
     state.isSessionActive,
     state.isLoadingHistory,
@@ -2547,6 +2550,89 @@ describe("useAgentSession", () => {
     expect(
       fetchMock.mock.calls.filter(([input]) => String(input) === "/api/noctis/missions/mission-1/banter"),
     ).toHaveLength(1);
+  });
+
+  it("emits session-settled banter for the Lunafreya surface via the Lunafreya mission endpoint", async () => {
+    vi.useFakeTimers();
+
+    const mission = createMission({
+      missionId: "mission-1",
+      primaryAgentId: "lunafreya",
+      primarySessionId: "session-luna",
+      surfaceId: "lunafreya",
+      sessions: {
+        primary: "session-luna",
+        noctis: null,
+        ignis: null,
+        gladiolus: null,
+        prompto: null,
+      },
+    });
+    let runtimeFetchCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "/api/lunafreya/missions/mission-1/runtime") {
+        runtimeFetchCount += 1;
+        return createJsonResponse({
+          ...createRuntimePayload(mission),
+          sessionStatuses: {},
+        });
+      }
+
+      if (url === "/api/lunafreya/missions/mission-1/banter") {
+        return createJsonResponse({
+          recorded: true,
+          entry: {
+            id: "banter-luna-1",
+            missionId: "mission-1",
+            kind: "ambient",
+            speakerAgent: "lunafreya",
+            cue: "session-settled",
+            renderedMessage: "The path is quiet now. I will remain ready for what follows.",
+            createdAt: "2026-04-26T00:00:00.000Z",
+          },
+        });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await act(async () => {
+      useChatStore.getState().setOptimisticSessionState("session-luna", "busy", 60_000);
+    });
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: [createAssistantMessage("message-1", "Oracle reply")],
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    await act(async () => {
+      useChatStore.getState().clearOptimisticSessionState("session-luna");
+    });
+
+    const baselineFetchCount = runtimeFetchCount;
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    await waitFor(() => runtimeFetchCount > baselineFetchCount);
+
+    expect(
+      fetchMock.mock.calls.some(([input]) => String(input) === "/api/lunafreya/missions/mission-1/banter"),
+    ).toBe(true);
   });
 
   it("triggers a targeted runtime refresh when the primary stream disconnects", async () => {

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -1245,16 +1245,12 @@ export function useAgentSession({
       renderedMessage?: string;
       sourceEvent: string;
     }) => {
-      if (isLunafreyaSurface) {
-        return;
-      }
-
       const missionId = missionIdRef.current ?? activeMissionIdRef.current;
       if (!missionId) {
         return;
       }
 
-      const response = await fetch(`/api/noctis/missions/${missionId}/banter`, {
+      const response = await fetch(`${missionRouteBase}/${missionId}/banter`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -1279,7 +1275,7 @@ export function useAgentSession({
         banterFeedPresenterRef.current?.enqueueLiveEntries([payload.entry]);
       }
     },
-    [isLunafreyaSurface]
+    [missionRouteBase]
   );
 
   const clearProgressBanter = useCallback((agentId?: string) => {
@@ -1664,9 +1660,11 @@ export function useAgentSession({
         scheduleIdleReset();
       }
 
-      const update = isLunafreyaSurface ? null : eventToPartyUpdate(event);
+      const update = eventToPartyUpdate(event, primaryAgentId);
       if (update) {
-        setPartyRuntime((prev) => applyPartyRuntimeUpdate(prev, update));
+        if (!isLunafreyaSurface) {
+          setPartyRuntime((prev) => applyPartyRuntimeUpdate(prev, update));
+        }
         if (update.cue && update.speakerAgent) {
           void persistAmbientBanter({
             speakerAgent: update.speakerAgent,
@@ -1680,6 +1678,7 @@ export function useAgentSession({
       clearProgressBanter,
       clearStreamingState,
       isLunafreyaSurface,
+      primaryAgentId,
       persistAmbientBanter,
       scheduleIdleReset,
       setOptimisticSessionState,
@@ -1927,7 +1926,6 @@ export function useAgentSession({
         Date.now() - lastNoctisSettledEmitAtRef.current < MISSION_SETTLED_BANTER_COOLDOWN_MS;
       const shouldEmitSettled =
         hasHydratedSettled &&
-        !isLunafreyaSurface &&
         isPrimarySettled &&
         !previousSettled &&
         !isSettledBanterCoolingDown;
@@ -2043,7 +2041,7 @@ export function useAgentSession({
       if (!hasHydratedNoctisSettledRef.current) {
         hasHydratedNoctisSettledRef.current = true;
         lastNoctisSettledRef.current = isPrimarySettled;
-      } else if (!isLunafreyaSurface && isPrimarySettled && !lastNoctisSettledRef.current) {
+      } else if (isPrimarySettled && !lastNoctisSettledRef.current) {
         if (!isSettledBanterCoolingDown) {
           void persistAmbientBanter({
             speakerAgent: primaryAgentId,
@@ -2113,7 +2111,6 @@ export function useAgentSession({
     [
       clearPendingMissionSession,
       clearAbortSettlement,
-      isLunafreyaSurface,
       isStreaming,
       missionRouteBase,
       pendingMissionSessionId,

--- a/web/app/hooks/use-owned-iris-session-realtime.test.ts
+++ b/web/app/hooks/use-owned-iris-session-realtime.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionStatus } from "@/lib/session-status";
+import { useOwnedIrisSessionRealtime } from "./use-owned-iris-session-realtime";
+
+type HookSnapshot = {
+  isLiveUnavailable: boolean;
+  sessionStatus: SessionStatus | null;
+  streamingContent: string;
+  streamingMessageId: string | null;
+};
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent<string>) => unknown) | null = null;
+  readonly url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  close(): void {
+    // no-op
+  }
+}
+
+function createStatusesResponse(statuses: Record<string, SessionStatus>) {
+  return {
+    json: async () => ({ statuses }),
+    ok: true,
+  };
+}
+
+function HookProbe({
+  loadMessages,
+  onIdle,
+  onSnapshot,
+  sessionId,
+}: {
+  loadMessages: (sessionId: string) => Promise<void>;
+  onIdle?: (sessionId: string) => void | Promise<void>;
+  onSnapshot: (snapshot: HookSnapshot) => void;
+  sessionId: string | null;
+}) {
+  const realtime = useOwnedIrisSessionRealtime({
+    loadMessages,
+    onSessionIdle: onIdle,
+    sessionId,
+  });
+
+  useEffect(() => {
+    onSnapshot({
+      isLiveUnavailable: realtime.isLiveUnavailable,
+      sessionStatus: realtime.sessionStatus,
+      streamingContent: realtime.streamingContent,
+      streamingMessageId: realtime.streamingMessageId,
+    });
+  }, [
+    onSnapshot,
+    realtime.isLiveUnavailable,
+    realtime.sessionStatus,
+    realtime.streamingContent,
+    realtime.streamingMessageId,
+  ]);
+
+  return null;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useOwnedIrisSessionRealtime", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+
+    container.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("bootstraps the owner-aware session status and reloads authoritative messages on idle", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createStatusesResponse({ "session-1": "busy" }));
+    const loadMessages = vi.fn().mockResolvedValue(undefined);
+    const idleSpy = vi.fn();
+    let latestSnapshot: HookSnapshot | null = null;
+
+    const getSnapshot = () => {
+      if (!latestSnapshot) {
+        throw new Error("Hook snapshot was not captured.");
+      }
+
+      return latestSnapshot;
+    };
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          loadMessages,
+          onIdle: idleSpy,
+          onSnapshot: (snapshot: HookSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+          sessionId: "session-1",
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    expect(MockEventSource.instances[0]?.url).toBe("/api/session/session-1/events");
+    expect(fetchMock).toHaveBeenCalledWith("/api/session-status");
+  expect(getSnapshot().sessionStatus).toBe("busy");
+
+    const eventSource = MockEventSource.instances[0];
+    if (!eventSource?.onmessage) {
+      throw new Error("EventSource handler was not registered.");
+    }
+
+    await act(async () => {
+      eventSource.onmessage?.call(eventSource as unknown as EventSource, {
+        data: JSON.stringify({
+          properties: {
+            sessionID: "session-1",
+          },
+          type: "session.idle",
+        }),
+      } as MessageEvent<string>);
+      await flushMicrotasks();
+    });
+
+    expect(loadMessages).toHaveBeenCalledWith("session-1");
+    expect(idleSpy).toHaveBeenCalledWith("session-1");
+    expect(getSnapshot().sessionStatus).toBe("idle");
+  });
+
+  it("falls back to polling messages and statuses when the live stream drops during an active reply", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockResolvedValue(createStatusesResponse({ "session-1": "busy" }));
+    const loadMessages = vi.fn().mockResolvedValue(undefined);
+    let latestSnapshot: HookSnapshot | null = null;
+
+    const getSnapshot = () => {
+      if (!latestSnapshot) {
+        throw new Error("Hook snapshot was not captured.");
+      }
+
+      return latestSnapshot;
+    };
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          loadMessages,
+          onSnapshot: (snapshot: HookSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+          sessionId: "session-1",
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const eventSource = MockEventSource.instances[0];
+    if (!eventSource?.onerror) {
+      throw new Error("EventSource error handler was not registered.");
+    }
+
+    await act(async () => {
+      eventSource.onerror?.call(eventSource as unknown as EventSource, new Event("error"));
+    });
+
+    expect(getSnapshot().isLiveUnavailable).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+      await flushMicrotasks();
+    });
+
+    expect(loadMessages).toHaveBeenCalledWith("session-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getSnapshot().sessionStatus).toBe("busy");
+  });
+});

--- a/web/app/hooks/use-owned-iris-session-realtime.ts
+++ b/web/app/hooks/use-owned-iris-session-realtime.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchSessionStatus, isSessionStatusActive, type SessionStatus } from "@/lib/session-status";
+import {
+  useSessionLiveThread,
+  type UseSessionLiveThreadOptions,
+  type UseSessionLiveThreadResult,
+} from "./use-session-live-thread";
+
+export type UseOwnedIrisSessionRealtimeOptions = {
+  enabled?: boolean;
+  loadMessages: (sessionId: string) => Promise<void>;
+  onSessionIdle?: (sessionId: string) => void | Promise<void>;
+  onTextPartMatched?: UseSessionLiveThreadOptions["onTextPartMatched"];
+  onUnhandledEvent?: UseSessionLiveThreadOptions["onUnhandledEvent"];
+  pollingIntervalMs?: number;
+  sessionId: string | null;
+};
+
+export type UseOwnedIrisSessionRealtimeResult = UseSessionLiveThreadResult & {
+  sessionStatus: SessionStatus | null;
+};
+
+export function useOwnedIrisSessionRealtime({
+  enabled = true,
+  loadMessages,
+  onSessionIdle,
+  onTextPartMatched,
+  onUnhandledEvent,
+  pollingIntervalMs = 2500,
+  sessionId,
+}: UseOwnedIrisSessionRealtimeOptions): UseOwnedIrisSessionRealtimeResult {
+  const [sessionStatus, setSessionStatus] = useState<SessionStatus | null>(null);
+  const sessionIdRef = useRef<string | null>(sessionId);
+  const statusRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  const refreshSessionStatus = useCallback(async (targetSessionId: string) => {
+    const requestId = statusRequestIdRef.current + 1;
+    statusRequestIdRef.current = requestId;
+
+    try {
+      const nextStatus = await fetchSessionStatus(targetSessionId);
+      if (statusRequestIdRef.current !== requestId || sessionIdRef.current !== targetSessionId) {
+        return;
+      }
+
+      setSessionStatus(nextStatus);
+    } catch {
+      // Keep the last known status until a future poll or session event settles it.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !sessionId) {
+      statusRequestIdRef.current += 1;
+      setSessionStatus(null);
+      return;
+    }
+
+    void refreshSessionStatus(sessionId);
+  }, [enabled, refreshSessionStatus, sessionId]);
+
+  const handleSessionIdle = useCallback(
+    (eventSessionId: string) => {
+      if (eventSessionId !== sessionId) {
+        return;
+      }
+
+      setSessionStatus("idle");
+      void loadMessages(eventSessionId);
+      void onSessionIdle?.(eventSessionId);
+    },
+    [loadMessages, onSessionIdle, sessionId],
+  );
+
+  const handleSessionStatus = useCallback(
+    (nextStatus: SessionStatus, eventSessionId: string) => {
+      if (eventSessionId !== sessionId) {
+        return;
+      }
+
+      setSessionStatus(nextStatus);
+    },
+    [sessionId],
+  );
+
+  const liveThread = useSessionLiveThread({
+    enabled,
+    onSessionIdle: handleSessionIdle,
+    onSessionStatus: handleSessionStatus,
+    onTextPartMatched,
+    onUnhandledEvent,
+    sessionId,
+  });
+
+  useEffect(() => {
+    if (!enabled || !sessionId || !liveThread.isLiveUnavailable || !isSessionStatusActive(sessionStatus)) {
+      return;
+    }
+
+    const activeSessionId = sessionId;
+    const interval = window.setInterval(() => {
+      void loadMessages(activeSessionId);
+      void refreshSessionStatus(activeSessionId);
+    }, pollingIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [
+    enabled,
+    liveThread.isLiveUnavailable,
+    loadMessages,
+    pollingIntervalMs,
+    refreshSessionStatus,
+    sessionId,
+    sessionStatus,
+  ]);
+
+  return {
+    ...liveThread,
+    sessionStatus,
+  };
+}

--- a/web/app/lib/banter/ambient-service.test.ts
+++ b/web/app/lib/banter/ambient-service.test.ts
@@ -68,4 +68,38 @@ describe("recordAmbientBanter", () => {
       }),
     ]);
   });
+
+  it("creates Lunafreya ambient banter from the catalog", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const missionId = `mission-ambient-lunafreya-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-lunafreya", {
+      title: "Lunafreya ambient banter",
+      objective: "Verify Lunafreya banter generation",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+
+    const entry = recordAmbientBanter({
+      missionId,
+      speakerAgent: "lunafreya",
+      cue: "session-settled",
+      sourceEvent: "session.settled",
+      createdAt: "2026-04-11T12:00:00.000Z",
+    });
+
+    expect(entry).toEqual(
+      expect.objectContaining({
+        speakerAgent: "lunafreya",
+        cue: "session-settled",
+        renderedMessage: expect.stringMatching(/\S/),
+      }),
+    );
+    expect([
+      "The path is quiet now. I will remain ready for what follows.",
+      "This turn has settled. Call for me when the next thread appears.",
+      "The current tide has stilled. I can wait until the next need arrives.",
+      "For now, the matter rests. I will answer when it is time to move again.",
+    ]).toContain(entry?.renderedMessage);
+  });
 });

--- a/web/app/lib/banter/catalog.ts
+++ b/web/app/lib/banter/catalog.ts
@@ -59,6 +59,48 @@ export const BANTER_CATALOG: BanterCatalog = {
       ],
       "runtime-recovered": ["戻ったな。続けるぞ。", "再開だ。ここから詰める。"],
     },
+    lunafreya: {
+      "session-start": [
+        "承知しました。流れを静かに見定めます。",
+        "始めましょう。必要な声は、いずれここへ集まります。",
+        "この糸を辿ります。乱れがあればすぐに拾いましょう。",
+      ],
+      "task-progress-early": [
+        "まだ波は浅いままです。もう少し見守ります。",
+        "気配を集めています。答えは、まだ霧の向こうです。",
+        "焦らず進めましょう。輪郭はこれから現れます。",
+      ],
+      "task-progress-late": [
+        "流れが整ってきました。次で形になるはずです。",
+        "もうすぐ届きます。必要な線だけが残っています。",
+        "霧は薄れました。このまま辿れます。",
+      ],
+      "session-settled": [
+        "今は静まっています。次の呼びかけがあれば、すぐに応えます。",
+        "ひとまず波は収まりました。次に必要とされる時まで待ちましょう。",
+        "この流れはいったん落ち着きました。次の糸が現れるまで備えます。",
+        "今は幕を下ろせます。また動く時が来れば、すぐに向かいます。",
+      ],
+      "task-completed": [
+        "果たせました。次に繋げましょう。",
+        "役目は終えました。必要なら、すぐ次へ進めます。",
+        "整いました。この結果は次の道標になるでしょう。",
+      ],
+      "task-failed": [
+        "ここでは届きませんでした。別の糸を探しましょう。",
+        "まだ霧が深いようです。進め方を改めます。",
+        "この道は閉じています。別の流れへ移ります。",
+      ],
+      "task-retrying": [
+        "もう一度、静かに結び直しましょう。",
+        "流れを整え直します。まだ手は届きます。",
+        "大丈夫です。別の結び方で、もう一度辿ります。",
+      ],
+      "runtime-recovered": [
+        "戻りました。乱れた流れをここから整えます。",
+        "再び辿れます。続きから静かに進めましょう。",
+      ],
+    },
     ignis: {
       "message-received": [
         "了解した。内容を確認する。",
@@ -319,6 +361,48 @@ export const BANTER_CATALOG: BanterCatalog = {
         "We still have room to push.",
       ],
       "runtime-recovered": ["Back online. Continue.", "We're back. Keep going."],
+    },
+    lunafreya: {
+      "session-start": [
+        "Understood. I will follow the thread carefully.",
+        "Let us begin. What matters will reveal itself in time.",
+        "I am listening for the shape of the next turn now.",
+      ],
+      "task-progress-early": [
+        "The signal is still faint. I need a little more quiet to read it.",
+        "I am gathering the shape of it. The answer has not surfaced yet.",
+        "Not yet. The path is there, but still covered in mist.",
+      ],
+      "task-progress-late": [
+        "The pattern is settling into view now.",
+        "The noise is receding. I can follow the right line from here.",
+        "It is almost clear. One more pass should be enough.",
+      ],
+      "session-settled": [
+        "The path is quiet now. I will remain ready for what follows.",
+        "This turn has settled. Call for me when the next thread appears.",
+        "The current tide has stilled. I can wait until the next need arrives.",
+        "For now, the matter rests. I will answer when it is time to move again.",
+      ],
+      "task-completed": [
+        "It is done. We may carry this forward now.",
+        "The thread holds. I am ready for the next turn.",
+        "This result should guide the next step well enough.",
+      ],
+      "task-failed": [
+        "This path did not open. I will look for another.",
+        "The signal broke apart. I need to approach it differently.",
+        "Not this way. Another thread may still answer.",
+      ],
+      "task-retrying": [
+        "Then I will gather the thread again, more carefully this time.",
+        "The line can still be restored. I will try once more.",
+        "It is not over yet. I will trace it from another angle.",
+      ],
+      "runtime-recovered": [
+        "I am back. Let me bring the current back into order.",
+        "The thread is reachable again. I will continue from here.",
+      ],
     },
     ignis: {
       "message-received": [

--- a/web/app/lib/banter/route-action.server.ts
+++ b/web/app/lib/banter/route-action.server.ts
@@ -1,0 +1,85 @@
+import { missionMatchesSurface } from "@/lib/mission-api.server";
+import { getMission } from "@/lib/mission-store";
+import type { AgentId, MissionSurfaceId } from "@/lib/types/mission";
+import { recordAmbientBanter } from "./ambient-service";
+import type { BanterCue } from "./types";
+
+const AGENT_IDS: ReadonlySet<string> = new Set<AgentId>([
+  "noctis",
+  "lunafreya",
+  "ignis",
+  "gladiolus",
+  "prompto",
+]);
+const BANTER_CUES: ReadonlySet<string> = new Set<BanterCue>([
+  "session-start",
+  "task-delegated",
+  "task-assigned",
+  "message-received",
+  "task-progress-early",
+  "task-progress-late",
+  "report-running",
+  "report-blocked",
+  "report-completed",
+  "report-failed",
+  "report-acknowledged",
+  "session-settled",
+  "task-completed",
+  "task-failed",
+  "task-retrying",
+  "runtime-recovered",
+]);
+
+function isAgentId(value: unknown): value is AgentId {
+  return typeof value === "string" && AGENT_IDS.has(value);
+}
+
+function isBanterCue(value: unknown): value is BanterCue {
+  return typeof value === "string" && BANTER_CUES.has(value);
+}
+
+export async function handleMissionBanterAction(input: {
+  request: Request;
+  missionId?: string;
+  surfaceId: MissionSurfaceId;
+}) {
+  const { missionId, request, surfaceId } = input;
+
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  if (!missionId) {
+    return Response.json({ error: "Missing missionId" }, { status: 400 });
+  }
+
+  const mission = getMission(missionId);
+  if (!mission || !missionMatchesSurface(mission, surfaceId)) {
+    return Response.json({ error: "Mission not found" }, { status: 404 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    speakerAgent?: unknown;
+    cue?: unknown;
+    renderedMessage?: unknown;
+    sourceEvent?: unknown;
+  } | null;
+
+  if (!body || !isAgentId(body.speakerAgent)) {
+    return Response.json({ error: "Invalid speakerAgent" }, { status: 400 });
+  }
+
+  if (!isBanterCue(body.cue)) {
+    return Response.json({ error: "Invalid cue" }, { status: 400 });
+  }
+
+  const entry = recordAmbientBanter({
+    missionId,
+    speakerAgent: body.speakerAgent,
+    cue: body.cue,
+    renderedMessage: typeof body.renderedMessage === "string" ? body.renderedMessage : undefined,
+    sourceEvent: typeof body.sourceEvent === "string" ? body.sourceEvent : undefined,
+  });
+
+  return Response.json({ recorded: Boolean(entry), entry });
+}

--- a/web/app/lib/banter/runtime.ts
+++ b/web/app/lib/banter/runtime.ts
@@ -9,6 +9,7 @@ import type {
 
 const AGENT_DISPLAY: Record<BanterAgentId, { name: string; avatar: string; memberId: string }> = {
   noctis: { name: "Noctis", avatar: "/images/noctis.png", memberId: "noctis" },
+  lunafreya: { name: "Lunafreya", avatar: "/images/lunafreya.png", memberId: "lunafreya" },
   ignis: { name: "Ignis", avatar: "/images/ignis.png", memberId: "ignis" },
   gladiolus: { name: "Gladio", avatar: "/images/gladiolus.png", memberId: "gladio" },
   prompto: { name: "Prompto", avatar: "/images/prompto.png", memberId: "prompto" },
@@ -21,6 +22,7 @@ export function normalizeBanterAgentId(agentId: string): BanterAgentId | null {
 
   if (
     agentId === "noctis" ||
+    agentId === "lunafreya" ||
     agentId === "ignis" ||
     agentId === "gladiolus" ||
     agentId === "prompto"

--- a/web/app/lib/banter/types.ts
+++ b/web/app/lib/banter/types.ts
@@ -1,6 +1,6 @@
 import type { AppLanguage } from "@/lib/app-language.server";
 
-export type BanterAgentId = "noctis" | "ignis" | "gladiolus" | "prompto";
+export type BanterAgentId = "noctis" | "lunafreya" | "ignis" | "gladiolus" | "prompto";
 
 export type BanterCue =
   | "session-start"

--- a/web/app/lib/event-to-party-update.ts
+++ b/web/app/lib/event-to-party-update.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/banter/runtime";
 import type { BanterCue } from "@/lib/banter/types";
 import type { AgentStatus } from "@/lib/noctis-team-ui-types";
+import type { MissionPrimaryAgentId } from "@/lib/types/mission";
 
 export type AgentEvent =
   | { type: "session.created" }
@@ -39,13 +40,14 @@ const _TASK_ASSIGNED_LABEL: Record<string, string> = {
 
 export function eventToPartyUpdate(
   event: AgentEvent,
+  primaryAgentId: MissionPrimaryAgentId,
 ): PartyRuntimeUpdate | null {
   switch (event.type) {
     case "session.created": {
       return {
-        memberId: "noctis",
+        memberId: primaryAgentId,
         status: "working",
-        speakerAgent: "noctis",
+        speakerAgent: primaryAgentId,
         cue: "session-start",
       };
     }
@@ -108,7 +110,7 @@ export function eventToPartyUpdate(
 
     case "session.completed": {
       return {
-        memberId: "noctis",
+        memberId: primaryAgentId,
         status: "success",
       };
     }

--- a/web/app/lib/mission-primary-agent-outbox.server.ts
+++ b/web/app/lib/mission-primary-agent-outbox.server.ts
@@ -11,6 +11,7 @@ const OUTBOX_STATUSES = ["pending", "leased", "submitted", "failed", "cancelled"
 
 export type PrimaryAgentOutboxStatus = (typeof OUTBOX_STATUSES)[number];
 export type TmuxDispatchStatus = PrimaryAgentOutboxStatus;
+export type TmuxDispatchAgentId = AgentId | "iris";
 
 export interface PrimaryAgentOutboxRecoveredLease {
   attempt: number;
@@ -67,7 +68,7 @@ export interface PrimaryAgentOutboxRecordLinks {
 export type TmuxDispatchRecordLinks = PrimaryAgentOutboxRecordLinks;
 
 export interface PrimaryAgentOutboxPayload {
-  agent: AgentId;
+  agent: TmuxDispatchAgentId;
   sessionId: string;
   sessionTitle?: string;
   parts: TextPromptPart[];
@@ -99,6 +100,17 @@ function isOutboxStatus(value: unknown): value is PrimaryAgentOutboxStatus {
 
 function normalizeString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function normalizeTmuxDispatchAgentId(value: unknown): TmuxDispatchAgentId | null {
+  return value === "noctis" ||
+    value === "lunafreya" ||
+    value === "ignis" ||
+    value === "gladiolus" ||
+    value === "prompto" ||
+    value === "iris"
+    ? value
+    : null;
 }
 
 function normalizePromptParts(value: unknown): TextPromptPart[] | null {
@@ -163,7 +175,7 @@ function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
   }
 
   const record = value as Record<string, unknown>;
-  const agent = normalizeString(record.agent);
+  const agent = normalizeTmuxDispatchAgentId(record.agent);
   const sessionId = normalizeString(record.sessionId);
   const parts = normalizePromptParts(record.parts);
 
@@ -172,7 +184,7 @@ function normalizePayload(value: unknown): PrimaryAgentOutboxPayload | null {
   }
 
   return {
-    agent: agent as AgentId,
+    agent,
     sessionId,
     ...(normalizeString(record.sessionTitle)
       ? { sessionTitle: normalizeString(record.sessionTitle) }

--- a/web/app/lib/mission-store.test.ts
+++ b/web/app/lib/mission-store.test.ts
@@ -330,6 +330,33 @@ describe("mission store", () => {
     ]);
   });
 
+  it("ignores owned-session transport directories without mission.json", () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const mission = createMission("mission-listed-with-owned-session-dir", "session-3", {
+      title: "Listed Mission",
+    });
+    missionIds.push(mission.id);
+
+    mkdirSync(
+      join(
+        root,
+        "runtime",
+        "noctis-missions",
+        "owned-session-ses_22175d7e6ffea4hkNLJZosfeTc",
+      ),
+      { recursive: true },
+    );
+
+    expect(listMissionSummaries({ view: "all" })).toEqual([
+      expect.objectContaining({
+        missionId: "mission-listed-with-owned-session-dir",
+        title: "Listed Mission",
+      }),
+    ]);
+  });
+
   it("flattens primary and worker activity session ids into mission summaries", () => {
     process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
 

--- a/web/app/lib/mission-store.ts
+++ b/web/app/lib/mission-store.ts
@@ -530,7 +530,7 @@ export function listMissionSummaries(options?: {
     .map((entry) => entry.name);
   const missions = missionIds
     .map((missionId) => getMission(missionId))
-    .filter((mission): mission is Mission => mission !== null)
+    .filter((mission): mission is Mission => mission != null)
     .filter((mission) => {
       if (view === "all") {
         return true;

--- a/web/app/lib/mission-surface-hydration.server.test.ts
+++ b/web/app/lib/mission-surface-hydration.server.test.ts
@@ -208,7 +208,7 @@ describe("mission-surface-hydration.server", () => {
     expect(sessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-noctis" });
   });
 
-  it("omits team-only runtime fields for Lunafreya", async () => {
+  it("keeps banter hydration while omitting team-only runtime fields for Lunafreya", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;
 
@@ -246,7 +246,14 @@ describe("mission-surface-hydration.server", () => {
 
     expect(payload).not.toHaveProperty("primaryMessages");
     expect(payload).not.toHaveProperty("noctisMessages");
-    expect(payload).not.toHaveProperty("banterTimeline");
+    expect(payload.banterTimeline).toEqual([
+      expect.objectContaining({
+        id: "ambient-luna-1",
+        cue: "task-progress-early",
+        renderedMessage: "Should not leak into Lunafreya shell.",
+        speakerAgent: "ignis",
+      }),
+    ]);
     expect(payload.latestPrimaryMessageId).toBeNull();
     expect(payload.latestPrimaryMessageCreatedAt).toBeNull();
     expect(Object.keys(payload.contextUsageByAgent)).toEqual(["lunafreya"]);

--- a/web/app/lib/mission-surface.test.ts
+++ b/web/app/lib/mission-surface.test.ts
@@ -29,7 +29,7 @@ describe("mission surface", () => {
       primaryAgentId: "lunafreya",
       portraitSrc: "/images/lunafreya.png",
       hiddenOperationName: "lunafreya-autonomous",
-      supportsBanter: false,
+      supportsBanter: true,
       supportsPartyStatus: false,
       supportsWorkflowSelector: false,
     });

--- a/web/app/lib/mission-surface.ts
+++ b/web/app/lib/mission-surface.ts
@@ -34,7 +34,7 @@ const MISSION_SURFACES: MissionSurfaceDefinition[] = [
     portraitSrc: "/images/lunafreya.png",
     hiddenOperationName: "lunafreya-autonomous",
     lastMissionStorageKey: "lunafreya:last-mission-id",
-    supportsBanter: false,
+    supportsBanter: true,
     supportsPartyStatus: false,
     supportsWorkflowSelector: false,
   },

--- a/web/app/lib/owned-session-registry.server.test.ts
+++ b/web/app/lib/owned-session-registry.server.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getProjectRootMock } = vi.hoisted(() => ({
+  getProjectRootMock: vi.fn(),
+}));
+
+vi.mock("@/lib/get-project-root.server", () => ({
+  getProjectRoot: getProjectRootMock,
+}));
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-owned-session-registry-"));
+  tempRoots.push(root);
+  getProjectRootMock.mockReturnValue(root);
+  return root;
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./owned-session-registry.server");
+}
+
+afterEach(() => {
+  getProjectRootMock.mockReset();
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("owned-session-registry.server", () => {
+  it("persists Iris-owned tmux sessions by session ID", async () => {
+    const root = createTempRoot();
+    const module = await loadModule();
+
+    const entry = module.saveOwnedSession({
+      ownerAgent: "iris",
+      sessionId: "session-iris-1",
+      sessionTitle: "iris:projects",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+
+    expect(existsSync(module.getOwnedSessionRegistryStatePath(root))).toBe(true);
+    expect(entry).toMatchObject({
+      ownerAgent: "iris",
+      sessionTitle: "iris:projects",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+    expect(entry.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(module.readOwnedSession("session-iris-1")).toEqual(entry);
+    expect(module.listOwnedSessions()).toMatchObject({
+      "session-iris-1": entry,
+    });
+  });
+});

--- a/web/app/lib/owned-session-registry.server.ts
+++ b/web/app/lib/owned-session-registry.server.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getProjectRoot } from "@/lib/get-project-root.server";
+
+export type OwnedSessionSurface = "operation-studio-iris" | "projects-iris";
+
+export interface OwnedSessionEntry {
+  ownerAgent: "iris";
+  sessionTitle: string;
+  surface: OwnedSessionSurface;
+  transportMode: "tmux-resident";
+  updatedAt: string;
+}
+
+interface OwnedSessionRegistryState {
+  sessions: Record<string, OwnedSessionEntry>;
+  version: 1;
+}
+
+function getEmptyState(): OwnedSessionRegistryState {
+  return {
+    sessions: {},
+    version: 1,
+  };
+}
+
+function ensureStateDir(root: string): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+}
+
+function readState(root = getProjectRoot()): OwnedSessionRegistryState {
+  const path = getOwnedSessionRegistryStatePath(root);
+  if (!existsSync(path)) {
+    return getEmptyState();
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<OwnedSessionRegistryState>;
+    if (parsed.version !== 1 || !parsed.sessions || typeof parsed.sessions !== "object") {
+      return getEmptyState();
+    }
+
+    return {
+      sessions: parsed.sessions as Record<string, OwnedSessionEntry>,
+      version: 1,
+    };
+  } catch {
+    return getEmptyState();
+  }
+}
+
+function writeState(state: OwnedSessionRegistryState, root = getProjectRoot()): void {
+  ensureStateDir(root);
+  writeFileSync(getOwnedSessionRegistryStatePath(root), `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+}
+
+export function getOwnedSessionRegistryStatePath(root = getProjectRoot()): string {
+  return join(root, "runtime", "owned-session-registry.json");
+}
+
+export function listOwnedSessions(): Record<string, OwnedSessionEntry> {
+  return readState().sessions;
+}
+
+export function readOwnedSession(sessionId: string): OwnedSessionEntry | null {
+  return readState().sessions[sessionId] ?? null;
+}
+
+export function saveOwnedSession(input: {
+  ownerAgent: "iris";
+  sessionId: string;
+  sessionTitle: string;
+  surface: OwnedSessionSurface;
+  transportMode: "tmux-resident";
+}): OwnedSessionEntry {
+  const state = readState();
+  const entry: OwnedSessionEntry = {
+    ownerAgent: input.ownerAgent,
+    sessionTitle: input.sessionTitle,
+    surface: input.surface,
+    transportMode: input.transportMode,
+    updatedAt: new Date().toISOString(),
+  };
+
+  state.sessions[input.sessionId] = entry;
+  writeState(state);
+
+  return entry;
+}

--- a/web/app/lib/owned-session-registry.server.ts
+++ b/web/app/lib/owned-session-registry.server.ts
@@ -13,6 +13,14 @@ export interface OwnedSessionEntry {
   updatedAt: string;
 }
 
+export function getOwnedSessionTitle(sessionId: string): string {
+  return `session:${sessionId}:iris`;
+}
+
+export function hasOwnedSessionTitle(sessionId: string, sessionTitle: string): boolean {
+  return sessionTitle === getOwnedSessionTitle(sessionId);
+}
+
 interface OwnedSessionRegistryState {
   sessions: Record<string, OwnedSessionEntry>;
   version: 1;

--- a/web/app/lib/owned-session-transport.server.test.ts
+++ b/web/app/lib/owned-session-transport.server.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempRoots: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-owned-session-transport-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+afterEach(() => {
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("owned-session-transport.server", () => {
+  it("queues durable tmux dispatch records for Iris-owned sessions", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const module = await import("./owned-session-transport.server");
+    const item = module.queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: "Refresh the project registry." }],
+      model: {
+        providerID: "openai",
+        modelID: "gpt-4.1",
+      },
+      variant: "high",
+    });
+
+    expect(item).toMatchObject({
+      missionId: module.getOwnedSessionTransportMissionId("session-iris"),
+      status: "pending",
+      payload: {
+        agent: "iris",
+        sessionId: "session-iris",
+        sessionTitle: "iris:projects",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4.1",
+        },
+        variant: "high",
+      },
+    });
+    expect(module.listOwnedSessionTmuxDispatchItems("session-iris")).toEqual([item]);
+  });
+});

--- a/web/app/lib/owned-session-transport.server.ts
+++ b/web/app/lib/owned-session-transport.server.ts
@@ -1,0 +1,60 @@
+import {
+  cancelTmuxDispatchItemsForSession,
+  enqueuePrimaryAgentOutboxItem,
+  listTmuxDispatchItems,
+  type PrimaryAgentOutboxItem,
+  type TmuxDispatchItem,
+} from "./mission-primary-agent-outbox.server";
+import type { TextPromptPart } from "./prompt-parts";
+import type { OwnedSessionEntry } from "./owned-session-registry.server";
+import type { ModelSelection } from "./types/mission";
+
+const OWNED_SESSION_TRANSPORT_MISSION_PREFIX = "owned-session";
+
+export function getOwnedSessionTransportMissionId(sessionId: string): string {
+  return `${OWNED_SESSION_TRANSPORT_MISSION_PREFIX}-${sessionId}`;
+}
+
+export function queueOwnedSessionTmuxDispatch(input: {
+  ownerAgent: OwnedSessionEntry["ownerAgent"];
+  sessionId: string;
+  sessionTitle: string;
+  parts: TextPromptPart[];
+  model?: Pick<ModelSelection, "providerID" | "modelID">;
+  queuedAt?: string;
+  system?: string;
+  variant?: string;
+}): PrimaryAgentOutboxItem {
+  return enqueuePrimaryAgentOutboxItem({
+    missionId: getOwnedSessionTransportMissionId(input.sessionId),
+    ...(input.queuedAt ? { createdAt: input.queuedAt } : {}),
+    payload: {
+      agent: input.ownerAgent,
+      sessionId: input.sessionId,
+      sessionTitle: input.sessionTitle,
+      parts: input.parts,
+      ...(input.system ? { system: input.system } : {}),
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.variant ? { variant: input.variant } : {}),
+    },
+  });
+}
+
+export function listOwnedSessionTmuxDispatchItems(sessionId: string): TmuxDispatchItem[] {
+  return listTmuxDispatchItems(getOwnedSessionTransportMissionId(sessionId));
+}
+
+export function cancelOwnedSessionTmuxDispatchItems(input: {
+  sessionId: string;
+  cancelledAt?: string;
+  cancelledBy: string;
+  reason: string;
+}): TmuxDispatchItem[] {
+  return cancelTmuxDispatchItemsForSession({
+    missionId: getOwnedSessionTransportMissionId(input.sessionId),
+    sessionId: input.sessionId,
+    ...(input.cancelledAt ? { cancelledAt: input.cancelledAt } : {}),
+    cancelledBy: input.cancelledBy,
+    reason: input.reason,
+  });
+}

--- a/web/app/lib/primary-agent-mission-transport.server.ts
+++ b/web/app/lib/primary-agent-mission-transport.server.ts
@@ -1,0 +1,94 @@
+import { resolveManagedSessionActivationTitle } from "./managed-session-activation.server";
+import { queuePrimaryAgentTmuxDispatch } from "./primary-agent-outbox-dispatch.server";
+import type { TextPromptPart } from "./prompt-parts";
+import {
+  activateTmuxMissionWriteFocus,
+  getTmuxMissionWriteConflict,
+} from "./tmux-mission-activation.server";
+import {
+  getMissionTransportStatus,
+  type ConfiguredMissionTransportStatus,
+} from "./tmux-transport-bootstrap.server";
+import { getOpencodeClient } from "./opencode-client";
+import type { MissionPrimaryAgentId, MissionTransportMode, ModelSelection } from "./types/mission";
+
+export class MissionTransportNotReadyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissionTransportNotReadyError";
+  }
+}
+
+export class TmuxMissionWriteConflictError extends Error {
+  readonly activeMissionId: string;
+
+  constructor(activeMissionId: string) {
+    super(`Tmux write focus is still held by mission ${activeMissionId}.`);
+    this.name = "TmuxMissionWriteConflictError";
+    this.activeMissionId = activeMissionId;
+  }
+}
+
+export async function requireReadyMissionTransport(input: {
+  appRoot: string;
+  transportMode?: MissionTransportMode | null;
+}): Promise<ConfiguredMissionTransportStatus> {
+  const transportStatus = await getMissionTransportStatus(input.appRoot, input.transportMode);
+  if (!transportStatus.isReady) {
+    throw new MissionTransportNotReadyError(
+      transportStatus.error ?? "Tmux transport bootstrap is not ready.",
+    );
+  }
+
+  return transportStatus;
+}
+
+export async function claimPrimaryAgentTmuxMissionWriteFocus(input: {
+  appRoot: string;
+  client: ReturnType<typeof getOpencodeClient>;
+  missionId: string;
+  updatedAt?: string;
+}): Promise<void> {
+  const conflict = await getTmuxMissionWriteConflict({
+    appRoot: input.appRoot,
+    missionId: input.missionId,
+    client: input.client,
+  });
+  if (conflict) {
+    throw new TmuxMissionWriteConflictError(conflict.activeMissionId);
+  }
+
+  activateTmuxMissionWriteFocus({
+    appRoot: input.appRoot,
+    missionId: input.missionId,
+    ...(input.updatedAt ? { updatedAt: input.updatedAt } : {}),
+  });
+}
+
+export async function queueResolvedPrimaryAgentTmuxMissionWrite(input: {
+  agentId: MissionPrimaryAgentId;
+  appRoot: string;
+  client: ReturnType<typeof getOpencodeClient>;
+  missionId: string;
+  model?: Pick<ModelSelection, "providerID" | "modelID">;
+  parts: TextPromptPart[];
+  sessionId: string;
+  system?: string;
+  variant?: string;
+}): Promise<void> {
+  queuePrimaryAgentTmuxDispatch({
+    missionId: input.missionId,
+    sessionId: input.sessionId,
+    sessionTitle: await resolveManagedSessionActivationTitle({
+      client: input.client,
+      missionId: input.missionId,
+      agentId: input.agentId,
+      sessionId: input.sessionId,
+    }),
+    agent: input.agentId,
+    parts: input.parts,
+    ...(input.system ? { system: input.system } : {}),
+    ...(input.model ? { model: input.model } : {}),
+    ...(input.variant ? { variant: input.variant } : {}),
+  });
+}

--- a/web/app/lib/primary-agent-outbox-dispatch.server.test.ts
+++ b/web/app/lib/primary-agent-outbox-dispatch.server.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { listPrimaryAgentOutboxItems } from "./mission-primary-agent-outbox.server";
 import { createMission, deleteMission, getMission } from "./mission-store";
-import { queueTmuxAgentDispatch } from "./primary-agent-outbox-dispatch.server";
+import {
+  queuePrimaryAgentTmuxDispatch,
+  queueTmuxAgentDispatch,
+} from "./primary-agent-outbox-dispatch.server";
 
 const tempRoots: string[] = [];
 const missionIds: string[] = [];
@@ -75,6 +78,43 @@ describe("primary-agent-outbox-dispatch.server", () => {
     );
     expect(getMission(mission.id)?.activityLog.map((entry) => entry.body).join("\n") ?? "").not.toContain(
       "Delegated worker task payload",
+    );
+  });
+
+  it("queues Lunafreya primary-agent deliveries through the shared tmux contract", () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    const mission = createMission("mission-lunafreya-queue", "session-lunafreya", {
+      title: "Lunafreya queue mission",
+      objective: "Queue primary-agent deliveries through tmux transport",
+      executionProjectId: "alpha",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+    missionIds.push(mission.id);
+
+    const item = queuePrimaryAgentTmuxDispatch({
+      missionId: mission.id,
+      agent: "lunafreya",
+      sessionId: "session-lunafreya",
+      sessionTitle: `mission:${mission.id}:lunafreya`,
+      parts: [{ type: "text", text: "Lunafreya primary-agent payload" }],
+    });
+
+    expect(item).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "lunafreya",
+        sessionId: "session-lunafreya",
+        sessionTitle: `mission:${mission.id}:lunafreya`,
+      },
+    });
+    expect(listPrimaryAgentOutboxItems(mission.id)).toEqual([item]);
+    expect(getMission(mission.id)?.activityLog).toContainEqual(
+      expect.objectContaining({
+        kind: "system_event",
+        body: "Queued primary-agent tmux delivery.",
+      }),
     );
   });
 });

--- a/web/app/lib/session-owner-routing.server.test.ts
+++ b/web/app/lib/session-owner-routing.server.test.ts
@@ -18,6 +18,7 @@ vi.mock("./opencode-server", () => ({
 }));
 
 import { createMission, deleteMission } from "./mission-store";
+import { saveOwnedSession } from "./owned-session-registry.server";
 import { resolveSessionRouteTarget } from "./session-owner-routing.server";
 
 const tempRoots: string[] = [];
@@ -74,6 +75,44 @@ afterEach(() => {
 });
 
 describe("session-owner-routing.server", () => {
+  it("resolves an Iris-owned tmux session to the Iris endpoint", () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeEndpointManifest(root, [
+      {
+        agentId: "iris",
+        port: 4405,
+        url: "http://127.0.0.1:4405",
+      },
+    ]);
+    saveOwnedSession({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+
+    const target = resolveSessionRouteTarget("session-iris");
+
+    expect(target).toMatchObject({
+      endpointUrl: "http://127.0.0.1:4405",
+      mode: "owned",
+      ownerAgent: "iris",
+      managedSession: null,
+      ownedSession: expect.objectContaining({
+        ownerAgent: "iris",
+        surface: "projects-iris",
+      }),
+    });
+    expect(target.client).toEqual({
+      options: {
+        baseUrl: "http://127.0.0.1:4405",
+        directory: root,
+      },
+    });
+  });
+
   it("resolves a managed tmux session to its owning agent endpoint", () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;

--- a/web/app/lib/session-owner-routing.server.ts
+++ b/web/app/lib/session-owner-routing.server.ts
@@ -7,6 +7,8 @@ import { findManagedSession } from "./managed-session.server";
 import { getManagedSessionTitle } from "./managed-session-titles";
 import { getMission, setMissionPrimarySession, setWorkerSession } from "./mission-store";
 import { createProjectOpencodeClient, getOpencodeClient } from "./opencode-client";
+import type { OwnedSessionEntry } from "./owned-session-registry.server";
+import { readOwnedSession } from "./owned-session-registry.server";
 import type { AgentId } from "./types/mission";
 import { activateTmuxMissionWriteFocus, getTmuxMissionWriteConflict } from "./tmux-mission-activation.server";
 
@@ -24,7 +26,8 @@ export interface SessionRouteTarget {
   client: ReturnType<typeof createProjectOpencodeClient>;
   endpointUrl: string | null;
   managedSession: ManagedSessionInfo | null;
-  mode: "managed" | "default";
+  mode: "managed" | "owned" | "default";
+  ownedSession: OwnedSessionEntry | null;
   ownerAgent: string | null;
 }
 
@@ -41,6 +44,12 @@ export interface TmuxWriteTarget {
   ownerAgent: AgentId;
   sessionId: string;
   sessionTitle: string;
+}
+
+export interface OwnerEndpointTarget {
+  client: ReturnType<typeof createProjectOpencodeClient>;
+  endpointUrl: string;
+  ownerAgent: string;
 }
 
 function toErrorMessage(error: unknown): string {
@@ -119,27 +128,58 @@ function readEndpointManifest(root: string): EndpointManifest | null {
   };
 }
 
-export function resolveSessionRouteTarget(sessionId: string): SessionRouteTarget {
-  const managedSession = findManagedSession(sessionId);
-  if (!managedSession) {
-    return {
-      client: getOpencodeClient(),
-      endpointUrl: null,
-      managedSession: null,
-      mode: "default",
-      ownerAgent: null,
-    };
-  }
-
+export function resolveOwnerEndpointTarget(
+  ownerAgent: string,
+  context: string,
+): OwnerEndpointTarget {
   const root = getProjectRoot();
-  const endpointUrl = resolveManagedEndpointUrl(root, managedSession.ownerAgent, `managed session ${sessionId}`);
+  const endpointUrl = resolveManagedEndpointUrl(root, ownerAgent, context);
 
   return {
     client: createProjectOpencodeClient(endpointUrl),
     endpointUrl,
-    managedSession,
-    mode: "managed",
-    ownerAgent: managedSession.ownerAgent,
+    ownerAgent,
+  };
+}
+
+export function resolveSessionRouteTarget(sessionId: string): SessionRouteTarget {
+  const managedSession = findManagedSession(sessionId);
+  if (managedSession) {
+    const root = getProjectRoot();
+    const endpointUrl = resolveManagedEndpointUrl(root, managedSession.ownerAgent, `managed session ${sessionId}`);
+
+    return {
+      client: createProjectOpencodeClient(endpointUrl),
+      endpointUrl,
+      managedSession,
+      mode: "managed",
+      ownedSession: null,
+      ownerAgent: managedSession.ownerAgent,
+    };
+  }
+
+  const ownedSession = readOwnedSession(sessionId);
+  if (ownedSession) {
+    const root = getProjectRoot();
+    const endpointUrl = resolveManagedEndpointUrl(root, ownedSession.ownerAgent, `owned session ${sessionId}`);
+
+    return {
+      client: createProjectOpencodeClient(endpointUrl),
+      endpointUrl,
+      managedSession: null,
+      mode: "owned",
+      ownedSession,
+      ownerAgent: ownedSession.ownerAgent,
+    };
+  }
+
+  return {
+    client: getOpencodeClient(),
+    endpointUrl: null,
+    managedSession: null,
+    mode: "default",
+    ownedSession: null,
+    ownerAgent: null,
   };
 }
 

--- a/web/app/lib/tmux-monitor.server.test.ts
+++ b/web/app/lib/tmux-monitor.server.test.ts
@@ -1,0 +1,139 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getConfiguredMissionTransportStatusMock,
+  listSessionStatusTargetsMock,
+  spawnSyncMock,
+} = vi.hoisted(() => ({
+  getConfiguredMissionTransportStatusMock: vi.fn(),
+  listSessionStatusTargetsMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+vi.mock("./tmux-transport-bootstrap.server", () => ({
+  getConfiguredMissionTransportStatus: getConfiguredMissionTransportStatusMock,
+}));
+
+vi.mock("./session-owner-routing.server", () => ({
+  listSessionStatusTargets: listSessionStatusTargetsMock,
+}));
+
+import { readTmuxMonitorSnapshot } from "./tmux-monitor.server";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-tmux-monitor-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+afterEach(() => {
+  getConfiguredMissionTransportStatusMock.mockReset();
+  listSessionStatusTargetsMock.mockReset();
+  spawnSyncMock.mockReset();
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("tmux-monitor.server", () => {
+  it("collects pane output and per-agent status in tmux-resident mode", async () => {
+    const root = createTempRoot();
+
+    getConfiguredMissionTransportStatusMock.mockResolvedValue({
+      bootstrapStatus: {
+        agentCount: 6,
+        dispatcherPid: 4321,
+        error: null,
+        isReady: true,
+        lastStartedAt: "2026-05-01T00:00:00.000Z",
+      },
+      error: null,
+      isReady: true,
+      transportMode: "tmux-resident",
+    });
+
+    listSessionStatusTargetsMock.mockReturnValue([
+      {
+        agentId: "noctis",
+        client: {
+          session: {
+            status: vi.fn().mockResolvedValue({
+              data: {
+                "session-noctis": { type: "busy" },
+              },
+              error: null,
+            }),
+          },
+        },
+      },
+      {
+        agentId: "ignis",
+        client: {
+          session: {
+            status: vi.fn().mockResolvedValue({
+              data: {
+                "session-ignis": { type: "idle" },
+              },
+              error: null,
+            }),
+          },
+        },
+      },
+    ]);
+
+    spawnSyncMock.mockImplementation((_file: string, args?: string[]) => {
+      const target = Array.isArray(args) ? args[2] : "";
+      if (target === "ff15:main.0") {
+        return { status: 0, stderr: "", stdout: "Noctis pane output\n" };
+      }
+      if (target === "ff15:main.1") {
+        return { status: 0, stderr: "", stdout: "Ignis pane output\n" };
+      }
+
+      return { status: 1, stderr: "missing pane", stdout: "" };
+    });
+
+    const snapshot = await readTmuxMonitorSnapshot(root);
+
+    expect(snapshot.transportMode).toBe("tmux-resident");
+    expect(snapshot.bootstrapStatus).toMatchObject({
+      dispatcherPid: 4321,
+      isReady: true,
+    });
+    expect(snapshot.agentStatuses).toMatchObject({
+      ignis: "idle",
+      noctis: "busy",
+    });
+    expect(snapshot.panes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agentId: "noctis",
+          content: "Noctis pane output\n",
+          paneIndex: 0,
+          target: "ff15:main.0",
+        }),
+        expect.objectContaining({
+          agentId: "ignis",
+          content: "Ignis pane output\n",
+          paneIndex: 1,
+          target: "ff15:main.1",
+        }),
+      ]),
+    );
+  });
+});

--- a/web/app/lib/tmux-monitor.server.ts
+++ b/web/app/lib/tmux-monitor.server.ts
@@ -1,0 +1,133 @@
+import { spawnSync } from "node:child_process";
+import { getProjectRoot } from "@/lib/get-project-root.server";
+import { listSessionStatusTargets } from "@/lib/session-owner-routing.server";
+import { coerceSessionStatus } from "@/lib/session-status";
+import {
+  getConfiguredMissionTransportStatus,
+  type TmuxTransportBootstrapStatus,
+} from "@/lib/tmux-transport-bootstrap.server";
+
+export type TmuxMonitorAgentId =
+  | "noctis"
+  | "ignis"
+  | "gladiolus"
+  | "prompto"
+  | "lunafreya"
+  | "iris";
+
+export type TmuxMonitorAgentStatus = "busy" | "idle" | "retry" | "offline" | "unknown";
+
+export type TmuxMonitorPane = {
+  agentId: TmuxMonitorAgentId;
+  content: string;
+  paneIndex: number;
+  target: string;
+};
+
+export type TmuxMonitorSnapshot = {
+  agentStatuses: Record<TmuxMonitorAgentId, TmuxMonitorAgentStatus>;
+  bootstrapStatus: TmuxTransportBootstrapStatus | null;
+  panes: TmuxMonitorPane[];
+  transportMode: string;
+};
+
+const TMUX_MONITOR_PANES: ReadonlyArray<{ agentId: TmuxMonitorAgentId; paneIndex: number }> = [
+  { agentId: "noctis", paneIndex: 0 },
+  { agentId: "ignis", paneIndex: 1 },
+  { agentId: "gladiolus", paneIndex: 2 },
+  { agentId: "prompto", paneIndex: 3 },
+  { agentId: "lunafreya", paneIndex: 4 },
+  { agentId: "iris", paneIndex: 5 },
+];
+
+const PANE_CAPTURE_TIMEOUT_MS = 2000;
+const TMUX_SESSION_NAME = "ff15";
+const MISSING_PANE_MESSAGE = "Pane not available.";
+
+function deriveAgentStatus(value: unknown): TmuxMonitorAgentStatus {
+  if (!value || typeof value !== "object") {
+    return "idle";
+  }
+
+  const entries = Object.values(value as Record<string, unknown>)
+    .map((entry) => coerceSessionStatus(entry))
+    .filter((status): status is NonNullable<typeof status> => status !== null);
+
+  if (entries.includes("busy")) {
+    return "busy";
+  }
+
+  if (entries.includes("retry")) {
+    return "retry";
+  }
+
+  return entries[0] ?? "idle";
+}
+
+async function readAgentStatuses(): Promise<Record<TmuxMonitorAgentId, TmuxMonitorAgentStatus>> {
+  const statuses = Object.fromEntries(
+    TMUX_MONITOR_PANES.map(({ agentId }) => [agentId, "unknown"]),
+  ) as Record<TmuxMonitorAgentId, TmuxMonitorAgentStatus>;
+
+  for (const target of listSessionStatusTargets()) {
+    const agentId = target.agentId as TmuxMonitorAgentId;
+    if (!(agentId in statuses)) {
+      continue;
+    }
+
+    try {
+      const result = await target.client.session.status();
+      if (result.error) {
+        statuses[agentId] = "offline";
+        continue;
+      }
+
+      statuses[agentId] = deriveAgentStatus(result.data ?? {});
+    } catch {
+      statuses[agentId] = "offline";
+    }
+  }
+
+  return statuses;
+}
+
+function readPanes(root: string): TmuxMonitorPane[] {
+  return TMUX_MONITOR_PANES.map(({ agentId, paneIndex }) => {
+    const target = `${TMUX_SESSION_NAME}:main.${paneIndex}`;
+    const result = spawnSync("tmux", ["capture-pane", "-t", target, "-p", "-e"], {
+      cwd: root,
+      encoding: "utf-8",
+      timeout: PANE_CAPTURE_TIMEOUT_MS,
+    });
+
+    return {
+      agentId,
+      content: (result.status ?? 1) === 0 ? (result.stdout ?? "") : MISSING_PANE_MESSAGE,
+      paneIndex,
+      target,
+    };
+  });
+}
+
+export async function readTmuxMonitorSnapshot(root = getProjectRoot()): Promise<TmuxMonitorSnapshot> {
+  const transportStatus = await getConfiguredMissionTransportStatus(root);
+  if (transportStatus.transportMode !== "tmux-resident") {
+    return {
+      agentStatuses: Object.fromEntries(
+        TMUX_MONITOR_PANES.map(({ agentId }) => [agentId, "unknown"]),
+      ) as Record<TmuxMonitorAgentId, TmuxMonitorAgentStatus>,
+      bootstrapStatus: null,
+      panes: [],
+      transportMode: transportStatus.transportMode,
+    };
+  }
+
+  const [agentStatuses, panes] = await Promise.all([readAgentStatuses(), Promise.resolve(readPanes(root))]);
+
+  return {
+    agentStatuses,
+    bootstrapStatus: transportStatus.bootstrapStatus,
+    panes,
+    transportMode: transportStatus.transportMode,
+  };
+}

--- a/web/app/lib/tmux-transport-abort.server.test.ts
+++ b/web/app/lib/tmux-transport-abort.server.test.ts
@@ -150,4 +150,17 @@ describe("tmux transport abort helper", () => {
 
     expect(readFileSync(logPath, "utf-8").trim()).toBe("send-keys -t ff15:main.3 Escape");
   });
+
+  it("sends Escape to the Lunafreya pane for active tmux-managed responses", () => {
+    const root = createTempRoot();
+    const logPath = installFakeTmux(root);
+
+    interruptManagedTmuxSession({
+      method: "escape",
+      ownerAgent: "lunafreya",
+      root,
+    });
+
+    expect(readFileSync(logPath, "utf-8").trim()).toBe("send-keys -t ff15:main.4 Escape");
+  });
 });

--- a/web/app/lib/tmux-transport-abort.server.ts
+++ b/web/app/lib/tmux-transport-abort.server.ts
@@ -8,12 +8,15 @@ import type { AgentId } from "@/lib/types/mission";
 export const TMUX_TRANSPORT_ABORT_REQUEST_DIR = "tmux-transport-aborts";
 export const TMUX_TRANSPORT_CURRENT_DISPATCH_FILE = "tmux-transport-current-dispatch.json";
 
-const TMUX_AGENT_PANE_INDEX: Record<AgentId, number> = {
+export type TmuxTransportOwnerAgent = AgentId | "iris";
+
+const TMUX_AGENT_PANE_INDEX: Record<TmuxTransportOwnerAgent, number> = {
   noctis: 0,
   ignis: 1,
   gladiolus: 2,
   prompto: 3,
   lunafreya: 4,
+  iris: 5,
 };
 const TMUX_SESSION_NAME = "ff15";
 
@@ -27,7 +30,7 @@ export type TmuxDispatchPhase =
 export type ManagedTmuxInterruptMethod = "ctrl-c" | "escape";
 
 export interface TmuxCurrentDispatchRecord {
-  agent: AgentId;
+  agent: TmuxTransportOwnerAgent;
   itemId: string;
   missionId: string;
   phase: TmuxDispatchPhase;
@@ -58,8 +61,15 @@ function isDispatchPhase(value: unknown): value is TmuxDispatchPhase {
   );
 }
 
-function isAgentId(value: unknown): value is AgentId {
-  return value === "noctis" || value === "ignis" || value === "gladiolus" || value === "prompto" || value === "lunafreya";
+function isAgentId(value: unknown): value is TmuxTransportOwnerAgent {
+  return (
+    value === "noctis" ||
+    value === "ignis" ||
+    value === "gladiolus" ||
+    value === "prompto" ||
+    value === "lunafreya" ||
+    value === "iris"
+  );
 }
 
 function normalizeCurrentDispatch(value: unknown): TmuxCurrentDispatchRecord | null {
@@ -157,7 +167,7 @@ export function requestTmuxDispatchAbortForSession(input: {
 
 export function interruptManagedTmuxSession(input: {
   method: ManagedTmuxInterruptMethod;
-  ownerAgent: AgentId;
+  ownerAgent: TmuxTransportOwnerAgent;
   root?: string;
 }): void {
   const root = input.root ?? getProjectRoot();

--- a/web/app/lib/tmux-transport-dispatcher.test.ts
+++ b/web/app/lib/tmux-transport-dispatcher.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listOwnedSessionTmuxDispatchItems,
+  queueOwnedSessionTmuxDispatch,
+} from "./owned-session-transport.server";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-dispatcher-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+afterEach(() => {
+  spawnSyncMock.mockReset();
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("tmux_transport_dispatcher", () => {
+  it("submits owned Iris dispatches through pane 5 using the retained session title", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    spawnSyncMock.mockImplementation((file: string) => {
+      if (file === "tmux" || file === "sleep") {
+        return { status: 0, stderr: "", stdout: "" };
+      }
+
+      return { status: 1, stderr: `Unexpected command ${file}`, stdout: "" };
+    });
+
+    const dispatcherModulePath = "../../../scripts/tmux_transport_dispatcher";
+    const { submitClaimedItem } = (await import(dispatcherModulePath)) as {
+      submitClaimedItem: (root: string, item: ReturnType<typeof queueOwnedSessionTmuxDispatch>) => void;
+    };
+    const item = queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: "Refresh the project registry." }],
+    });
+
+    submitClaimedItem(root, item);
+
+    const tmuxCalls = spawnSyncMock.mock.calls.filter(([file]) => file === "tmux");
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          args[4] === "Switch session",
+      ),
+    ).toBe(true);
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          args[4] === "iris:projects",
+      ),
+    ).toBe(true);
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          typeof args[4] === "string" &&
+          args[4].includes("Refresh the project registry."),
+      ),
+    ).toBe(true);
+
+    expect(listOwnedSessionTmuxDispatchItems("session-iris")).toEqual([
+      expect.objectContaining({
+        status: "submitted",
+        submission: expect.objectContaining({
+          submittedBy: expect.stringMatching(/^dispatcher:/),
+        }),
+      }),
+    ]);
+  });
+});

--- a/web/app/routes/_layout.monitor/components/tmux-monitor-pane.test.tsx
+++ b/web/app/routes/_layout.monitor/components/tmux-monitor-pane.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TmuxMonitorPaneCard } from "./tmux-monitor-pane";
+
+describe("TmuxMonitorPaneCard", () => {
+  it("renders ANSI color output as styled HTML instead of raw escape text", () => {
+    const markup = renderToStaticMarkup(
+      <TmuxMonitorPaneCard
+        pane={{
+          agentId: "noctis",
+          content: "\u001b[38;2;255;0;0mRED\u001b[0m",
+          paneIndex: 0,
+          target: "ff15:main.0",
+        }}
+        status="busy"
+      />,
+    );
+
+    expect(markup).toContain("RED");
+    expect(markup).not.toContain("\u001b[38;2;255;0;0m");
+    expect(markup).toContain("color:rgb");
+  });
+
+  it("keeps pane content inside a dual-axis scroll region", () => {
+    const markup = renderToStaticMarkup(
+      <TmuxMonitorPaneCard
+        pane={{
+          agentId: "ignis",
+          content: "wide output",
+          paneIndex: 1,
+          target: "ff15:main.1",
+        }}
+        status="idle"
+      />,
+    );
+
+    expect(markup).toContain("overflow-auto");
+    expect(markup).toContain("min-w-max");
+    expect(markup).toContain("whitespace-pre");
+  });
+
+  it("uses tight terminal spacing so the pane background does not show as horizontal stripes", () => {
+    const markup = renderToStaticMarkup(
+      <TmuxMonitorPaneCard
+        pane={{
+          agentId: "lunafreya",
+          content: "line 1\nline 2",
+          paneIndex: 4,
+          target: "ff15:main.4",
+        }}
+        status="idle"
+      />,
+    );
+
+    expect(markup).toContain("bg-[#0a0a0a]");
+    expect(markup).toContain("px-2");
+    expect(markup).toContain("py-2");
+    expect(markup).toContain("leading-none");
+  });
+});

--- a/web/app/routes/_layout.monitor/components/tmux-monitor-pane.tsx
+++ b/web/app/routes/_layout.monitor/components/tmux-monitor-pane.tsx
@@ -1,0 +1,280 @@
+import { Fragment, useMemo, type CSSProperties, type ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import type { TmuxMonitorAgentStatus, TmuxMonitorPane } from "@/lib/tmux-monitor.server";
+
+type TmuxMonitorPaneCardProps = {
+  pane: TmuxMonitorPane;
+  status: TmuxMonitorAgentStatus;
+};
+
+type TerminalStyleState = {
+  backgroundColor: string | null;
+  color: string | null;
+  fontWeight: CSSProperties["fontWeight"] | null;
+};
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI SGR escape codes intentionally include ESC.
+const ANSI_SGR_REGEX = /\u001b\[([0-9;]*)m/g;
+
+const ANSI_BASE_PALETTE = [
+  [0, 0, 0],
+  [128, 0, 0],
+  [0, 128, 0],
+  [128, 128, 0],
+  [0, 0, 128],
+  [128, 0, 128],
+  [0, 128, 128],
+  [192, 192, 192],
+  [128, 128, 128],
+  [255, 0, 0],
+  [0, 255, 0],
+  [255, 255, 0],
+  [0, 0, 255],
+  [255, 0, 255],
+  [0, 255, 255],
+  [255, 255, 255],
+] as const;
+
+const STATUS_TONE_CLASS_NAMES: Record<TmuxMonitorAgentStatus, string> = {
+  busy: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  idle: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  offline: "bg-zinc-500/15 text-zinc-300 border-zinc-500/30",
+  retry: "bg-sky-500/15 text-sky-300 border-sky-500/30",
+  unknown: "bg-zinc-500/15 text-zinc-300 border-zinc-500/30",
+};
+
+function createDefaultTerminalStyle(): TerminalStyleState {
+  return {
+    backgroundColor: null,
+    color: null,
+    fontWeight: null,
+  };
+}
+
+function rgbString(red: number, green: number, blue: number): string {
+  return `rgb(${red},${green},${blue})`;
+}
+
+function ansi256Color(index: number): string {
+  if (index < 16) {
+    const [red, green, blue] = ANSI_BASE_PALETTE[index] ?? ANSI_BASE_PALETTE[0];
+    return rgbString(red, green, blue);
+  }
+
+  if (index >= 232) {
+    const value = 8 + (index - 232) * 10;
+    return rgbString(value, value, value);
+  }
+
+  const cubeIndex = index - 16;
+  const red = Math.floor(cubeIndex / 36);
+  const green = Math.floor((cubeIndex % 36) / 6);
+  const blue = cubeIndex % 6;
+  const toChannel = (value: number) => (value === 0 ? 0 : 55 + value * 40);
+
+  return rgbString(toChannel(red), toChannel(green), toChannel(blue));
+}
+
+function basicColor(code: number): string | null {
+  if (code >= 30 && code <= 37) {
+    const [red, green, blue] = ANSI_BASE_PALETTE[code - 30] ?? ANSI_BASE_PALETTE[0];
+    return rgbString(red, green, blue);
+  }
+
+  if (code >= 90 && code <= 97) {
+    const [red, green, blue] = ANSI_BASE_PALETTE[code - 90 + 8] ?? ANSI_BASE_PALETTE[8];
+    return rgbString(red, green, blue);
+  }
+
+  return null;
+}
+
+function basicBackgroundColor(code: number): string | null {
+  if (code >= 40 && code <= 47) {
+    const [red, green, blue] = ANSI_BASE_PALETTE[code - 40] ?? ANSI_BASE_PALETTE[0];
+    return rgbString(red, green, blue);
+  }
+
+  if (code >= 100 && code <= 107) {
+    const [red, green, blue] = ANSI_BASE_PALETTE[code - 100 + 8] ?? ANSI_BASE_PALETTE[8];
+    return rgbString(red, green, blue);
+  }
+
+  return null;
+}
+
+function applyAnsiCodes(input: TerminalStyleState, rawCodes: number[]): TerminalStyleState {
+  let next = { ...input };
+  const codes = rawCodes.length > 0 ? rawCodes : [0];
+
+  for (let index = 0; index < codes.length; index += 1) {
+    const code = codes[index] ?? 0;
+
+    if (code === 0) {
+      next = createDefaultTerminalStyle();
+      continue;
+    }
+
+    if (code === 1) {
+      next.fontWeight = 700;
+      continue;
+    }
+
+    if (code === 22) {
+      next.fontWeight = null;
+      continue;
+    }
+
+    if (code === 39) {
+      next.color = null;
+      continue;
+    }
+
+    if (code === 49) {
+      next.backgroundColor = null;
+      continue;
+    }
+
+    const nextForeground = basicColor(code);
+    if (nextForeground) {
+      next.color = nextForeground;
+      continue;
+    }
+
+    const nextBackground = basicBackgroundColor(code);
+    if (nextBackground) {
+      next.backgroundColor = nextBackground;
+      continue;
+    }
+
+    if (code !== 38 && code !== 48) {
+      continue;
+    }
+
+    const mode = codes[index + 1];
+    if (mode === 2) {
+      const red = codes[index + 2] ?? 0;
+      const green = codes[index + 3] ?? 0;
+      const blue = codes[index + 4] ?? 0;
+      const value = rgbString(red, green, blue);
+      if (code === 38) {
+        next.color = value;
+      } else {
+        next.backgroundColor = value;
+      }
+      index += 4;
+      continue;
+    }
+
+    if (mode === 5) {
+      const paletteIndex = codes[index + 2] ?? 0;
+      const value = ansi256Color(paletteIndex);
+      if (code === 38) {
+        next.color = value;
+      } else {
+        next.backgroundColor = value;
+      }
+      index += 2;
+    }
+  }
+
+  return next;
+}
+
+function toReactStyle(state: TerminalStyleState): CSSProperties | undefined {
+  const style: CSSProperties = {};
+
+  if (state.color) {
+    style.color = state.color;
+  }
+
+  if (state.backgroundColor) {
+    style.backgroundColor = state.backgroundColor;
+  }
+
+  if (state.fontWeight) {
+    style.fontWeight = state.fontWeight;
+  }
+
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function renderAnsiText(source: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let styleState = createDefaultTerminalStyle();
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of source.matchAll(ANSI_SGR_REGEX)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      const chunk = source.slice(lastIndex, matchIndex);
+      const style = toReactStyle(styleState);
+      nodes.push(
+        style ? (
+          <span key={key} style={style}>
+            {chunk}
+          </span>
+        ) : (
+          <Fragment key={key}>{chunk}</Fragment>
+        ),
+      );
+      key += 1;
+    }
+
+    const codes = (match[1] ?? "")
+      .split(";")
+      .filter((code) => code.length > 0)
+      .map((code) => Number.parseInt(code, 10))
+      .filter((code) => Number.isFinite(code));
+    styleState = applyAnsiCodes(styleState, codes);
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < source.length || nodes.length === 0) {
+    const chunk = lastIndex < source.length ? source.slice(lastIndex) : source;
+    const style = toReactStyle(styleState);
+    nodes.push(
+      style ? (
+        <span key={key} style={style}>
+          {chunk}
+        </span>
+      ) : (
+        <Fragment key={key}>{chunk}</Fragment>
+      ),
+    );
+  }
+
+  return nodes;
+}
+
+export function TmuxMonitorPaneCard({ pane, status }: TmuxMonitorPaneCardProps) {
+  const renderedContent = useMemo(() => {
+    const source = pane.content.length > 0 ? pane.content : "Waiting for output...";
+    return renderAnsiText(source);
+  }, [pane.content]);
+
+  return (
+    <article className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-zinc-800 bg-[#0a0a0a] font-mono shadow-lg">
+      <div className="flex items-center justify-between border-b border-white/5 bg-zinc-900/40 px-3 py-2">
+        <div className="min-w-0">
+          <div className="font-bold text-[11px] uppercase tracking-[0.24em] text-zinc-200">
+            {pane.agentId}
+          </div>
+          <div className="truncate text-[10px] text-zinc-400">{pane.target}</div>
+        </div>
+        <Badge className={STATUS_TONE_CLASS_NAMES[status]} variant="outline">
+          {status.toUpperCase()}
+        </Badge>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="min-w-max bg-[#0a0a0a] px-2 py-2">
+          <pre className="m-0 whitespace-pre text-[11px] leading-none text-emerald-50">
+            {renderedContent}
+          </pre>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/web/app/routes/_layout.monitor/route.test.tsx
+++ b/web/app/routes/_layout.monitor/route.test.tsx
@@ -137,6 +137,7 @@ describe("tmux monitor route", () => {
     expect(markup).toContain("Noctis pane output");
     expect(markup).toContain("Ignis pane output");
     expect(markup).toContain("lg:grid-cols-3");
+    expect(markup).toContain("lg:grid-flow-col");
     expect(markup).toContain("lg:grid-rows-2");
     expect(markup).toContain("w-full");
   });

--- a/web/app/routes/_layout.monitor/route.test.tsx
+++ b/web/app/routes/_layout.monitor/route.test.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const { readTmuxMonitorSnapshotMock } = vi.hoisted(() => ({
+  readTmuxMonitorSnapshotMock: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+
+  return {
+    ...actual,
+    useRevalidator: () => ({
+      revalidate: vi.fn(),
+      state: "idle",
+    }),
+  };
+});
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("./components/tmux-monitor-pane", () => ({
+  TmuxMonitorPaneCard: ({ pane }: { pane: { agentId: string; content: string } }) => (
+    <div>
+      {pane.agentId}
+      {pane.content}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/tmux-monitor.server", () => ({
+  readTmuxMonitorSnapshot: readTmuxMonitorSnapshotMock,
+}));
+
+import { loader, TmuxMonitorPage } from "./route";
+
+const TestPage = TmuxMonitorPage as unknown as (props: { loaderData: unknown }) => ReactNode;
+
+describe("tmux monitor route", () => {
+  it("loads the monitor snapshot from the server helper", async () => {
+    readTmuxMonitorSnapshotMock.mockResolvedValue({
+      agentStatuses: {
+        noctis: "busy",
+      },
+      bootstrapStatus: null,
+      panes: [],
+      transportMode: "tmux-resident",
+    });
+
+    await expect(loader({} as never)).resolves.toEqual({
+      agentStatuses: {
+        noctis: "busy",
+      },
+      bootstrapStatus: null,
+      panes: [],
+      transportMode: "tmux-resident",
+    });
+    expect(readTmuxMonitorSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the tmux transport summary and pane roster", () => {
+    const markup = renderToStaticMarkup(
+      <TestPage
+        loaderData={{
+          agentStatuses: {
+            gladiolus: "idle",
+            ignis: "idle",
+            iris: "idle",
+            lunafreya: "idle",
+            noctis: "busy",
+            prompto: "idle",
+          },
+          bootstrapStatus: {
+            agentCount: 6,
+            dispatcherPid: 4321,
+            error: null,
+            isReady: true,
+            lastStartedAt: "2026-05-01T00:00:00.000Z",
+          },
+          panes: [
+            {
+              agentId: "noctis",
+              content: "Noctis pane output",
+              paneIndex: 0,
+              target: "ff15:main.0",
+            },
+            {
+              agentId: "ignis",
+              content: "Ignis pane output",
+              paneIndex: 1,
+              target: "ff15:main.1",
+            },
+            {
+              agentId: "gladiolus",
+              content: "Gladiolus pane output",
+              paneIndex: 2,
+              target: "ff15:main.2",
+            },
+            {
+              agentId: "prompto",
+              content: "Prompto pane output",
+              paneIndex: 3,
+              target: "ff15:main.3",
+            },
+            {
+              agentId: "lunafreya",
+              content: "Lunafreya pane output",
+              paneIndex: 4,
+              target: "ff15:main.4",
+            },
+            {
+              agentId: "iris",
+              content: "Iris pane output",
+              paneIndex: 5,
+              target: "ff15:main.5",
+            },
+          ],
+          transportMode: "tmux-resident",
+        } as never}
+      />, 
+    );
+
+    expect(markup).toContain("Tmux Monitor");
+    expect(markup).toContain("Transport Ready");
+    expect(markup).toContain("Noctis pane output");
+    expect(markup).toContain("Ignis pane output");
+    expect(markup).toContain("lg:grid-cols-3");
+    expect(markup).toContain("lg:grid-rows-2");
+    expect(markup).toContain("w-full");
+  });
+});

--- a/web/app/routes/_layout.monitor/route.test.tsx
+++ b/web/app/routes/_layout.monitor/route.test.tsx
@@ -19,16 +19,26 @@ vi.mock("react-router", async () => {
 });
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  Button: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <button className={className} type="button">
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock("@/components/ui/card", () => ({
-  Card: ({ children }: { children: ReactNode }) => <section>{children}</section>,
-  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Card: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <section className={className}>{children}</section>
+  ),
+  CardContent: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
 }));
 
 vi.mock("@/components/ui/badge", () => ({
-  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Badge: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
 }));
 
 vi.mock("./components/tmux-monitor-pane", () => ({
@@ -136,6 +146,10 @@ describe("tmux monitor route", () => {
     expect(markup).toContain("Transport Ready");
     expect(markup).toContain("Noctis pane output");
     expect(markup).toContain("Ignis pane output");
+    expect(markup).toContain("gap-3 overflow-hidden p-3 md:p-4");
+    expect(markup).toContain("items-center justify-between gap-3");
+    expect(markup).not.toContain("Inspect the tmux-resident transport and live pane output for each agent.");
+    expect(markup).not.toContain("p-6 md:grid-cols-4");
     expect(markup).toContain("lg:grid-cols-3");
     expect(markup).toContain("lg:grid-flow-col");
     expect(markup).toContain("lg:grid-rows-2");

--- a/web/app/routes/_layout.monitor/route.tsx
+++ b/web/app/routes/_layout.monitor/route.tsx
@@ -1,8 +1,8 @@
 import { Monitor, RefreshCw } from "lucide-react";
 import { useEffect } from "react";
 import { useRevalidator } from "react-router";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   readTmuxMonitorSnapshot,
   type TmuxMonitorSnapshot,
@@ -38,6 +38,8 @@ function getTransportLabel(loaderData: TmuxMonitorSnapshot): string {
 
 export const TmuxMonitorPage = ({ loaderData }: Route.ComponentProps) => {
   const revalidator = useRevalidator();
+  const transportLabel = getTransportLabel(loaderData);
+  const lastStarted = formatTimestamp(loaderData.bootstrapStatus?.lastStartedAt ?? null);
 
   useEffect(() => {
     if (loaderData.transportMode !== "tmux-resident") {
@@ -57,50 +59,40 @@ export const TmuxMonitorPage = ({ loaderData }: Route.ComponentProps) => {
 
   return (
     <div className="h-full min-h-0 overflow-hidden">
-      <div className="flex h-full min-h-0 w-full flex-col gap-5 overflow-hidden p-4 md:p-6">
-        <div className="flex shrink-0 flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-background/70">
-                <Monitor className="h-5 w-5" />
+      <div className="flex h-full min-h-0 w-full flex-col gap-3 overflow-hidden p-3 md:p-4">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            <div className="flex items-center gap-2 pr-1">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-border/60 bg-background/70">
+                <Monitor className="h-4 w-4" />
               </div>
-              <div>
-                <h1 className="text-xl">Tmux Monitor</h1>
-                <p className="text-muted-foreground text-sm">
-                  Inspect the tmux-resident transport and live pane output for each agent.
-                </p>
-              </div>
+              <h1 className="text-base leading-none">Tmux Monitor</h1>
             </div>
+
+            <Badge className="rounded-full px-2 py-1 text-[11px]" variant="outline">
+              Mode: {loaderData.transportMode}
+            </Badge>
+            <Badge className="rounded-full px-2 py-1 text-[11px]" variant="outline">
+              Status: {transportLabel}
+            </Badge>
+            <Badge className="rounded-full px-2 py-1 text-[11px]" variant="outline">
+              PID: {loaderData.bootstrapStatus?.dispatcherPid ?? "-"}
+            </Badge>
+            <Badge className="rounded-full px-2 py-1 text-[11px]" variant="outline">
+              Last Started: {lastStarted}
+            </Badge>
           </div>
 
-          <Button onClick={() => revalidator.revalidate()} type="button" variant="outline">
+          <Button
+            className="h-8 shrink-0 px-3 text-xs"
+            onClick={() => revalidator.revalidate()}
+            type="button"
+            variant="outline"
+          >
             <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
             Refresh
           </Button>
         </div>
-
-        <Card className="shrink-0">
-          <CardContent className="grid gap-3 p-6 md:grid-cols-4">
-            <div>
-              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Mode</div>
-              <div className="mt-2 text-sm">{loaderData.transportMode}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Status</div>
-              <div className="mt-2 text-sm">{getTransportLabel(loaderData)}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Dispatcher PID</div>
-              <div className="mt-2 text-sm">{loaderData.bootstrapStatus?.dispatcherPid ?? "-"}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Last Started</div>
-              <div className="mt-2 text-sm">
-                {formatTimestamp(loaderData.bootstrapStatus?.lastStartedAt ?? null)}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
 
         <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2 lg:grid-flow-col lg:grid-cols-3 lg:grid-rows-2">
           {loaderData.panes.map((pane) => (

--- a/web/app/routes/_layout.monitor/route.tsx
+++ b/web/app/routes/_layout.monitor/route.tsx
@@ -1,0 +1,119 @@
+import { Monitor, RefreshCw } from "lucide-react";
+import { useEffect } from "react";
+import { useRevalidator } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  readTmuxMonitorSnapshot,
+  type TmuxMonitorSnapshot,
+} from "@/lib/tmux-monitor.server";
+import { TmuxMonitorPaneCard } from "./components/tmux-monitor-pane";
+import type { Route } from "./+types/route";
+
+const POLL_INTERVAL_MS = 2000;
+
+export const loader = async (_args: Route.LoaderArgs): Promise<TmuxMonitorSnapshot> =>
+  readTmuxMonitorSnapshot();
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+function getTransportLabel(loaderData: TmuxMonitorSnapshot): string {
+  if (loaderData.transportMode !== "tmux-resident") {
+    return "App-Owned Transport";
+  }
+
+  return loaderData.bootstrapStatus?.isReady ? "Transport Ready" : "Transport Unavailable";
+}
+
+export const TmuxMonitorPage = ({ loaderData }: Route.ComponentProps) => {
+  const revalidator = useRevalidator();
+
+  useEffect(() => {
+    if (loaderData.transportMode !== "tmux-resident") {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      if (revalidator.state === "idle") {
+        revalidator.revalidate();
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loaderData.transportMode, revalidator]);
+
+  return (
+    <div className="h-full min-h-0 overflow-hidden">
+      <div className="flex h-full min-h-0 w-full flex-col gap-5 overflow-hidden p-4 md:p-6">
+        <div className="flex shrink-0 flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-background/70">
+                <Monitor className="h-5 w-5" />
+              </div>
+              <div>
+                <h1 className="text-xl">Tmux Monitor</h1>
+                <p className="text-muted-foreground text-sm">
+                  Inspect the tmux-resident transport and live pane output for each agent.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <Button onClick={() => revalidator.revalidate()} type="button" variant="outline">
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </div>
+
+        <Card className="shrink-0">
+          <CardContent className="grid gap-3 p-6 md:grid-cols-4">
+            <div>
+              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Mode</div>
+              <div className="mt-2 text-sm">{loaderData.transportMode}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Status</div>
+              <div className="mt-2 text-sm">{getTransportLabel(loaderData)}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Dispatcher PID</div>
+              <div className="mt-2 text-sm">{loaderData.bootstrapStatus?.dispatcherPid ?? "-"}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-xs uppercase tracking-[0.18em]">Last Started</div>
+              <div className="mt-2 text-sm">
+                {formatTimestamp(loaderData.bootstrapStatus?.lastStartedAt ?? null)}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
+          {loaderData.panes.map((pane) => (
+            <TmuxMonitorPaneCard
+              key={pane.target}
+              pane={pane}
+              status={loaderData.agentStatuses[pane.agentId] ?? "unknown"}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TmuxMonitorPage;

--- a/web/app/routes/_layout.monitor/route.tsx
+++ b/web/app/routes/_layout.monitor/route.tsx
@@ -102,7 +102,7 @@ export const TmuxMonitorPage = ({ loaderData }: Route.ComponentProps) => {
           </CardContent>
         </Card>
 
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2 lg:grid-flow-col lg:grid-cols-3 lg:grid-rows-2">
           {loaderData.panes.map((pane) => (
             <TmuxMonitorPaneCard
               key={pane.target}

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
@@ -645,7 +645,7 @@ describe("noctis-team-screen", () => {
     expect(markup).toContain("mission-output-browser");
   });
 
-  it("renders the Lunafreya surface without workflow or party chrome", () => {
+  it("renders the Lunafreya surface with banter instead of activity chrome", () => {
     paramsMock.mockReturnValue({ id: "mission-luna" });
     agentSessionStateMock.mockReturnValue({
       messages: [],
@@ -703,7 +703,8 @@ describe("noctis-team-screen", () => {
     expect(markup).toContain("header:Oracle Mission Surface");
     expect(markup).toContain("composer-status:Solo mission surface");
     expect(markup).toContain("lunafreya-status:oracle:hydraean");
-    expect(markup).toContain("activity-log:1");
+    expect(markup).toContain("banter-log");
+    expect(markup).not.toContain("activity-log:1");
     expect(markup).not.toContain("party-status-panel");
   });
 

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -46,7 +46,15 @@ type ModelPreset = {
 
 function normalizePartyAgentId(agentId: string): PresetAgentId | null {
   const normalized = normalizeBanterAgentId(agentId);
-  return normalized && PRESET_AGENT_IDS.includes(normalized) ? normalized : null;
+  switch (normalized) {
+    case "noctis":
+    case "ignis":
+    case "gladiolus":
+    case "prompto":
+      return normalized;
+    default:
+      return null;
+  }
 }
 
 const PresetSelector = memo(

--- a/web/app/routes/_layout.operations/route.test.tsx
+++ b/web/app/routes/_layout.operations/route.test.tsx
@@ -497,6 +497,7 @@ describe("operations route", () => {
       contextProjectIds: ["alpha"],
       executionProjectId: "alpha",
       model: selectedModel,
+      ownedSessionSurface: "operation-studio-iris",
       parts: [{ type: "text", text: "Revise this operation." }],
     });
 

--- a/web/app/routes/_layout.operations/route.test.tsx
+++ b/web/app/routes/_layout.operations/route.test.tsx
@@ -6,7 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildProjectOperationRef } from "@/lib/operation-definition/operation-catalog";
 
-const { buildOperationsPreviewBundleMock, irisAuthoringSheetPropsSpy, sessionChatRenderSnapshotMock, useSessionLiveThreadMock } = vi.hoisted(() => ({
+const { buildOperationsPreviewBundleMock, irisAuthoringSheetPropsSpy, sessionChatRenderSnapshotMock, useOwnedIrisSessionRealtimeMock } = vi.hoisted(() => ({
   buildOperationsPreviewBundleMock: vi.fn(() => ({ flowSteps: [] })),
   irisAuthoringSheetPropsSpy: vi.fn(),
   sessionChatRenderSnapshotMock: vi.fn(() => ({
@@ -17,7 +17,7 @@ const { buildOperationsPreviewBundleMock, irisAuthoringSheetPropsSpy, sessionCha
     scrollSignal: "none",
     streamingMessage: null,
   })),
-  useSessionLiveThreadMock: vi.fn(() => ({
+  useOwnedIrisSessionRealtimeMock: vi.fn(() => ({
     clearStreaming: vi.fn(),
     isLiveUnavailable: false,
     liveDraft: null as
@@ -28,6 +28,7 @@ const { buildOperationsPreviewBundleMock, irisAuthoringSheetPropsSpy, sessionCha
         }
       | null,
     resetLiveThread: vi.fn(),
+    sessionStatus: null as "busy" | "idle" | "retry" | null,
     streamingContent: "",
     streamingMessageId: null as string | null,
   })),
@@ -124,8 +125,8 @@ vi.mock("@/hooks/use-session-chat-render-snapshot", () => ({
   useSessionChatRenderSnapshot: sessionChatRenderSnapshotMock,
 }));
 
-vi.mock("@/hooks/use-session-live-thread", () => ({
-  useSessionLiveThread: useSessionLiveThreadMock,
+vi.mock("@/hooks/use-owned-iris-session-realtime", () => ({
+  useOwnedIrisSessionRealtime: useOwnedIrisSessionRealtimeMock,
 }));
 
 import {
@@ -251,12 +252,13 @@ afterEach(() => {
     scrollSignal: "none",
     streamingMessage: null,
   });
-  useSessionLiveThreadMock.mockReset();
-  useSessionLiveThreadMock.mockReturnValue({
+  useOwnedIrisSessionRealtimeMock.mockReset();
+  useOwnedIrisSessionRealtimeMock.mockReturnValue({
     clearStreaming: vi.fn(),
     isLiveUnavailable: false,
     liveDraft: null,
     resetLiveThread: vi.fn(),
+    sessionStatus: null,
     streamingContent: "",
     streamingMessageId: null,
   });
@@ -514,7 +516,7 @@ describe("operations route", () => {
   });
 
   it("passes a live Iris draft through to the authoring sheet before history settles", () => {
-    useSessionLiveThreadMock.mockReturnValue({
+    useOwnedIrisSessionRealtimeMock.mockReturnValue({
       clearStreaming: vi.fn(),
       isLiveUnavailable: false,
       liveDraft: {
@@ -523,6 +525,7 @@ describe("operations route", () => {
         sessionId: "session-iris-1",
       },
       resetLiveThread: vi.fn(),
+      sessionStatus: "busy",
       streamingContent: "",
       streamingMessageId: "assistant-1",
     });

--- a/web/app/routes/_layout.operations/route.tsx
+++ b/web/app/routes/_layout.operations/route.tsx
@@ -7,9 +7,8 @@ import { OperationListPane } from "@/components/operations/operation-list-pane";
 import { PreviewInputsSheet } from "@/components/operations/preview-inputs-sheet";
 import { PreviewTabs } from "@/components/operations/preview-tabs";
 import { PageContainer } from "@/components/page-container";
+import { useOwnedIrisSessionRealtime } from "@/hooks/use-owned-iris-session-realtime";
 import { useSessionChatRenderSnapshot } from "@/hooks/use-session-chat-render-snapshot";
-import { useSessionLiveThread } from "@/hooks/use-session-live-thread";
-import { useSessionStatusFeed } from "@/hooks/use-session-status-feed";
 import { useChatStore } from "@/stores/chat-store";
 import { APP_ROOT_EXECUTION_PROJECT_ID } from "@/lib/execution-context";
 import { Badge } from "@/components/ui/badge";
@@ -50,7 +49,6 @@ import {
   buildOperationsIrisStreamingText,
   createOperationsIrisOptimisticMessage,
   shouldClearOperationsIrisOptimisticMessage,
-  shouldUseOperationsIrisPollingFallback,
   type OperationsIrisOptimisticMessage,
 } from "@/lib/operations/iris-live-thread";
 import {
@@ -678,29 +676,6 @@ export const OperationsPage = ({ loaderData }: Route.ComponentProps) => {
     syncIrisContextState(operationsIrisContextKey);
   }, [operationsIrisContextKey, syncIrisContextState]);
 
-  const liveThread = useSessionLiveThread({
-    onTextPartMatched: ({ messageId, text }) => {
-      if (!messageId) {
-        return false;
-      }
-
-      let matchedExistingMessage = false;
-      setIrisMessages((current) =>
-        current.map((message) => {
-          if (message.info.id !== messageId) {
-            return message;
-          }
-
-          matchedExistingMessage = true;
-          return mergeMessageInfoText(message, text);
-        }),
-      );
-
-      return matchedExistingMessage;
-    },
-    sessionId: irisSessionId,
-  });
-
   const loadIrisMessages = useCallback(async (sessionId: string) => {
     const requestId = irisLoadRequestIdRef.current + 1;
     irisLoadRequestIdRef.current = requestId;
@@ -739,15 +714,30 @@ export const OperationsPage = ({ loaderData }: Route.ComponentProps) => {
     }
   }, []);
 
-  const sessionStatuses = useSessionStatusFeed({
-    enabled: Boolean(irisSessionId),
-    onSessionIdle: (sessionId) => {
-      if (sessionId === irisSessionId) {
-        void loadIrisMessages(sessionId);
+  const liveThread = useOwnedIrisSessionRealtime({
+    loadMessages: loadIrisMessages,
+    onTextPartMatched: ({ messageId, text }) => {
+      if (!messageId) {
+        return false;
       }
+
+      let matchedExistingMessage = false;
+      setIrisMessages((current) =>
+        current.map((message) => {
+          if (message.info.id !== messageId) {
+            return message;
+          }
+
+          matchedExistingMessage = true;
+          return mergeMessageInfoText(message, text);
+        }),
+      );
+
+      return matchedExistingMessage;
     },
+    sessionId: irisSessionId,
   });
-  const irisSessionStatus = irisSessionId ? sessionStatuses[irisSessionId] ?? null : null;
+  const irisSessionStatus = liveThread.sessionStatus;
 
   useEffect(() => {
     if (!irisSessionId) {
@@ -761,31 +751,6 @@ export const OperationsPage = ({ loaderData }: Route.ComponentProps) => {
 
     void loadIrisMessages(irisSessionId);
   }, [irisSessionId, loadIrisMessages]);
-
-  useEffect(() => {
-    if (
-      !shouldUseOperationsIrisPollingFallback({
-        isLiveUnavailable: liveThread.isLiveUnavailable,
-        sessionId: irisSessionId,
-        sessionStatus: irisSessionStatus,
-      })
-    ) {
-      return;
-    }
-
-    const activeIrisSessionId = irisSessionId;
-    if (!activeIrisSessionId) {
-      return;
-    }
-
-    const interval = window.setInterval(() => {
-      void loadIrisMessages(activeIrisSessionId);
-    }, 2500);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [irisSessionId, irisSessionStatus, liveThread.isLiveUnavailable, loadIrisMessages]);
 
   const visibleDrafts = useMemo(
     () => drafts.filter((draft) => draft.scope === scope && draft.targetValue === targetValue),

--- a/web/app/routes/_layout.operations/route.tsx
+++ b/web/app/routes/_layout.operations/route.tsx
@@ -196,6 +196,7 @@ export function buildOperationsIrisStartPayload(input: {
     contextProjectIds: input.contextProjectIds,
     executionProjectId: input.executionProjectId,
     model: input.model ?? undefined,
+    ownedSessionSurface: "operation-studio-iris" as const,
     parts: input.parts,
   };
 }

--- a/web/app/routes/_layout.projects/route.test.tsx
+++ b/web/app/routes/_layout.projects/route.test.tsx
@@ -6,11 +6,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSessionChatRenderSnapshot } from "@/lib/session-chat-rendering-orchestration";
 
-const { chatStoreStateMock, projectIrisSheetPropsSpy, setAgentModelMock, useSessionLiveThreadMock } = vi.hoisted(() => ({
+const { chatStoreStateMock, projectIrisSheetPropsSpy, setAgentModelMock, useOwnedIrisSessionRealtimeMock } = vi.hoisted(() => ({
   chatStoreStateMock: vi.fn(),
   projectIrisSheetPropsSpy: vi.fn(),
   setAgentModelMock: vi.fn(),
-  useSessionLiveThreadMock: vi.fn(() => ({
+  useOwnedIrisSessionRealtimeMock: vi.fn(() => ({
     clearStreaming: vi.fn(),
     isLiveUnavailable: false,
     liveDraft: null as
@@ -21,6 +21,7 @@ const { chatStoreStateMock, projectIrisSheetPropsSpy, setAgentModelMock, useSess
         }
       | null,
     resetLiveThread: vi.fn(),
+    sessionStatus: null as "busy" | "idle" | "retry" | null,
     streamingContent: "",
     streamingMessageId: null as string | null,
   })),
@@ -48,8 +49,8 @@ vi.mock("@/hooks/use-vscode-preferences", () => ({
   }),
 }));
 
-vi.mock("@/hooks/use-session-live-thread", () => ({
-  useSessionLiveThread: useSessionLiveThreadMock,
+vi.mock("@/hooks/use-owned-iris-session-realtime", () => ({
+  useOwnedIrisSessionRealtime: useOwnedIrisSessionRealtimeMock,
 }));
 
 vi.mock("./components/project-iris-sheet", () => ({
@@ -135,12 +136,13 @@ afterEach(() => {
 beforeEach(() => {
   projectIrisSheetPropsSpy.mockReset();
   setAgentModelMock.mockReset();
-  useSessionLiveThreadMock.mockReset();
-  useSessionLiveThreadMock.mockReturnValue({
+  useOwnedIrisSessionRealtimeMock.mockReset();
+  useOwnedIrisSessionRealtimeMock.mockReturnValue({
     clearStreaming: vi.fn(),
     isLiveUnavailable: false,
     liveDraft: null,
     resetLiveThread: vi.fn(),
+    sessionStatus: null,
     streamingContent: "",
     streamingMessageId: null,
   });
@@ -354,7 +356,7 @@ describe("projects route", () => {
   });
 
   it("passes a live Projects Iris draft through to the sheet before authoritative history settles", () => {
-    useSessionLiveThreadMock.mockReturnValue({
+    useOwnedIrisSessionRealtimeMock.mockReturnValue({
       clearStreaming: vi.fn(),
       isLiveUnavailable: false,
       liveDraft: {
@@ -363,6 +365,7 @@ describe("projects route", () => {
         sessionId: "session-project-iris-1",
       },
       resetLiveThread: vi.fn(),
+      sessionStatus: "busy",
       streamingContent: "",
       streamingMessageId: "assistant-1",
     });

--- a/web/app/routes/_layout.projects/route.test.tsx
+++ b/web/app/routes/_layout.projects/route.test.tsx
@@ -67,7 +67,12 @@ vi.mock("./components/project-iris-sheet", () => ({
   },
 }));
 
-import { loader, normalizeProjectIrisHistoryMessages, ProjectsPage } from "./route";
+import {
+  buildProjectIrisStartPayload,
+  loader,
+  normalizeProjectIrisHistoryMessages,
+  ProjectsPage,
+} from "./route";
 
 const TestPage = ProjectsPage as unknown as (props: { loaderData: unknown }) => ReactNode;
 
@@ -325,6 +330,26 @@ describe("projects route", () => {
       providerID: "github-copilot",
       modelID: "gpt-5.4",
       variant: "balanced",
+    });
+  });
+
+  it("builds the Projects Iris start payload with the owned-session surface hint", () => {
+    const selectedModel = {
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      variant: "thinking",
+    };
+
+    expect(
+      buildProjectIrisStartPayload({
+        model: selectedModel,
+        parts: [{ type: "text", text: "Refresh the project registry." }],
+      }),
+    ).toEqual({
+      agent: "iris",
+      model: selectedModel,
+      ownedSessionSurface: "projects-iris",
+      parts: [{ type: "text", text: "Refresh the project registry." }],
     });
   });
 

--- a/web/app/routes/_layout.projects/route.tsx
+++ b/web/app/routes/_layout.projects/route.tsx
@@ -5,9 +5,8 @@ import { Alert, AlertCircle, AlertDescription, AlertTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageContainer } from "@/components/page-container";
+import { useOwnedIrisSessionRealtime } from "@/hooks/use-owned-iris-session-realtime";
 import { useSessionChatRenderSnapshot } from "@/hooks/use-session-chat-render-snapshot";
-import { useSessionLiveThread } from "@/hooks/use-session-live-thread";
-import { useSessionStatusFeed } from "@/hooks/use-session-status-feed";
 import type { ProjectRegistryEntry } from "@/hooks/use-project-registry";
 import { useVSCodePreferences } from "@/hooks/use-vscode-preferences";
 import { getProjectRoot } from "@/lib/get-project-root.server";
@@ -25,13 +24,12 @@ import {
   buildProjectIrisLiveDraft,
   buildProjectIrisStreamingText,
   mergeProjectIrisStreamingMessage,
-  shouldUseProjectIrisPollingFallback,
 } from "@/lib/project-management/iris-live-thread";
 import {
   toSessionPresentationMessages,
   type SessionPresentationMessage,
 } from "@/lib/session-message-presentation";
-import { getSessionStatusForId, isSessionStatusActive } from "@/lib/session-status";
+import { isSessionStatusActive } from "@/lib/session-status";
 import type { ModelSelection } from "@/lib/types/mission";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
@@ -225,29 +223,6 @@ export const ProjectsPage = ({ loaderData }: { loaderData?: ProjectsPageLoaderDa
     [projectManageSkill],
   );
 
-  const liveThread = useSessionLiveThread({
-    onTextPartMatched: ({ messageId, text }) => {
-      if (!messageId) {
-        return false;
-      }
-
-      let matchedExistingMessage = false;
-      setProjectIrisMessages((current) =>
-        current.map((message) => {
-          if (message.id !== messageId) {
-            return message;
-          }
-
-          matchedExistingMessage = true;
-          return mergeProjectIrisStreamingMessage(message, text);
-        }),
-      );
-
-      return matchedExistingMessage;
-    },
-    sessionId: projectIrisSessionId,
-  });
-
   const fetchData = useCallback(async () => {
     setLoading(true);
     setFetchError(null);
@@ -277,20 +252,36 @@ export const ProjectsPage = ({ loaderData }: { loaderData?: ProjectsPageLoaderDa
         return;
       }
 
-      void loadProjectIrisMessages(sessionId);
       void fetchData();
     },
-    [fetchData, loadProjectIrisMessages, projectIrisSessionId],
+    [fetchData, projectIrisSessionId],
   );
 
-  const projectIrisSessionStatuses = useSessionStatusFeed({
-    enabled: Boolean(projectIrisSessionId),
+  const liveThread = useOwnedIrisSessionRealtime({
+    loadMessages: loadProjectIrisMessages,
     onSessionIdle: handleProjectIrisSessionIdle,
+    onTextPartMatched: ({ messageId, text }) => {
+      if (!messageId) {
+        return false;
+      }
+
+      let matchedExistingMessage = false;
+      setProjectIrisMessages((current) =>
+        current.map((message) => {
+          if (message.id !== messageId) {
+            return message;
+          }
+
+          matchedExistingMessage = true;
+          return mergeProjectIrisStreamingMessage(message, text);
+        }),
+      );
+
+      return matchedExistingMessage;
+    },
+    sessionId: projectIrisSessionId,
   });
-  const projectIrisSessionStatus = getSessionStatusForId(
-    projectIrisSessionStatuses,
-    projectIrisSessionId,
-  );
+  const projectIrisSessionStatus = liveThread.sessionStatus;
   const projectIrisRenderSnapshot = useSessionChatRenderSnapshot({
     assistantPending: isSessionStatusActive(projectIrisSessionStatus),
     continuityAssistant: {
@@ -342,31 +333,6 @@ export const ProjectsPage = ({ loaderData }: { loaderData?: ProjectsPageLoaderDa
 
     void loadProjectIrisMessages(projectIrisSessionId);
   }, [hasHydratedProjectIrisSession, loadProjectIrisMessages, projectIrisSessionId]);
-
-  useEffect(() => {
-    if (
-      !shouldUseProjectIrisPollingFallback({
-        isLiveUnavailable: liveThread.isLiveUnavailable,
-        sessionId: projectIrisSessionId,
-        sessionStatus: projectIrisSessionStatus,
-      })
-    ) {
-      return;
-    }
-
-    const activeProjectIrisSessionId = projectIrisSessionId;
-    if (!activeProjectIrisSessionId) {
-      return;
-    }
-
-    const interval = window.setInterval(() => {
-      void loadProjectIrisMessages(activeProjectIrisSessionId);
-    }, 2500);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [liveThread.isLiveUnavailable, loadProjectIrisMessages, projectIrisSessionId, projectIrisSessionStatus]);
 
   const handleOpenProjectIrisSheet = useCallback(() => {
     setIsProjectIrisSheetOpen(true);

--- a/web/app/routes/_layout.projects/route.tsx
+++ b/web/app/routes/_layout.projects/route.tsx
@@ -87,16 +87,24 @@ async function fetchProjectIrisMessages(sessionId: string): Promise<SessionPrese
   return normalizeProjectIrisHistoryMessages(data?.messages ?? []);
 }
 
+export function buildProjectIrisStartPayload(input: {
+  model: ModelSelection | null;
+  parts: PromptPart[];
+}) {
+  return {
+    agent: PROJECT_IRIS_AGENT_ID,
+    model: input.model ?? undefined,
+    ownedSessionSurface: "projects-iris" as const,
+    parts: input.parts,
+  };
+}
+
 async function startProjectIrisSession(input: {
   model: ModelSelection | null;
   parts: PromptPart[];
 }): Promise<string> {
   const response = await fetch("/api/opencode/session/start", {
-    body: JSON.stringify({
-      agent: PROJECT_IRIS_AGENT_ID,
-      ...(input.model ? { model: input.model } : {}),
-      parts: input.parts,
-    }),
+    body: JSON.stringify(buildProjectIrisStartPayload(input)),
     headers: {
       "Content-Type": "application/json",
     },

--- a/web/app/routes/_layout/route.test.tsx
+++ b/web/app/routes/_layout/route.test.tsx
@@ -66,6 +66,7 @@ describe("app layout navigation", () => {
 
     expect(markup).toContain("Skills");
     expect(markup.indexOf("Skills")).toBeLessThan(markup.indexOf("Operations"));
+    expect(markup).toContain("Tmux Monitor");
     expect(markup).toContain("Config");
     expect(markup).toContain("Server Monitor");
     expect(markup).not.toContain("OMO Config");

--- a/web/app/routes/_layout/route.tsx
+++ b/web/app/routes/_layout/route.tsx
@@ -8,6 +8,7 @@ import {
   FolderGit2,
   Github,
   LoaderCircle,
+  Monitor,
   Sparkles,
   Rabbit,
   ServerCrash,
@@ -100,6 +101,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Debug",
     items: [
       { to: "/loading-lab", icon: Rabbit, label: "Loading Lab", end: true },
+      { to: "/monitor", icon: Monitor, label: "Tmux Monitor", end: true },
       { to: "/opencode-sdk-lab", icon: Gauge, label: "OpenCode SDK Lab", end: true },
     ],
   },

--- a/web/app/routes/api.lunafreya.banter-route.test.ts
+++ b/web/app/routes/api.lunafreya.banter-route.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createMission, deleteMission, getMission } from "@/lib/mission-store";
+import { action } from "./api.lunafreya.missions.$missionId.banter";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-lunafreya-banter-route-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("api.lunafreya.missions.$missionId.banter", () => {
+  it("records Lunafreya ambient banter entries for the mission timeline", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const missionId = `mission-luna-banter-route-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-lunafreya", {
+      title: "Lunafreya ambient banter",
+      objective: "Verify Lunafreya ambient banter route",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+
+    const response = await action({
+      request: new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          speakerAgent: "lunafreya",
+          cue: "session-settled",
+          sourceEvent: "session.settled",
+          createdAt: "2026-04-11T12:00:00.000Z",
+        }),
+      }),
+      params: { missionId },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(
+      readJson<{
+        recorded: boolean;
+        entry: { kind: "ambient"; cue: string; speakerAgent: string; renderedMessage: string } | null;
+      }>(response),
+    ).resolves.toEqual({
+      recorded: true,
+      entry: expect.objectContaining({
+        kind: "ambient",
+        cue: "session-settled",
+        speakerAgent: "lunafreya",
+        renderedMessage: expect.stringMatching(/\S/),
+      }),
+    });
+    expect(getMission(missionId)?.ambientBanterLog).toEqual([
+      expect.objectContaining({
+        speakerAgent: "lunafreya",
+        cue: "session-settled",
+        payload: expect.objectContaining({
+          sourceEvent: "session.settled",
+        }),
+      }),
+    ]);
+  });
+});

--- a/web/app/routes/api.lunafreya.mission.continue.ts
+++ b/web/app/routes/api.lunafreya.mission.continue.ts
@@ -7,6 +7,13 @@ import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { resolveMissionExecutionRoot } from "@/lib/mission-execution-workspace.server";
 import { getMissionCompatibilityIssue } from "@/lib/mission-runtime-compatibility.server";
 import {
+  claimPrimaryAgentTmuxMissionWriteFocus,
+  MissionTransportNotReadyError,
+  queueResolvedPrimaryAgentTmuxMissionWrite,
+  requireReadyMissionTransport,
+  TmuxMissionWriteConflictError,
+} from "@/lib/primary-agent-mission-transport.server";
+import {
   appendMissionActivity,
   clearMissionSessions,
   getMission,
@@ -22,7 +29,6 @@ import { buildBuiltinOperationRef } from "@/lib/operation-definition/operation-c
 import { readOperationLanguage } from "@/lib/operation-definition/language";
 import { composeUserToPrimaryAgentPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
-import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 
 function listBuiltinLanguages(language: string): string[] {
@@ -156,16 +162,18 @@ export const action = async ({ request }: { request: Request }) => {
 
   try {
     const appRoot = getProjectRoot();
-    const transportStatus = await getMissionTransportStatus(appRoot, mission.transportMode);
-    if (!transportStatus.isReady) {
-      return Response.json(
-        {
-          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
-        },
-        { status: 503 },
-      );
-    }
+    const transportStatus = await requireReadyMissionTransport({
+      appRoot,
+      transportMode: mission.transportMode,
+    });
     const client = getOpencodeClient();
+    if (transportStatus.transportMode === "tmux-resident") {
+      await claimPrimaryAgentTmuxMissionWriteFocus({
+        appRoot,
+        client,
+        missionId,
+      });
+    }
     const executionRoot = resolveMissionExecutionRoot({
       appRoot,
       mission,
@@ -254,6 +262,21 @@ export const action = async ({ request }: { request: Request }) => {
       workflowExtensionAppend: facetSelection.promptExtension,
     });
 
+    if (transportStatus.transportMode === "tmux-resident") {
+      await queueResolvedPrimaryAgentTmuxMissionWrite({
+        agentId: "lunafreya",
+        appRoot,
+        client,
+        missionId,
+        parts: composed.payloadParts,
+        sessionId,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      return Response.json({ lunafreyaSessionId: sessionId });
+    }
+
     const result = await client.session.promptAsync({
       sessionID: sessionId,
       parts: composed.payloadParts,
@@ -268,6 +291,14 @@ export const action = async ({ request }: { request: Request }) => {
 
     return Response.json({ lunafreyaSessionId: sessionId });
   } catch (error) {
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
+    if (error instanceof TmuxMissionWriteConflictError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+
     if (error instanceof Error && error.message.length > 0) {
       return Response.json({ error: error.message }, { status: 409 });
     }

--- a/web/app/routes/api.lunafreya.mission.start.ts
+++ b/web/app/routes/api.lunafreya.mission.start.ts
@@ -8,6 +8,13 @@ import {
   provisionMissionExecutionWorkspace,
   resolveManagedMissionStartRoots,
 } from "@/lib/mission-execution-workspace.server";
+import {
+  claimPrimaryAgentTmuxMissionWriteFocus,
+  MissionTransportNotReadyError,
+  queueResolvedPrimaryAgentTmuxMissionWrite,
+  requireReadyMissionTransport,
+  TmuxMissionWriteConflictError,
+} from "@/lib/primary-agent-mission-transport.server";
 import { createMission, setAgentModels } from "@/lib/mission-store";
 import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selection";
 import { getOpencodeClient } from "@/lib/opencode-client";
@@ -17,7 +24,6 @@ import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeUserToPrimaryAgentPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
-import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 
 function listBuiltinLanguages(language: string): string[] {
@@ -113,16 +119,18 @@ export const action = async ({ request }: { request: Request }) => {
 
   try {
     const projectRoot = getProjectRoot();
-    const transportStatus = await getMissionTransportStatus(projectRoot);
-    if (!transportStatus.isReady) {
-      return Response.json(
-        {
-          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
-        },
-        { status: 503 },
-      );
-    }
+    const transportStatus = await requireReadyMissionTransport({ appRoot: projectRoot });
     const client = getOpencodeClient();
+    const missionId = crypto.randomUUID();
+    const missionCreatedAt = new Date().toISOString();
+    if (transportStatus.transportMode === "tmux-resident") {
+      await claimPrimaryAgentTmuxMissionWriteFocus({
+        appRoot: projectRoot,
+        client,
+        missionId,
+        updatedAt: missionCreatedAt,
+      });
+    }
     const executionProject = readRegisteredProjectDefinition(projectRoot, executionProjectId);
     if (!executionProject) {
       return Response.json({ error: "Execution project is not registered." }, { status: 409 });
@@ -141,8 +149,6 @@ export const action = async ({ request }: { request: Request }) => {
       selectedSkillIds,
     });
     const selectedOperation = resolveLunafreyaOperationRef(projectRoot, language);
-    const missionId = crypto.randomUUID();
-    const missionCreatedAt = new Date().toISOString();
     const executionWorkspace =
       executionTargetMode === "mission_workspace"
         ? provisionMissionExecutionWorkspace({
@@ -211,6 +217,25 @@ export const action = async ({ request }: { request: Request }) => {
       workflowExtensionAppend: facetSelection.promptExtension,
     });
 
+    if (transportStatus.transportMode === "tmux-resident") {
+      await queueResolvedPrimaryAgentTmuxMissionWrite({
+        agentId: "lunafreya",
+        appRoot: projectRoot,
+        client,
+        missionId,
+        parts: composed.payloadParts,
+        sessionId,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      return Response.json({
+        missionId,
+        lunafreyaSessionId: sessionId,
+        operationState: getOperationState(missionId) ?? null,
+      });
+    }
+
     const promptResult = await client.session.promptAsync({
       sessionID: sessionId,
       parts: composed.payloadParts,
@@ -229,6 +254,14 @@ export const action = async ({ request }: { request: Request }) => {
       operationState: getOperationState(missionId) ?? null,
     });
   } catch (error) {
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
+    if (error instanceof TmuxMissionWriteConflictError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+
     if (error instanceof Error && error.message.length > 0) {
       return Response.json({ error: error.message }, { status: 409 });
     }

--- a/web/app/routes/api.lunafreya.mission.test.ts
+++ b/web/app/routes/api.lunafreya.mission.test.ts
@@ -5,11 +5,14 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getProjectRoot } from "@/lib/get-project-root.server";
+import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
 import { createMission, deleteMission, getMission } from "@/lib/mission-store";
+import { writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 
-const { promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+const { promptAsyncMock, sessionCreateMock, sessionStatusMock } = vi.hoisted(() => ({
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
+  sessionStatusMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
@@ -17,6 +20,7 @@ vi.mock("@/lib/opencode-client", () => ({
     session: {
       create: sessionCreateMock,
       promptAsync: promptAsyncMock,
+      status: sessionStatusMock,
     },
   }),
 }));
@@ -144,6 +148,44 @@ function createTempRoot(): string {
   return root;
 }
 
+function writeHealthyTmuxTransportBootstrapArtifacts(root: string): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  writeFileSync(
+    join(root, "runtime", "opencode-endpoints.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        startedAt: "2026-04-28T00:00:00.000Z",
+        agents: [
+          {
+            agentId: "lunafreya",
+            port: 4402,
+            url: "http://127.0.0.1:4402",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(root, "runtime", "tmux-transport-dispatcher.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        owner: "standby",
+        mode: "tmux-resident",
+        pid: process.pid,
+        startedAt: "2026-04-28T00:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
 async function readJson<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
 }
@@ -217,6 +259,101 @@ describe("Lunafreya mission routing", () => {
       error: expect.stringContaining("Missing tmux transport endpoint manifest"),
     });
     expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues tmux-resident Lunafreya mission start payloads instead of dispatching them inline", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    sessionCreateMock.mockResolvedValue({ data: { id: "session-lunafreya-tmux-start" } });
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/lunafreya/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Guide me through tmux transport.",
+          executionProjectId: "alpha",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{ missionId: string; lunafreyaSessionId: string }>(response);
+    missionIds.push(data.missionId);
+
+    expect(data.lunafreyaSessionId).toBe("session-lunafreya-tmux-start");
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+
+    const queuedItems = listPrimaryAgentOutboxItems(data.missionId);
+    expect(queuedItems).toHaveLength(1);
+    expect(queuedItems[0]).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "lunafreya",
+        sessionId: "session-lunafreya-tmux-start",
+        sessionTitle: `mission:${data.missionId}:lunafreya`,
+        parts: [
+          {
+            type: "text",
+            text: expect.stringContaining('<user-request from="user" to="lunafreya">') as never,
+          },
+        ],
+      },
+    });
+  });
+
+  it("blocks tmux-resident Lunafreya mission start when another writable mission is still busy", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+
+    const activeMission = createMission(`mission-luna-active-${crypto.randomUUID()}`, "session-luna-active", {
+      title: "Active Lunafreya mission",
+      objective: "Hold tmux write focus",
+      executionProjectId: "alpha",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+    missionIds.push(activeMission.id);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.id,
+      updatedAt: "2026-04-30T10:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-luna-active": "busy",
+      },
+      error: null,
+    });
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/lunafreya/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          executionProjectId: "alpha",
+          message: "Do not steal tmux focus from another active Lunafreya mission.",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(409);
+    expect(await readJson<{ error: string }>(response)).toEqual({
+      error: expect.stringContaining(activeMission.id),
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
   });
 
   it("starts a Lunafreya mission with the implicit default Job when no explicit override is selected", async () => {
@@ -419,6 +556,111 @@ describe("Lunafreya mission routing", () => {
     expect(promptText).not.toContain("<instruction>");
     expect(promptText).not.toContain("Hidden Lunafreya Instruction");
     expect(promptText).not.toContain("<lunafreya-skill-overlay>");
+  });
+
+  it("enqueues tmux-resident Lunafreya mission continue payloads instead of dispatching them inline", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+
+    const mission = createMission(`mission-luna-tmux-${crypto.randomUUID()}`, "session-lunafreya-existing", {
+      title: "Lunafreya tmux mission",
+      objective: "Resume through tmux outbox",
+      surfaceId: "lunafreya",
+      primaryAgentId: "lunafreya",
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/lunafreya/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Guide me through tmux resume.",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(readJson<{ lunafreyaSessionId: string }>(response)).resolves.toEqual({
+      lunafreyaSessionId: "session-lunafreya-existing",
+    });
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+
+    const queuedItems = listPrimaryAgentOutboxItems(mission.id);
+    expect(queuedItems).toHaveLength(1);
+    expect(queuedItems[0]).toMatchObject({
+      status: "pending",
+      payload: {
+        agent: "lunafreya",
+        sessionId: "session-lunafreya-existing",
+        sessionTitle: `mission:${mission.id}:lunafreya`,
+      },
+    });
+  });
+
+  it("blocks tmux-resident Lunafreya mission continue when another writable mission is still busy", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(
+      join(root, "config", "settings.yaml"),
+      ['language: ja', 'transport_mode: "tmux-resident"', 'execution_workspace_root: ".worktrees"', ''].join("\n"),
+      "utf-8",
+    );
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+
+    const activeMission = createMission(`mission-luna-active-${crypto.randomUUID()}`, "session-luna-active", {
+      title: "Active Lunafreya mission",
+      objective: "Hold tmux write focus",
+      executionProjectId: "alpha",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+    const targetMission = createMission(`mission-luna-target-${crypto.randomUUID()}`, "session-luna-target", {
+      title: "Target Lunafreya mission",
+      objective: "Attempt to resume while another mission is busy",
+      executionProjectId: "alpha",
+      primaryAgentId: "lunafreya",
+      surfaceId: "lunafreya",
+    });
+    missionIds.push(activeMission.id, targetMission.id);
+    writeTmuxActiveMission(root, {
+      missionId: activeMission.id,
+      updatedAt: "2026-04-30T10:00:00.000Z",
+    });
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-luna-active": "busy",
+        "session-luna-target": "idle",
+      },
+      error: null,
+    });
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/lunafreya/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: targetMission.id,
+          message: "Do not steal tmux focus from the active mission.",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(409);
+    expect(await readJson<{ error: string }>(response)).toEqual({
+      error: expect.stringContaining(activeMission.id),
+    });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
   });
 
   it("recreates a missing Lunafreya session from the app root on continue", async () => {

--- a/web/app/routes/api.lunafreya.missions.$missionId.banter.ts
+++ b/web/app/routes/api.lunafreya.missions.$missionId.banter.ts
@@ -1,0 +1,9 @@
+import { handleMissionBanterAction } from "@/lib/banter/route-action.server";
+
+export const action = async ({ request, params }: { request: Request; params: { missionId?: string } }) => {
+  return handleMissionBanterAction({
+    request,
+    missionId: params.missionId,
+    surfaceId: "lunafreya",
+  });
+};

--- a/web/app/routes/api.noctis.mission.continue.ts
+++ b/web/app/routes/api.noctis.mission.continue.ts
@@ -25,7 +25,29 @@ import { getOpencodeClient } from "@/lib/opencode-client";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
+import { resolveOwnerEndpointTarget } from "@/lib/session-owner-routing.server";
 import type { Route } from "./+types/api.noctis.mission.continue";
+
+async function hasSessionOnClient(
+  client: ReturnType<typeof getOpencodeClient>,
+  sessionId: string,
+): Promise<boolean> {
+  const listSessions = client.session.list;
+  if (typeof listSessions !== "function") {
+    return false;
+  }
+
+  try {
+    const result = await listSessions();
+    if (result.error || !Array.isArray(result.data)) {
+      return false;
+    }
+
+    return result.data.some((session) => session?.id === sessionId);
+  } catch {
+    return false;
+  }
+}
 
 export const action = async ({ request }: Route.ActionArgs) => {
   if (request.method !== "POST") {
@@ -116,7 +138,10 @@ export const action = async ({ request }: Route.ActionArgs) => {
       appRoot,
       transportMode: mission.transportMode,
     });
-    const client = getOpencodeClient();
+    const client =
+      transportStatus.transportMode === "tmux-resident"
+        ? resolveOwnerEndpointTarget(noctisAgentProfile, `mission continue ${missionId}`).client
+        : getOpencodeClient();
     if (transportStatus.transportMode === "tmux-resident") {
       await claimPrimaryAgentTmuxMissionWriteFocus({
         appRoot,
@@ -147,7 +172,10 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
     let sessionId = mission.noctisSessionId;
     let sessionRecreated = false;
-    if (!sessionId) {
+    const needsManagedSessionRecreation =
+      !sessionId ||
+      (transportStatus.transportMode === "tmux-resident" && !(await hasSessionOnClient(client, sessionId)));
+    if (needsManagedSessionRecreation) {
       const sessionResult = await client.session.create({
         directory: executionRoot.sessionHostRoot,
         title: getManagedSessionTitle(missionId, "noctis"),

--- a/web/app/routes/api.noctis.mission.continue.ts
+++ b/web/app/routes/api.noctis.mission.continue.ts
@@ -1,8 +1,14 @@
 import { getProjectRoot } from "@/lib/get-project-root.server";
-import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
 import { getManagedSessionTitle } from "@/lib/managed-session-titles";
 import { getMissionCompatibilityIssue } from "@/lib/mission-runtime-compatibility.server";
 import { resolveMissionExecutionRoot } from "@/lib/mission-execution-workspace.server";
+import {
+  claimPrimaryAgentTmuxMissionWriteFocus,
+  MissionTransportNotReadyError,
+  queueResolvedPrimaryAgentTmuxMissionWrite,
+  requireReadyMissionTransport,
+  TmuxMissionWriteConflictError,
+} from "@/lib/primary-agent-mission-transport.server";
 import {
   clearMissionSessions,
   getMission,
@@ -16,15 +22,9 @@ import {
   getNoctisExecutionMode,
 } from "@/lib/noctis-working-party";
 import { getOpencodeClient } from "@/lib/opencode-client";
-import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
-import {
-  activateTmuxMissionWriteFocus,
-  getTmuxMissionWriteConflict,
-} from "@/lib/tmux-mission-activation.server";
-import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { Route } from "./+types/api.noctis.mission.continue";
 
 export const action = async ({ request }: Route.ActionArgs) => {
@@ -112,32 +112,17 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   try {
     const appRoot = getProjectRoot();
-    const transportStatus = await getMissionTransportStatus(appRoot, mission.transportMode);
-    if (!transportStatus.isReady) {
-      return Response.json(
-        {
-          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
-        },
-        { status: 503 },
-      );
-    }
+    const transportStatus = await requireReadyMissionTransport({
+      appRoot,
+      transportMode: mission.transportMode,
+    });
     const client = getOpencodeClient();
     if (transportStatus.transportMode === "tmux-resident") {
-      const conflict = await getTmuxMissionWriteConflict({
+      await claimPrimaryAgentTmuxMissionWriteFocus({
         appRoot,
-        missionId,
         client,
+        missionId,
       });
-      if (conflict) {
-        return Response.json(
-          {
-            error: `Tmux write focus is still held by mission ${conflict.activeMissionId}.`,
-          },
-          { status: 409 },
-        );
-      }
-
-      activateTmuxMissionWriteFocus({ appRoot, missionId });
     }
     const missionDebugContext = {
       allowedWorkers,
@@ -217,17 +202,13 @@ export const action = async ({ request }: Route.ActionArgs) => {
         },
       });
 
-      queuePrimaryAgentTmuxDispatch({
+      await queueResolvedPrimaryAgentTmuxMissionWrite({
+        agentId: noctisAgentProfile,
+        appRoot,
+        client,
         missionId,
-        sessionId,
-        sessionTitle: await resolveManagedSessionActivationTitle({
-          client,
-          missionId,
-          agentId: noctisAgentProfile,
-          sessionId,
-        }),
-        agent: noctisAgentProfile,
         parts: composed.payloadParts,
+        sessionId,
         ...(model ? { model } : {}),
         ...(variant ? { variant } : {}),
       });
@@ -292,6 +273,14 @@ export const action = async ({ request }: Route.ActionArgs) => {
         missionId,
       },
     });
+
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
+    if (error instanceof TmuxMissionWriteConflictError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
 
     if (error instanceof Error && error.message.length > 0) {
       return Response.json({ error: error.message }, { status: 409 });

--- a/web/app/routes/api.noctis.mission.execution-workspace.test.ts
+++ b/web/app/routes/api.noctis.mission.execution-workspace.test.ts
@@ -15,7 +15,18 @@ import { getProjectRoot } from "@/lib/get-project-root.server";
 import { listPrimaryAgentOutboxItems } from "@/lib/mission-primary-agent-outbox.server";
 import { readTmuxActiveMission, writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
 
-const { promptAsyncMock, sessionCreateMock, sessionListMock, sessionStatusMock } = vi.hoisted(() => ({
+const {
+  ownerSessionCreateMock,
+  ownerSessionListMock,
+  ownerSessionStatusMock,
+  promptAsyncMock,
+  sessionCreateMock,
+  sessionListMock,
+  sessionStatusMock,
+} = vi.hoisted(() => ({
+  ownerSessionCreateMock: vi.fn(),
+  ownerSessionListMock: vi.fn(),
+  ownerSessionStatusMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
   sessionListMock: vi.fn(),
@@ -23,6 +34,14 @@ const { promptAsyncMock, sessionCreateMock, sessionListMock, sessionStatusMock }
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
+  createProjectOpencodeClient: () => ({
+    session: {
+      create: ownerSessionCreateMock,
+      list: ownerSessionListMock,
+      promptAsync: promptAsyncMock,
+      status: ownerSessionStatusMock,
+    },
+  }),
   getOpencodeClient: () => ({
     session: {
       create: sessionCreateMock,
@@ -259,7 +278,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     const root = createTempRoot({ transportMode: "tmux-resident" });
     process.env.MULTI_AGENT_FF15_ROOT = root;
     writeHealthyTmuxTransportBootstrapArtifacts(root);
-    sessionCreateMock.mockResolvedValue({ data: { id: "session-tmux-start" } });
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-tmux-start" } });
 
     const response = await startAction({
       request: new Request("http://localhost/api/noctis/mission/start", {
@@ -279,6 +298,13 @@ describe("Noctis mission execution workspace lifecycle", () => {
 
     expect(data.noctisSessionId).toBe("session-tmux-start");
     expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${data.missionId}:noctis`,
+      }),
+    );
 
     const queuedItems = listPrimaryAgentOutboxItems(data.missionId);
     expect(queuedItems).toHaveLength(1);
@@ -309,6 +335,38 @@ describe("Noctis mission execution workspace lifecycle", () => {
     );
   });
 
+  it("creates tmux-resident Noctis mission sessions on the owner endpoint", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-owner-start" } });
+
+    const response = await startAction({
+      request: new Request("http://localhost/api/noctis/mission/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Start through the Noctis owner endpoint.",
+          executionProjectId: "alpha",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{ missionId: string; noctisSessionId: string }>(response);
+    missionIds.push(data.missionId);
+
+    expect(data.noctisSessionId).toBe("session-owner-start");
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${data.missionId}:noctis`,
+      }),
+    );
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+  });
+
   it("blocks tmux mission start when another writable mission is still busy", async () => {
     const root = createTempRoot({ transportMode: "tmux-resident" });
     process.env.MULTI_AGENT_FF15_ROOT = root;
@@ -325,7 +383,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       missionId: activeMission.id,
       updatedAt: "2026-04-29T00:00:00.000Z",
     });
-    sessionStatusMock.mockResolvedValue({
+    ownerSessionStatusMock.mockResolvedValue({
       data: {
         "session-active": "busy",
       },
@@ -717,7 +775,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       executionTargetMode: "execution_project",
     });
     missionIds.push(mission.id);
-    sessionListMock.mockResolvedValue({
+    ownerSessionListMock.mockResolvedValue({
       data: [
         {
           id: "session-tmux-existing",
@@ -745,6 +803,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
     });
     expect(sessionCreateMock).not.toHaveBeenCalled();
     expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(sessionListMock).not.toHaveBeenCalled();
 
     const queuedItems = listPrimaryAgentOutboxItems(mission.id);
     expect(queuedItems).toHaveLength(1);
@@ -760,6 +819,75 @@ describe("Noctis mission execution workspace lifecycle", () => {
     const activityBody = getMission(mission.id)?.activityLog.map((entry) => entry.body).join("\n") ?? "";
     expect(activityBody).toContain("Queued primary-agent tmux delivery.");
     expect(activityBody).not.toContain("Resume through tmux transport.");
+  });
+
+  it("recreates a tmux-resident Noctis session on the owner endpoint when the stored session is missing", async () => {
+    const root = createTempRoot({ transportMode: "tmux-resident" });
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    const mission = createMission(`mission-tmux-rebind-${crypto.randomUUID()}`, "session-stale-default", {
+      title: "Tmux rebound mission",
+      objective: "Repair a stale Noctis owner session",
+      allowedWorkers: [],
+      executionProjectId: "alpha",
+      executionTargetMode: "execution_project",
+    });
+    missionIds.push(mission.id);
+    ownerSessionListMock
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "session-other",
+            title: "unrelated-session",
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "session-owner-recreated",
+            title: `mission:${mission.id}:noctis`,
+          },
+        ],
+        error: null,
+      });
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-owner-recreated" } });
+
+    const response = await continueAction({
+      request: new Request("http://localhost/api/noctis/mission/continue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          missionId: mission.id,
+          message: "Repair the Noctis owner session.",
+          allowedWorkers: [],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(await readJson<{ noctisSessionId: string }>(response)).toEqual({
+      noctisSessionId: "session-owner-recreated",
+    });
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: `mission:${mission.id}:noctis`,
+      }),
+    );
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(getMission(mission.id)?.noctisSessionId).toBe("session-owner-recreated");
+
+    const queuedItems = listPrimaryAgentOutboxItems(mission.id);
+    expect(queuedItems).toHaveLength(1);
+    expect(queuedItems[0]).toMatchObject({
+      payload: {
+        agent: "noctis",
+        sessionId: "session-owner-recreated",
+        sessionTitle: `mission:${mission.id}:noctis`,
+      },
+    });
   });
 
   it("refuses mission continue when tmux transport bootstrap is unhealthy", async () => {
@@ -816,7 +944,7 @@ describe("Noctis mission execution workspace lifecycle", () => {
       missionId: activeMission.id,
       updatedAt: "2026-04-29T00:00:00.000Z",
     });
-    sessionStatusMock.mockResolvedValue({
+    ownerSessionStatusMock.mockResolvedValue({
       data: {
         "session-active": "busy",
         "session-target": "idle",
@@ -866,13 +994,13 @@ describe("Noctis mission execution workspace lifecycle", () => {
       missionId: activeMission.id,
       updatedAt: "2026-04-29T00:00:00.000Z",
     });
-    sessionStatusMock.mockResolvedValue({
+    ownerSessionStatusMock.mockResolvedValue({
       data: {
         "session-idle": "idle",
       },
       error: null,
     });
-    sessionListMock.mockResolvedValue({
+    ownerSessionListMock.mockResolvedValue({
       data: [
         {
           id: "session-target",

--- a/web/app/routes/api.noctis.mission.start.ts
+++ b/web/app/routes/api.noctis.mission.start.ts
@@ -28,6 +28,7 @@ import { getOperationState } from "@/lib/operation-runtime/state";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
+import { resolveOwnerEndpointTarget } from "@/lib/session-owner-routing.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 import type { Route } from "./+types/api.noctis.mission.start";
 
@@ -116,8 +117,11 @@ export const action = async ({ request }: Route.ActionArgs) => {
   try {
     const projectRoot = getProjectRoot();
     const transportStatus = await requireReadyMissionTransport({ appRoot: projectRoot });
-    const client = getOpencodeClient();
     const missionId = crypto.randomUUID();
+    const client =
+      transportStatus.transportMode === "tmux-resident"
+        ? resolveOwnerEndpointTarget(noctisAgentProfile, `mission start ${missionId}`).client
+        : getOpencodeClient();
     const missionCreatedAt = new Date().toISOString();
     if (transportStatus.transportMode === "tmux-resident") {
       await claimPrimaryAgentTmuxMissionWriteFocus({

--- a/web/app/routes/api.noctis.mission.start.ts
+++ b/web/app/routes/api.noctis.mission.start.ts
@@ -1,11 +1,17 @@
 import { getProjectRoot } from "@/lib/get-project-root.server";
-import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
 import { normalizeIncomingMissionExecutionTargetMode } from "@/lib/mission-execution-target-mode";
 import {
   provisionMissionExecutionWorkspace,
   resolveManagedMissionStartRoots,
 } from "@/lib/mission-execution-workspace.server";
 import { getManagedSessionTitle } from "@/lib/managed-session-titles";
+import {
+  claimPrimaryAgentTmuxMissionWriteFocus,
+  MissionTransportNotReadyError,
+  queueResolvedPrimaryAgentTmuxMissionWrite,
+  requireReadyMissionTransport,
+  TmuxMissionWriteConflictError,
+} from "@/lib/primary-agent-mission-transport.server";
 import { buildDelegationLedger, createMission, setAgentModels } from "@/lib/mission-store";
 import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selection";
 import {
@@ -19,15 +25,9 @@ import {
 } from "@/lib/operation-definition/operation-catalog";
 import { readOperationLanguage } from "@/lib/operation-definition/language";
 import { getOperationState } from "@/lib/operation-runtime/state";
-import { queuePrimaryAgentTmuxDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
 import { composeUserToNoctisPrompt } from "@/lib/prompt-composition-engine";
 import { type PromptPart, stringifyPromptParts } from "@/lib/prompt-parts";
 import { readRegisteredProjectDefinition } from "@/lib/project-config.server";
-import {
-  activateTmuxMissionWriteFocus,
-  getTmuxMissionWriteConflict,
-} from "@/lib/tmux-mission-activation.server";
-import { getMissionTransportStatus } from "@/lib/tmux-transport-bootstrap.server";
 import type { AgentId, ModelSelection } from "@/lib/types/mission";
 import type { Route } from "./+types/api.noctis.mission.start";
 
@@ -115,34 +115,17 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   try {
     const projectRoot = getProjectRoot();
-    const transportStatus = await getMissionTransportStatus(projectRoot);
-    if (!transportStatus.isReady) {
-      return Response.json(
-        {
-          error: transportStatus.error ?? "Tmux transport bootstrap is not ready.",
-        },
-        { status: 503 },
-      );
-    }
+    const transportStatus = await requireReadyMissionTransport({ appRoot: projectRoot });
+    const client = getOpencodeClient();
     const missionId = crypto.randomUUID();
     const missionCreatedAt = new Date().toISOString();
-    const client = getOpencodeClient();
     if (transportStatus.transportMode === "tmux-resident") {
-      const conflict = await getTmuxMissionWriteConflict({
+      await claimPrimaryAgentTmuxMissionWriteFocus({
         appRoot: projectRoot,
-        missionId,
         client,
+        missionId,
+        updatedAt: missionCreatedAt,
       });
-      if (conflict) {
-        return Response.json(
-          {
-            error: `Tmux write focus is still held by mission ${conflict.activeMissionId}.`,
-          },
-          { status: 409 },
-        );
-      }
-
-      activateTmuxMissionWriteFocus({ appRoot: projectRoot, missionId, updatedAt: missionCreatedAt });
     }
     const executionProject = readRegisteredProjectDefinition(projectRoot, executionProjectId);
     if (!executionProject) {
@@ -243,17 +226,13 @@ export const action = async ({ request }: Route.ActionArgs) => {
     });
 
     if (transportStatus.transportMode === "tmux-resident") {
-      queuePrimaryAgentTmuxDispatch({
+      await queueResolvedPrimaryAgentTmuxMissionWrite({
+        agentId: noctisAgentProfile,
+        appRoot: projectRoot,
+        client,
         missionId,
-        sessionId,
-        sessionTitle: await resolveManagedSessionActivationTitle({
-          client,
-          missionId,
-          agentId: noctisAgentProfile,
-          sessionId,
-        }),
-        agent: noctisAgentProfile,
         parts: composed.payloadParts,
+        sessionId,
         system: ledger,
         ...(model ? { model } : {}),
         ...(variant ? { variant } : {}),
@@ -285,6 +264,14 @@ export const action = async ({ request }: Route.ActionArgs) => {
       operationState: getOperationState(missionId) ?? null,
     });
   } catch (error) {
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
+    if (error instanceof TmuxMissionWriteConflictError) {
+      return Response.json({ error: error.message }, { status: 409 });
+    }
+
     if (error instanceof Error && error.message.length > 0) {
       return Response.json({ error: error.message }, { status: 409 });
     }

--- a/web/app/routes/api.noctis.missions.$missionId.banter.ts
+++ b/web/app/routes/api.noctis.missions.$missionId.banter.ts
@@ -1,69 +1,10 @@
-import { recordAmbientBanter } from "@/lib/banter/ambient-service";
-import type { BanterCue } from "@/lib/banter/types";
-import type { AgentId } from "@/lib/types/mission";
+import { handleMissionBanterAction } from "@/lib/banter/route-action.server";
 import type { Route } from "./+types/api.noctis.missions.$missionId.banter";
 
-const AGENT_IDS: ReadonlySet<string> = new Set<AgentId>(["noctis", "ignis", "gladiolus", "prompto"]);
-const BANTER_CUES: ReadonlySet<string> = new Set<BanterCue>([
-  "session-start",
-  "task-delegated",
-  "task-assigned",
-  "message-received",
-  "task-progress-early",
-  "task-progress-late",
-  "report-running",
-  "report-blocked",
-  "report-completed",
-  "report-failed",
-  "report-acknowledged",
-  "session-settled",
-  "task-completed",
-  "task-failed",
-  "task-retrying",
-  "runtime-recovered",
-]);
-
-function isAgentId(value: unknown): value is AgentId {
-  return typeof value === "string" && AGENT_IDS.has(value);
-}
-
-function isBanterCue(value: unknown): value is BanterCue {
-  return typeof value === "string" && BANTER_CUES.has(value);
-}
-
 export const action = async ({ request, params }: Route.ActionArgs) => {
-  if (request.method !== "POST") {
-    return Response.json({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const missionId = params.missionId;
-  if (!missionId) {
-    return Response.json({ error: "Missing missionId" }, { status: 400 });
-  }
-
-  const body = (await request.json().catch(() => null)) as {
-    speakerAgent?: unknown;
-    cue?: unknown;
-    renderedMessage?: unknown;
-    sourceEvent?: unknown;
-    createdAt?: unknown;
-  } | null;
-
-  if (!body || !isAgentId(body.speakerAgent)) {
-    return Response.json({ error: "Invalid speakerAgent" }, { status: 400 });
-  }
-
-  if (!isBanterCue(body.cue)) {
-    return Response.json({ error: "Invalid cue" }, { status: 400 });
-  }
-
-  const entry = recordAmbientBanter({
-    missionId,
-    speakerAgent: body.speakerAgent,
-    cue: body.cue,
-    renderedMessage: typeof body.renderedMessage === "string" ? body.renderedMessage : undefined,
-    sourceEvent: typeof body.sourceEvent === "string" ? body.sourceEvent : undefined,
+  return handleMissionBanterAction({
+    request,
+    missionId: params.missionId,
+    surfaceId: "noctis_team",
   });
-
-  return Response.json({ recorded: Boolean(entry), entry });
 };

--- a/web/app/routes/api.opencode.session.start.test.ts
+++ b/web/app/routes/api.opencode.session.start.test.ts
@@ -4,13 +4,15 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { APP_ROOT_EXECUTION_PROJECT_ID } from "@/lib/execution-context";
+import { getOwnedSessionTitle } from "@/lib/owned-session-registry.server";
 import { listOwnedSessionTmuxDispatchItems } from "@/lib/owned-session-transport.server";
 import { readOwnedSession } from "@/lib/owned-session-registry.server";
 import { readSessionExecutionContext } from "@/lib/session-execution-context.server";
 
-const { ownerPromptAsyncMock, ownerSessionCreateMock, promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+const { ownerPromptAsyncMock, ownerSessionCreateMock, ownerSessionUpdateMock, promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
   ownerPromptAsyncMock: vi.fn(),
   ownerSessionCreateMock: vi.fn(),
+  ownerSessionUpdateMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
 }));
@@ -20,6 +22,7 @@ vi.mock("@/lib/opencode-client", () => ({
     session: {
       create: ownerSessionCreateMock,
       promptAsync: ownerPromptAsyncMock,
+      update: ownerSessionUpdateMock,
     },
   }),
   getOpencodeClient: () => ({
@@ -136,6 +139,7 @@ describe("api.opencode.session.start", () => {
     writeFileSync(join(root, "config", "settings.yaml"), 'language: en\ntransport_mode: "tmux-resident"\n', "utf-8");
     writeHealthyTmuxTransportBootstrapArtifacts(root);
     ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-iris-start" } });
+    ownerSessionUpdateMock.mockResolvedValue({ data: { id: "session-iris-start" } });
 
     const response = await action({
       request: new Request("http://localhost/api/opencode/session/start", {
@@ -156,11 +160,16 @@ describe("api.opencode.session.start", () => {
         title: "Manage the project registry.",
       }),
     );
+    expect(ownerSessionUpdateMock).toHaveBeenCalledWith({
+      sessionID: "session-iris-start",
+      title: getOwnedSessionTitle("session-iris-start"),
+    });
     expect(sessionCreateMock).not.toHaveBeenCalled();
     expect(ownerPromptAsyncMock).not.toHaveBeenCalled();
     expect(promptAsyncMock).not.toHaveBeenCalled();
     expect(readOwnedSession("session-iris-start")).toMatchObject({
       ownerAgent: "iris",
+      sessionTitle: getOwnedSessionTitle("session-iris-start"),
       surface: "projects-iris",
       transportMode: "tmux-resident",
     });
@@ -170,7 +179,7 @@ describe("api.opencode.session.start", () => {
         payload: {
           agent: "iris",
           sessionId: "session-iris-start",
-          sessionTitle: "Manage the project registry.",
+          sessionTitle: getOwnedSessionTitle("session-iris-start"),
           parts: expect.arrayContaining([
             expect.objectContaining({
               type: "text",

--- a/web/app/routes/api.opencode.session.start.test.ts
+++ b/web/app/routes/api.opencode.session.start.test.ts
@@ -4,14 +4,24 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { APP_ROOT_EXECUTION_PROJECT_ID } from "@/lib/execution-context";
+import { listOwnedSessionTmuxDispatchItems } from "@/lib/owned-session-transport.server";
+import { readOwnedSession } from "@/lib/owned-session-registry.server";
 import { readSessionExecutionContext } from "@/lib/session-execution-context.server";
 
-const { promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+const { ownerPromptAsyncMock, ownerSessionCreateMock, promptAsyncMock, sessionCreateMock } = vi.hoisted(() => ({
+  ownerPromptAsyncMock: vi.fn(),
+  ownerSessionCreateMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
+  createProjectOpencodeClient: () => ({
+    session: {
+      create: ownerSessionCreateMock,
+      promptAsync: ownerPromptAsyncMock,
+    },
+  }),
   getOpencodeClient: () => ({
     session: {
       create: sessionCreateMock,
@@ -64,6 +74,44 @@ function createTempRoot(): string {
   return root;
 }
 
+function writeHealthyTmuxTransportBootstrapArtifacts(root: string): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  writeFileSync(
+    join(root, "runtime", "opencode-endpoints.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        startedAt: "2026-04-30T00:00:00.000Z",
+        agents: [
+          {
+            agentId: "iris",
+            port: 4405,
+            url: "http://127.0.0.1:4405",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(root, "runtime", "tmux-transport-dispatcher.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        owner: "standby",
+        mode: "tmux-resident",
+        pid: process.pid,
+        startedAt: "2026-04-30T00:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 
@@ -82,6 +130,58 @@ afterEach(() => {
 });
 
 describe("api.opencode.session.start", () => {
+  it("persists owned-session metadata for tmux-resident Iris session starts", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeFileSync(join(root, "config", "settings.yaml"), 'language: en\ntransport_mode: "tmux-resident"\n', "utf-8");
+    writeHealthyTmuxTransportBootstrapArtifacts(root);
+    ownerSessionCreateMock.mockResolvedValue({ data: { id: "session-iris-start" } });
+
+    const response = await action({
+      request: new Request("http://localhost/api/opencode/session/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent: "iris",
+          ownedSessionSurface: "projects-iris",
+          parts: [{ type: "text", text: "Manage the project registry." }],
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(201);
+    expect(ownerSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: root,
+        title: "Manage the project registry.",
+      }),
+    );
+    expect(sessionCreateMock).not.toHaveBeenCalled();
+    expect(ownerPromptAsyncMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(readOwnedSession("session-iris-start")).toMatchObject({
+      ownerAgent: "iris",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+    expect(listOwnedSessionTmuxDispatchItems("session-iris-start")).toMatchObject([
+      {
+        status: "pending",
+        payload: {
+          agent: "iris",
+          sessionId: "session-iris-start",
+          sessionTitle: "Manage the project registry.",
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: "text",
+              text: "Manage the project registry.",
+            }),
+          ]),
+        },
+      },
+    ]);
+  });
+
   it("defaults new sessions to the app root execution context", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;

--- a/web/app/routes/api.opencode.session.start.ts
+++ b/web/app/routes/api.opencode.session.start.ts
@@ -7,7 +7,11 @@ import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selec
 import { createOpencodeMessageId } from "@/lib/opencode-message-id";
 import { getOpencodeClient } from "@/lib/opencode-client";
 import { queueOwnedSessionTmuxDispatch } from "@/lib/owned-session-transport.server";
-import { saveOwnedSession, type OwnedSessionSurface } from "@/lib/owned-session-registry.server";
+import {
+  getOwnedSessionTitle,
+  saveOwnedSession,
+  type OwnedSessionSurface,
+} from "@/lib/owned-session-registry.server";
 import {
   MissionTransportNotReadyError,
   requireReadyMissionTransport,
@@ -133,15 +137,26 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return Response.json({ error: "Session creation returned no ID" }, { status: 502 });
     }
 
+    const ownedSessionTitle = isTmuxOwnedIrisSession ? getOwnedSessionTitle(sessionId) : null;
+
     if (
       body?.agent === "iris" &&
       isOwnedSessionSurface(body.ownedSessionSurface) &&
       appConfig.transportMode === "tmux-resident"
     ) {
+      const titleUpdateResult = await client.session.update({
+        sessionID: sessionId,
+        title: ownedSessionTitle ?? title,
+      });
+
+      if (titleUpdateResult.error) {
+        return Response.json({ error: titleUpdateResult.error }, { status: 502 });
+      }
+
       saveOwnedSession({
         ownerAgent: "iris",
         sessionId,
-        sessionTitle: title,
+        sessionTitle: ownedSessionTitle ?? title,
         surface: body.ownedSessionSurface,
         transportMode: "tmux-resident",
       });
@@ -181,7 +196,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       queueOwnedSessionTmuxDispatch({
         ownerAgent: "iris",
         sessionId,
-        sessionTitle: title,
+        sessionTitle: ownedSessionTitle ?? title,
         parts: composed.payloadParts,
         ...(model ? { model } : {}),
         ...(variant ? { variant } : {}),

--- a/web/app/routes/api.opencode.session.start.ts
+++ b/web/app/routes/api.opencode.session.start.ts
@@ -1,15 +1,23 @@
 import type { ActionFunctionArgs } from "react-router";
+import { readAppConfig } from "@/lib/app-config.server";
 import { APP_ROOT_EXECUTION_PROJECT_ID } from "@/lib/execution-context";
 import { readExecutionContextProjectDefinition } from "@/lib/execution-context.server";
 import { getProjectRoot } from "@/lib/get-project-root.server";
 import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selection";
 import { createOpencodeMessageId } from "@/lib/opencode-message-id";
 import { getOpencodeClient } from "@/lib/opencode-client";
+import { queueOwnedSessionTmuxDispatch } from "@/lib/owned-session-transport.server";
+import { saveOwnedSession, type OwnedSessionSurface } from "@/lib/owned-session-registry.server";
+import {
+  MissionTransportNotReadyError,
+  requireReadyMissionTransport,
+} from "@/lib/primary-agent-mission-transport.server";
 import { composeGenericSessionPrompt } from "@/lib/prompt-composition-engine";
 import type { PromptPart } from "@/lib/prompt-parts";
 import { stringifyPromptParts } from "@/lib/prompt-parts";
 import { saveSessionExecutionContext } from "@/lib/session-execution-context.server";
 import { saveSessionRequestAnchor } from "@/lib/session-request-anchors.server";
+import { resolveOwnerEndpointTarget } from "@/lib/session-owner-routing.server";
 import type { SessionSelection } from "@/lib/session-selection-adjustment";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
 import type { ModelSelection } from "@/lib/types/mission";
@@ -21,7 +29,12 @@ type StartSessionPayload = {
   contextProjectIds?: unknown;
   executionProjectId?: unknown;
   missionId?: string;
+  ownedSessionSurface?: unknown;
 };
+
+function isOwnedSessionSurface(value: unknown): value is OwnedSessionSurface {
+  return value === "operation-studio-iris" || value === "projects-iris";
+}
 
 function isPromptPart(value: unknown): value is PromptPart {
   if (!value || typeof value !== "object") {
@@ -68,8 +81,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   try {
-    const client = getOpencodeClient();
     const projectRoot = getProjectRoot();
+    const appConfig = readAppConfig(projectRoot);
     const executionProjectId =
       typeof body?.executionProjectId === "string" && body.executionProjectId.trim().length > 0
         ? body.executionProjectId.trim()
@@ -86,6 +99,21 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const selectedModel = isModelSelection(body?.model) ? body.model : undefined;
     const { model, variant } = splitModelSelection(selectedModel);
     const userMessageId = createOpencodeMessageId();
+    const isTmuxOwnedIrisSession =
+      body?.agent === "iris" &&
+      isOwnedSessionSurface(body.ownedSessionSurface) &&
+      appConfig.transportMode === "tmux-resident";
+
+    if (isTmuxOwnedIrisSession) {
+      await requireReadyMissionTransport({
+        appRoot: projectRoot,
+        transportMode: appConfig.transportMode,
+      });
+    }
+
+    const client = isTmuxOwnedIrisSession
+      ? resolveOwnerEndpointTarget("iris", `owned session start ${title}`).client
+      : getOpencodeClient();
     const requestedSelection: SessionSelection = {
       agent: body?.agent ? body.agent : null,
       model: selectedModel ?? null,
@@ -103,6 +131,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const sessionId = sessionResult.data?.id;
     if (!sessionId) {
       return Response.json({ error: "Session creation returned no ID" }, { status: 502 });
+    }
+
+    if (
+      body?.agent === "iris" &&
+      isOwnedSessionSurface(body.ownedSessionSurface) &&
+      appConfig.transportMode === "tmux-resident"
+    ) {
+      saveOwnedSession({
+        ownerAgent: "iris",
+        sessionId,
+        sessionTitle: title,
+        surface: body.ownedSessionSurface,
+        transportMode: "tmux-resident",
+      });
     }
 
     saveSessionExecutionContext(sessionId, {
@@ -134,6 +176,29 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         parts: composed.payloadParts,
       },
     });
+
+    if (isTmuxOwnedIrisSession) {
+      queueOwnedSessionTmuxDispatch({
+        ownerAgent: "iris",
+        sessionId,
+        sessionTitle: title,
+        parts: composed.payloadParts,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      try {
+        saveSessionRequestAnchor({
+          sessionId,
+          userMessageId,
+          requested: requestedSelection,
+        });
+      } catch {
+        // Request tracking must never block prompt delivery.
+      }
+
+      return Response.json({ session: sessionResult.data }, { status: 201 });
+    }
 
     const promptResult = await client.session.promptAsync({
       sessionID: sessionId,
@@ -170,6 +235,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     return Response.json({ session: sessionResult.data }, { status: 201 });
   } catch (error) {
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
     appendSessionPromptDebugLog({
       route: "api.opencode.session.start",
       stage: "prompt-error",

--- a/web/app/routes/api.session.$id.abort.test.ts
+++ b/web/app/routes/api.session.$id.abort.test.ts
@@ -9,6 +9,11 @@ import {
   leaseTmuxDispatchItem,
   listTmuxDispatchItems,
 } from "@/lib/mission-primary-agent-outbox.server";
+import {
+  getOwnedSessionTransportMissionId,
+  listOwnedSessionTmuxDispatchItems,
+  queueOwnedSessionTmuxDispatch,
+} from "@/lib/owned-session-transport.server";
 
 const {
   abortMock,
@@ -107,8 +112,96 @@ describe("api.session.$id.abort", () => {
       endpointUrl: null,
       managedSession: null,
       mode: "default",
+      ownedSession: null,
       ownerAgent: null,
     }));
+  });
+
+  it("cancels queued tmux work for owned Iris sessions before forwarding abort", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: "pending Iris payload" }],
+      queuedAt: "2026-04-28T01:00:00.000Z",
+    });
+    queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: "leased Iris payload" }],
+      queuedAt: "2026-04-28T01:01:00.000Z",
+    });
+    leaseTmuxDispatchItem({
+      missionId: getOwnedSessionTransportMissionId("session-iris"),
+      leaseOwner: "dispatcher-abort",
+      leasedAt: "2026-04-28T01:01:30.000Z",
+      staleAfterMs: 30_000,
+    });
+
+    resolvedAbortMock.mockResolvedValue({ data: { ok: true } });
+    requestTmuxDispatchAbortForSessionMock.mockReturnValue({
+      currentDispatch: {
+        agent: "iris",
+        itemId: "item-dispatch-owned",
+        missionId: getOwnedSessionTransportMissionId("session-iris"),
+        phase: "typing-payload",
+        sessionId: "session-iris",
+        target: "ff15:main.5",
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      },
+      requested: true,
+    });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          abort: resolvedAbortMock,
+          list: resolvedSessionListMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4405",
+      managedSession: null,
+      mode: "owned",
+      ownedSession: {
+        ownerAgent: "iris",
+        sessionTitle: "iris:projects",
+        surface: "projects-iris",
+        transportMode: "tmux-resident",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      ownerAgent: "iris",
+    });
+
+    const response = await action({ params: { id: "session-iris" } } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(requestTmuxDispatchAbortForSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        missionId: getOwnedSessionTransportMissionId("session-iris"),
+        requestedBy: "abort-route",
+        sessionId: "session-iris",
+      }),
+    );
+    expect(interruptManagedTmuxSessionMock).not.toHaveBeenCalled();
+    expect(listOwnedSessionTmuxDispatchItems("session-iris")).toEqual([
+      expect.objectContaining({
+        status: "cancelled",
+        cancellation: expect.objectContaining({
+          cancelledBy: "abort-route",
+          reason: "Owned session abort requested",
+        }),
+      }),
+      expect.objectContaining({
+        status: "cancelled",
+        cancellation: expect.objectContaining({
+          cancelledBy: "abort-route",
+          reason: "Owned session abort requested",
+        }),
+      }),
+    ]);
   });
 
   it("records managed abort activity and debug logs", async () => {
@@ -288,7 +381,12 @@ describe("api.session.$id.abort", () => {
     const missionId = `mission-${crypto.randomUUID()}`;
     missionIds.push(missionId);
     createMission(missionId, "session-noctis", { executionProjectId: "alpha" });
-    getMission(missionId)!.transportMode = "tmux-resident";
+    const mission = getMission(missionId);
+    expect(mission).toBeTruthy();
+    if (!mission) {
+      throw new Error("Mission not found");
+    }
+    mission.transportMode = "tmux-resident";
     setWorkerSession(missionId, "ignis", "session-ignis");
 
     resolvedSessionListMock.mockResolvedValue({
@@ -342,7 +440,12 @@ describe("api.session.$id.abort", () => {
     const missionId = `mission-${crypto.randomUUID()}`;
     missionIds.push(missionId);
     createMission(missionId, "session-noctis", { executionProjectId: "alpha" });
-    getMission(missionId)!.transportMode = "tmux-resident";
+    const mission = getMission(missionId);
+    expect(mission).toBeTruthy();
+    if (!mission) {
+      throw new Error("Mission not found");
+    }
+    mission.transportMode = "tmux-resident";
     setWorkerSession(missionId, "ignis", "session-ignis");
 
     resolvedSessionListMock.mockResolvedValue({

--- a/web/app/routes/api.session.$id.abort.ts
+++ b/web/app/routes/api.session.$id.abort.ts
@@ -1,5 +1,9 @@
 import { appendMissionActivity, getMission } from "@/lib/mission-store";
 import { cancelTmuxDispatchItemsForSession } from "@/lib/mission-primary-agent-outbox.server";
+import {
+  cancelOwnedSessionTmuxDispatchItems,
+  getOwnedSessionTransportMissionId,
+} from "@/lib/owned-session-transport.server";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
 import { resolveSessionRouteTarget } from "@/lib/session-owner-routing.server";
 import {
@@ -32,13 +36,21 @@ export const action = async ({ params }: Route.ActionArgs) => {
 
   const requestId = crypto.randomUUID();
   let managedSession: ReturnType<typeof resolveSessionRouteTarget>["managedSession"] = null;
+  let ownedSession: ReturnType<typeof resolveSessionRouteTarget>["ownedSession"] = null;
 
   try {
-    const { client, managedSession: resolvedManagedSession } = resolveSessionRouteTarget(sessionId);
+    const {
+      client,
+      managedSession: resolvedManagedSession,
+      ownedSession: resolvedOwnedSession,
+    } = resolveSessionRouteTarget(sessionId);
     managedSession = resolvedManagedSession;
+    ownedSession = resolvedOwnedSession;
     const managedMission = managedSession ? getMission(managedSession.missionId) : null;
     const isTmuxManagedSession = managedMission?.transportMode === "tmux-resident";
-    const rawSessionTitle = managedSession ? await resolveSessionTitle(client, sessionId) : null;
+    const rawSessionTitle = managedSession
+      ? await resolveSessionTitle(client, sessionId)
+      : ownedSession?.sessionTitle ?? null;
     const abortedAt = new Date().toISOString();
     let tmuxAbortAction:
       | {
@@ -59,6 +71,13 @@ export const action = async ({ params }: Route.ActionArgs) => {
               missionId: managedSession.missionId,
               ownerAgent: managedSession.ownerAgent,
               rawSessionTitle,
+            }
+          : null,
+        ownedSession: ownedSession
+          ? {
+              ownerAgent: ownedSession.ownerAgent,
+              rawSessionTitle,
+              surface: ownedSession.surface,
             }
           : null,
       },
@@ -109,6 +128,50 @@ export const action = async ({ params }: Route.ActionArgs) => {
       }
     }
 
+    if (ownedSession) {
+      cancelOwnedSessionTmuxDispatchItems({
+        sessionId,
+        cancelledAt: abortedAt,
+        cancelledBy: "abort-route",
+        reason: "Owned session abort requested",
+      });
+
+      if (ownedSession.transportMode === "tmux-resident") {
+        try {
+          const dispatchAbort = requestTmuxDispatchAbortForSession({
+            missionId: getOwnedSessionTransportMissionId(sessionId),
+            requestedAt: abortedAt,
+            requestedBy: "abort-route",
+            sessionId,
+          });
+
+          if (dispatchAbort.requested) {
+            tmuxAbortAction = {
+              mode: "dispatcher-cancel",
+              phase: dispatchAbort.currentDispatch?.phase ?? null,
+            };
+          } else {
+            interruptManagedTmuxSession({
+              method: "escape",
+              ownerAgent: ownedSession.ownerAgent,
+            });
+            tmuxAbortAction = {
+              mode: "escape",
+              phase: dispatchAbort.currentDispatch?.phase ?? null,
+            };
+          }
+        } catch (tmuxInterruptError) {
+          tmuxAbortAction = {
+            error:
+              tmuxInterruptError instanceof Error
+                ? tmuxInterruptError.message
+                : String(tmuxInterruptError),
+            mode: "error",
+          };
+        }
+      }
+    }
+
     const result = await client.session.abort({ sessionID: sessionId });
 
     appendSessionPromptDebugLog({
@@ -123,6 +186,13 @@ export const action = async ({ params }: Route.ActionArgs) => {
               missionId: managedSession.missionId,
               ownerAgent: managedSession.ownerAgent,
               rawSessionTitle,
+            }
+          : null,
+        ownedSession: ownedSession
+          ? {
+              ownerAgent: ownedSession.ownerAgent,
+              rawSessionTitle,
+              surface: ownedSession.surface,
             }
           : null,
         tmuxAbortAction,
@@ -161,6 +231,12 @@ export const action = async ({ params }: Route.ActionArgs) => {
           ? {
               missionId: managedSession.missionId,
               ownerAgent: managedSession.ownerAgent,
+            }
+          : null,
+        ownedSession: ownedSession
+          ? {
+              ownerAgent: ownedSession.ownerAgent,
+              surface: ownedSession.surface,
             }
           : null,
       },

--- a/web/app/routes/api.session.$id.events.test.ts
+++ b/web/app/routes/api.session.$id.events.test.ts
@@ -36,6 +36,7 @@ describe("api.session.$id.events", () => {
       endpointUrl: null,
       managedSession: null,
       mode: "default",
+      ownedSession: null,
       ownerAgent: null,
     }));
   });
@@ -146,5 +147,50 @@ describe("api.session.$id.events", () => {
     expect(globalEventMock).not.toHaveBeenCalled();
     const body = await response.text();
     expect(body).toContain('"sessionID":"session-managed"');
+  });
+
+  it("subscribes through the resolved owner client for owned Iris sessions", async () => {
+    const ownedGlobalEventMock = vi.fn().mockResolvedValue({
+      stream: createStream([
+        {
+          type: "session.status",
+          properties: {
+            sessionID: "session-iris",
+            status: { type: "busy" },
+          },
+        },
+      ]),
+    });
+
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        global: {
+          event: ownedGlobalEventMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4405",
+      managedSession: null,
+      mode: "owned",
+      ownedSession: {
+        ownerAgent: "iris",
+        sessionTitle: "iris:projects",
+        surface: "projects-iris",
+        transportMode: "tmux-resident",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      ownerAgent: "iris",
+    });
+
+    const response = await loader({
+      request: new Request("http://localhost/api/session/session-iris/events"),
+      params: { id: "session-iris" },
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(resolveSessionRouteTargetMock).toHaveBeenCalledWith("session-iris");
+    expect(ownedGlobalEventMock).toHaveBeenCalledTimes(1);
+    expect(globalEventMock).not.toHaveBeenCalled();
+    const body = await response.text();
+    expect(body).toContain('"sessionID":"session-iris"');
   });
 });

--- a/web/app/routes/api.session.$id.messages.$messageId.test.ts
+++ b/web/app/routes/api.session.$id.messages.$messageId.test.ts
@@ -41,6 +41,7 @@ describe("api.session.$id.messages.$messageId", () => {
       endpointUrl: null,
       managedSession: null,
       mode: "default",
+      ownedSession: null,
       ownerAgent: null,
     }));
   });
@@ -94,6 +95,56 @@ describe("api.session.$id.messages.$messageId", () => {
         info: expect.objectContaining({ id: "assistant-managed" }),
       }),
     });
+  });
+
+  it("loads owned Iris session detail through the resolved owner-aware client", async () => {
+    listSessionRequestAnchorsMock.mockReturnValue({});
+    sessionMessagesMock.mockRejectedValue(new Error("default client should not be used"));
+    resolvedSessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "assistant-owned",
+            role: "assistant",
+            agent: "iris",
+            time: { created: Date.parse("2026-04-28T10:00:00.000Z") },
+          },
+          parts: [{ type: "text", text: "Owned detail body." }],
+        },
+      ],
+    });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          messages: resolvedSessionMessagesMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4405",
+      managedSession: null,
+      mode: "owned",
+      ownedSession: {
+        ownerAgent: "iris",
+        sessionTitle: "iris:projects",
+        surface: "projects-iris",
+        transportMode: "tmux-resident",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      ownerAgent: "iris",
+    });
+
+    const response = await loader({
+      params: { id: "session-iris", messageId: "assistant-owned" },
+    } as never);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      message: expect.objectContaining({
+        info: expect.objectContaining({ id: "assistant-owned" }),
+      }),
+    });
+    expect(resolvedSessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-iris" });
+    expect(sessionMessagesMock).not.toHaveBeenCalled();
   });
 
   it("returns full message detail for on-demand transcript expansion", async () => {

--- a/web/app/routes/api.session.$id.open-terminal.test.ts
+++ b/web/app/routes/api.session.$id.open-terminal.test.ts
@@ -62,6 +62,7 @@ describe("api.session.$id.open-terminal", () => {
       endpointUrl: null,
       managedSession: null,
       mode: "default",
+      ownedSession: null,
       ownerAgent: null,
     }));
   });
@@ -109,5 +110,42 @@ describe("api.session.$id.open-terminal", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("validates owned Iris sessions through the resolved owner-aware client before launching the terminal", async () => {
+    sessionListMock.mockRejectedValue(new Error("default client should not be used"));
+    resolvedSessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-iris",
+          directory: "/workspace/root",
+        },
+      ],
+    });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          list: resolvedSessionListMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4405",
+      managedSession: null,
+      mode: "owned",
+      ownedSession: {
+        ownerAgent: "iris",
+        sessionTitle: "iris:projects",
+        surface: "projects-iris",
+        transportMode: "tmux-resident",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      ownerAgent: "iris",
+    });
+
+    const response = await action({ params: { id: "session-iris" } } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(resolvedSessionListMock).toHaveBeenCalledTimes(1);
+    expect(sessionListMock).not.toHaveBeenCalled();
   });
 });

--- a/web/app/routes/api.session.$id.prompt.test.ts
+++ b/web/app/routes/api.session.$id.prompt.test.ts
@@ -4,18 +4,30 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createMission, deleteMission, getMission, setAgentModels, setWorkerSession } from "@/lib/mission-store";
+import { listOwnedSessionTmuxDispatchItems } from "@/lib/owned-session-transport.server";
+import { saveOwnedSession } from "@/lib/owned-session-registry.server";
 
 const {
   appendSessionPromptDebugLogMock,
+  ownerPromptAsyncMock,
+  ownerSessionListMock,
   promptAsyncMock,
   sessionListMock,
 } = vi.hoisted(() => ({
   appendSessionPromptDebugLogMock: vi.fn(),
+  ownerPromptAsyncMock: vi.fn(),
+  ownerSessionListMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionListMock: vi.fn(),
 }));
 
 vi.mock("@/lib/opencode-client", () => ({
+  createProjectOpencodeClient: () => ({
+    session: {
+      list: ownerSessionListMock,
+      promptAsync: ownerPromptAsyncMock,
+    },
+  }),
   getOpencodeClient: () => ({
     session: {
       list: sessionListMock,
@@ -48,8 +60,52 @@ function createTempRoot(): string {
   return root;
 }
 
+function writeEndpointManifest(
+  root: string,
+  agents: Array<{ agentId: string; port: number; url: string }>,
+): void {
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  writeFileSync(
+    join(root, "runtime", "opencode-endpoints.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        startedAt: "2026-04-30T00:00:00.000Z",
+        agents,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+function writeReadyTmuxTransportArtifacts(
+  root: string,
+  agents: Array<{ agentId: string; port: number; url: string }>,
+): void {
+  writeEndpointManifest(root, agents);
+  writeFileSync(
+    join(root, "runtime", "tmux-transport-dispatcher.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        owner: "standby",
+        mode: "tmux-resident",
+        pid: process.pid,
+        startedAt: "2026-04-30T00:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
 afterEach(() => {
   appendSessionPromptDebugLogMock.mockReset();
+  ownerPromptAsyncMock.mockReset();
+  ownerSessionListMock.mockReset();
   promptAsyncMock.mockReset();
   sessionListMock.mockReset();
 
@@ -72,8 +128,64 @@ afterEach(() => {
 });
 
 describe("api.session.$id.prompt", () => {
+  it("queues owned Iris session prompts for tmux-resident delivery", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeReadyTmuxTransportArtifacts(root, [
+      {
+        agentId: "iris",
+        port: 4405,
+        url: "http://127.0.0.1:4405",
+      },
+    ]);
+    saveOwnedSession({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+
+    promptAsyncMock.mockResolvedValue({ error: "default client should not be used" });
+
+    const response = await action({
+      params: { id: "session-iris" },
+      request: new Request("http://localhost/api/session/session-iris/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          parts: [{ type: "text", text: "Refresh the project registry." }],
+          agent: "iris",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(204);
+    expect(ownerPromptAsyncMock).not.toHaveBeenCalled();
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(listOwnedSessionTmuxDispatchItems("session-iris")).toMatchObject([
+      {
+        status: "pending",
+        payload: {
+          agent: "iris",
+          sessionId: "session-iris",
+          sessionTitle: "iris:projects",
+          parts: [{ type: "text", text: "Refresh the project registry." }],
+        },
+      },
+    ]);
+  });
+
   it("logs manual managed-session overrides and mirrors worker overrides into mission activity", async () => {
-    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeEndpointManifest(root, [
+      {
+        agentId: "ignis",
+        port: 4402,
+        url: "http://127.0.0.1:4402",
+      },
+    ]);
     const missionId = `mission-${crypto.randomUUID()}`;
     missionIds.push(missionId);
     createMission(missionId, "session-noctis", {
@@ -85,10 +197,10 @@ describe("api.session.$id.prompt", () => {
       ignis: { providerID: "anthropic", modelID: "claude-3-7-sonnet" },
     });
 
-    sessionListMock.mockResolvedValue({
+    ownerSessionListMock.mockResolvedValue({
       data: [{ id: "session-ignis", title: `mission:${missionId}:ignis` }],
     });
-    promptAsyncMock.mockResolvedValue({ data: { ok: true } });
+    ownerPromptAsyncMock.mockResolvedValue({ data: { ok: true } });
 
     const response = await action({
       params: { id: "session-ignis" },
@@ -104,7 +216,7 @@ describe("api.session.$id.prompt", () => {
     } as never);
 
     expect(response.status).toBe(204);
-    expect(promptAsyncMock).toHaveBeenCalledWith(
+    expect(ownerPromptAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: "session-ignis",
         agent: "prompto",
@@ -114,6 +226,7 @@ describe("api.session.$id.prompt", () => {
         },
       }),
     );
+    expect(promptAsyncMock).not.toHaveBeenCalled();
     expect(getMission(missionId)?.activityLog.at(-1)).toMatchObject({
       actor: "user",
       speaker: "user",

--- a/web/app/routes/api.session.$id.prompt.test.ts
+++ b/web/app/routes/api.session.$id.prompt.test.ts
@@ -5,18 +5,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createMission, deleteMission, getMission, setAgentModels, setWorkerSession } from "@/lib/mission-store";
 import { listOwnedSessionTmuxDispatchItems } from "@/lib/owned-session-transport.server";
+import { getOwnedSessionTitle } from "@/lib/owned-session-registry.server";
 import { saveOwnedSession } from "@/lib/owned-session-registry.server";
 
 const {
   appendSessionPromptDebugLogMock,
   ownerPromptAsyncMock,
   ownerSessionListMock,
+  ownerSessionUpdateMock,
   promptAsyncMock,
   sessionListMock,
 } = vi.hoisted(() => ({
   appendSessionPromptDebugLogMock: vi.fn(),
   ownerPromptAsyncMock: vi.fn(),
   ownerSessionListMock: vi.fn(),
+  ownerSessionUpdateMock: vi.fn(),
   promptAsyncMock: vi.fn(),
   sessionListMock: vi.fn(),
 }));
@@ -26,6 +29,7 @@ vi.mock("@/lib/opencode-client", () => ({
     session: {
       list: ownerSessionListMock,
       promptAsync: ownerPromptAsyncMock,
+      update: ownerSessionUpdateMock,
     },
   }),
   getOpencodeClient: () => ({
@@ -106,6 +110,7 @@ afterEach(() => {
   appendSessionPromptDebugLogMock.mockReset();
   ownerPromptAsyncMock.mockReset();
   ownerSessionListMock.mockReset();
+  ownerSessionUpdateMock.mockReset();
   promptAsyncMock.mockReset();
   sessionListMock.mockReset();
 
@@ -141,7 +146,7 @@ describe("api.session.$id.prompt", () => {
     saveOwnedSession({
       ownerAgent: "iris",
       sessionId: "session-iris",
-      sessionTitle: "iris:projects",
+      sessionTitle: getOwnedSessionTitle("session-iris"),
       surface: "projects-iris",
       transportMode: "tmux-resident",
     });
@@ -162,6 +167,7 @@ describe("api.session.$id.prompt", () => {
 
     expect(response.status).toBe(204);
     expect(ownerPromptAsyncMock).not.toHaveBeenCalled();
+    expect(ownerSessionUpdateMock).not.toHaveBeenCalled();
     expect(promptAsyncMock).not.toHaveBeenCalled();
     expect(listOwnedSessionTmuxDispatchItems("session-iris")).toMatchObject([
       {
@@ -169,7 +175,56 @@ describe("api.session.$id.prompt", () => {
         payload: {
           agent: "iris",
           sessionId: "session-iris",
-          sessionTitle: "iris:projects",
+          sessionTitle: getOwnedSessionTitle("session-iris"),
+          parts: [{ type: "text", text: "Refresh the project registry." }],
+        },
+      },
+    ]);
+  });
+
+  it("repairs legacy owned Iris session titles before queuing tmux delivery", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    writeReadyTmuxTransportArtifacts(root, [
+      {
+        agentId: "iris",
+        port: 4405,
+        url: "http://127.0.0.1:4405",
+      },
+    ]);
+    saveOwnedSession({
+      ownerAgent: "iris",
+      sessionId: "session-iris-legacy",
+      sessionTitle: "<projects-iris-context>\nlegacy title",
+      surface: "projects-iris",
+      transportMode: "tmux-resident",
+    });
+    ownerSessionUpdateMock.mockResolvedValue({ data: { id: "session-iris-legacy" } });
+
+    const response = await action({
+      params: { id: "session-iris-legacy" },
+      request: new Request("http://localhost/api/session/session-iris-legacy/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          parts: [{ type: "text", text: "Refresh the project registry." }],
+          agent: "iris",
+        }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(204);
+    expect(ownerSessionUpdateMock).toHaveBeenCalledWith({
+      sessionID: "session-iris-legacy",
+      title: getOwnedSessionTitle("session-iris-legacy"),
+    });
+    expect(listOwnedSessionTmuxDispatchItems("session-iris-legacy")).toMatchObject([
+      {
+        status: "pending",
+        payload: {
+          agent: "iris",
+          sessionId: "session-iris-legacy",
+          sessionTitle: getOwnedSessionTitle("session-iris-legacy"),
           parts: [{ type: "text", text: "Refresh the project registry." }],
         },
       },

--- a/web/app/routes/api.session.$id.prompt.ts
+++ b/web/app/routes/api.session.$id.prompt.ts
@@ -60,10 +60,10 @@ async function resolveOwnedSessionActivationTitle(input: {
     return canonicalTitle;
   }
 
-  const result = await input.client.session.update({
+  const result = (await input.client.session.update({
     sessionID: input.sessionId,
     title: canonicalTitle,
-  });
+  })) as { error?: unknown };
 
   if (result.error) {
     throw new Error(typeof result.error === "string" ? result.error : "Unable to update owned session title.");

--- a/web/app/routes/api.session.$id.prompt.ts
+++ b/web/app/routes/api.session.$id.prompt.ts
@@ -3,6 +3,11 @@ import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selec
 import { appendMissionActivity } from "@/lib/mission-store";
 import { createOpencodeMessageId } from "@/lib/opencode-message-id";
 import { queueOwnedSessionTmuxDispatch } from "@/lib/owned-session-transport.server";
+import {
+  getOwnedSessionTitle,
+  hasOwnedSessionTitle,
+  saveOwnedSession,
+} from "@/lib/owned-session-registry.server";
 import { composeGenericSessionPrompt } from "@/lib/prompt-composition-engine";
 import {
   MissionTransportNotReadyError,
@@ -38,6 +43,41 @@ async function resolveSessionTitle(
   } catch {
     return null;
   }
+}
+
+async function resolveOwnedSessionActivationTitle(input: {
+  client: ReturnType<typeof resolveSessionRouteTarget>["client"];
+  sessionId: string;
+  ownedSession: NonNullable<ReturnType<typeof resolveSessionRouteTarget>["ownedSession"]>;
+  rawSessionTitle: string | null;
+}): Promise<string> {
+  const canonicalTitle = getOwnedSessionTitle(input.sessionId);
+  const storedTitleIsCanonical = hasOwnedSessionTitle(input.sessionId, input.ownedSession.sessionTitle);
+  const runtimeTitleIsCanonical =
+    input.rawSessionTitle === null || hasOwnedSessionTitle(input.sessionId, input.rawSessionTitle);
+
+  if (storedTitleIsCanonical && runtimeTitleIsCanonical) {
+    return canonicalTitle;
+  }
+
+  const result = await input.client.session.update({
+    sessionID: input.sessionId,
+    title: canonicalTitle,
+  });
+
+  if (result.error) {
+    throw new Error(typeof result.error === "string" ? result.error : "Unable to update owned session title.");
+  }
+
+  saveOwnedSession({
+    ownerAgent: input.ownedSession.ownerAgent,
+    sessionId: input.sessionId,
+    sessionTitle: canonicalTitle,
+    surface: input.ownedSession.surface,
+    transportMode: input.ownedSession.transportMode,
+  });
+
+  return canonicalTitle;
 }
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
@@ -86,9 +126,10 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     const selectedModel = isModelSelection(body.model) ? body.model : undefined;
     const { model, variant } = splitModelSelection(selectedModel);
     const userMessageId = createOpencodeMessageId();
+    const resolvedSessionTitle = await resolveSessionTitle(client, sessionId);
     const rawSessionTitle = managedSession
-      ? await resolveSessionTitle(client, sessionId)
-      : ownedSession?.sessionTitle ?? null;
+      ? resolvedSessionTitle
+      : resolvedSessionTitle ?? ownedSession?.sessionTitle ?? null;
     const requestedSelection: SessionSelection = {
       agent: body.agent ? body.agent : null,
       model: selectedModel ?? null,
@@ -145,10 +186,17 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         transportMode: ownedSession.transportMode,
       });
 
+      const activationTitle = await resolveOwnedSessionActivationTitle({
+        client,
+        sessionId,
+        ownedSession,
+        rawSessionTitle,
+      });
+
       queueOwnedSessionTmuxDispatch({
         ownerAgent: ownedSession.ownerAgent,
         sessionId,
-        sessionTitle: rawSessionTitle ?? ownedSession.sessionTitle,
+        sessionTitle: activationTitle,
         parts: composed.payloadParts,
         ...(model ? { model } : {}),
         ...(variant ? { variant } : {}),

--- a/web/app/routes/api.session.$id.prompt.ts
+++ b/web/app/routes/api.session.$id.prompt.ts
@@ -1,12 +1,16 @@
 import { getProjectRoot } from "@/lib/get-project-root.server";
-import { findManagedSession } from "@/lib/managed-session.server";
 import { isModelSelection, splitModelSelection } from "@/lib/model-variant-selection";
 import { appendMissionActivity } from "@/lib/mission-store";
 import { createOpencodeMessageId } from "@/lib/opencode-message-id";
-import { getOpencodeClient } from "@/lib/opencode-client";
+import { queueOwnedSessionTmuxDispatch } from "@/lib/owned-session-transport.server";
 import { composeGenericSessionPrompt } from "@/lib/prompt-composition-engine";
+import {
+  MissionTransportNotReadyError,
+  requireReadyMissionTransport,
+} from "@/lib/primary-agent-mission-transport.server";
 import { saveSessionRequestAnchor } from "@/lib/session-request-anchors.server";
 import type { SessionSelection } from "@/lib/session-selection-adjustment";
+import { resolveSessionRouteTarget } from "@/lib/session-owner-routing.server";
 import type { PromptPart } from "@/lib/prompt-parts";
 import { stringifyPromptParts } from "@/lib/prompt-parts";
 import { appendSessionPromptDebugLog } from "@/lib/session-prompt-debug.server";
@@ -20,9 +24,11 @@ type PromptPayload = {
   missionId?: string;
 };
 
-async function resolveSessionTitle(sessionId: string): Promise<string | null> {
+async function resolveSessionTitle(
+  client: ReturnType<typeof resolveSessionRouteTarget>["client"],
+  sessionId: string,
+): Promise<string | null> {
   try {
-    const client = getOpencodeClient();
     const result = await client.session.list();
     if (result.error) {
       return null;
@@ -42,7 +48,9 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   const requestId = crypto.randomUUID();
   const body = (await request.json().catch(() => null)) as PromptPayload | null;
-  const managedSession = findManagedSession(sessionId);
+  const routeTarget = resolveSessionRouteTarget(sessionId);
+  const managedSession = routeTarget.managedSession;
+  const ownedSession = routeTarget.ownedSession;
 
   appendSessionPromptDebugLog({
     route: "api.session.$id.prompt",
@@ -57,6 +65,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
             ownerAgent: managedSession.ownerAgent,
           }
         : null,
+      ownedSession: ownedSession
+        ? {
+            ownerAgent: ownedSession.ownerAgent,
+            sessionTitle: ownedSession.sessionTitle,
+            surface: ownedSession.surface,
+            transportMode: ownedSession.transportMode,
+          }
+        : null,
     },
   });
 
@@ -65,11 +81,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   }
 
   try {
-    const client = getOpencodeClient();
+    const appRoot = getProjectRoot();
+    const client = routeTarget.client;
     const selectedModel = isModelSelection(body.model) ? body.model : undefined;
     const { model, variant } = splitModelSelection(selectedModel);
     const userMessageId = createOpencodeMessageId();
-    const rawSessionTitle = managedSession ? await resolveSessionTitle(sessionId) : null;
+    const rawSessionTitle = managedSession
+      ? await resolveSessionTitle(client, sessionId)
+      : ownedSession?.sessionTitle ?? null;
     const requestedSelection: SessionSelection = {
       agent: body.agent ? body.agent : null,
       model: selectedModel ?? null,
@@ -85,12 +104,20 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
           selectedModel: selectedModel ?? null,
         }
       : null;
+    const ownedSessionLog = ownedSession
+      ? {
+          ownerAgent: ownedSession.ownerAgent,
+          rawSessionTitle,
+          surface: ownedSession.surface,
+          transportMode: ownedSession.transportMode,
+        }
+      : null;
     const composed = composeGenericSessionPrompt({
       context: {
         missionId: managedSession?.missionId ?? (typeof body.missionId === "string" ? body.missionId : undefined),
         sessionId,
         agent: body.agent,
-        appRoot: getProjectRoot(),
+        appRoot,
       },
       parts: body.parts,
     });
@@ -108,8 +135,50 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         agent: body.agent ?? null,
         parts: composed.payloadParts,
         managedSession: managedSessionLog,
+        ownedSession: ownedSessionLog,
       },
     });
+
+    if (ownedSession?.transportMode === "tmux-resident") {
+      await requireReadyMissionTransport({
+        appRoot,
+        transportMode: ownedSession.transportMode,
+      });
+
+      queueOwnedSessionTmuxDispatch({
+        ownerAgent: ownedSession.ownerAgent,
+        sessionId,
+        sessionTitle: rawSessionTitle ?? ownedSession.sessionTitle,
+        parts: composed.payloadParts,
+        ...(model ? { model } : {}),
+        ...(variant ? { variant } : {}),
+      });
+
+      appendSessionPromptDebugLog({
+        route: "api.session.$id.prompt",
+        stage: "prompt-result",
+        requestId,
+        sessionId,
+        payload: {
+          error: null,
+          managedSession: managedSessionLog,
+          ownedSession: ownedSessionLog,
+          queued: true,
+        },
+      });
+
+      try {
+        saveSessionRequestAnchor({
+          sessionId,
+          userMessageId,
+          requested: requestedSelection,
+        });
+      } catch {
+        // Request tracking must never block prompt delivery.
+      }
+
+      return new Response(null, { status: 204 });
+    }
 
     const result = await client.session.promptAsync({
       sessionID: sessionId,
@@ -128,6 +197,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       payload: {
         error: result.error ?? null,
         managedSession: managedSessionLog,
+        ownedSession: ownedSessionLog,
       },
     });
 
@@ -166,6 +236,10 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
     return new Response(null, { status: 204 });
   } catch (error) {
+    if (error instanceof MissionTransportNotReadyError) {
+      return Response.json({ error: error.message }, { status: 503 });
+    }
+
     appendSessionPromptDebugLog({
       route: "api.session.$id.prompt",
       stage: "prompt-error",

--- a/web/app/routes/api.session.$id.test.ts
+++ b/web/app/routes/api.session.$id.test.ts
@@ -76,8 +76,54 @@ describe("api.session.$id", () => {
       endpointUrl: null,
       managedSession: null,
       mode: "default",
+      ownedSession: null,
       ownerAgent: null,
     }));
+  });
+
+  it("loads owned Iris session transcript through the resolved owner-aware client", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot();
+
+    sessionMessagesMock.mockRejectedValue(new Error("default client should not be used"));
+    resolvedSessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: "assistant-owned",
+            role: "assistant",
+            agent: "iris",
+            time: { created: Date.parse("2026-04-28T10:00:00.000Z") },
+          },
+          parts: [{ type: "text", text: "Owned Iris route reply." }],
+        },
+      ],
+    });
+    resolveSessionRouteTargetMock.mockReturnValue({
+      client: {
+        session: {
+          messages: resolvedSessionMessagesMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4405",
+      managedSession: null,
+      mode: "owned",
+      ownedSession: {
+        ownerAgent: "iris",
+        sessionTitle: "iris:projects",
+        surface: "projects-iris",
+        transportMode: "tmux-resident",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+      ownerAgent: "iris",
+    });
+
+    const response = await loader({ params: { id: "session-iris" } } as never);
+
+    expect(response.status).toBe(200);
+    const data = await readJson<{ messages: Array<{ info: { id: string } }> }>(response);
+    expect(data.messages[0]?.info.id).toBe("assistant-owned");
+    expect(resolvedSessionMessagesMock).toHaveBeenCalledWith({ sessionID: "session-iris" });
+    expect(sessionMessagesMock).not.toHaveBeenCalled();
   });
 
   it("loads managed session transcript through the resolved owner-aware client", async () => {

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,6 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@react-router/express": "7.13.1",
     "@opencode-ai/sdk": "^1.2.27",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -29,6 +28,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-router/express": "7.13.1",
     "@react-router/fs-routes": "^7.13.1",
     "@react-router/node": "7.13.1",
     "@react-router/serve": "7.13.1",


### PR DESCRIPTION
## Summary

- Bring Lunafreya mission flows closer to Noctis tmux mission parity for owned sessions and transport handling.
- Add a tmux monitor surface and supporting UI updates so session state is easier to inspect from the dashboard.
- Expand ambient banter and mission/session routing coverage, with broad regression tests across the affected routes and hooks.
- Diff scope: 62 files changed, 3973 insertions, 449 deletions.

## Motivation

Lunafreya-owned and tmux-backed mission flows were missing pieces that already existed in the broader mission/session stack. This change aligns the transport, ownership, routing, and monitoring behavior so owned sessions can use the same durable tmux-backed flow while also exposing the relevant runtime state in the web UI.

## Changes Overview

- Add owned-session transport and registry support for tmux-backed mission dispatch, including routing updates for session-owned endpoints.
- Extend Lunafreya mission start/continue and banter routes so ambient banter and mission transport work through the owned-session flow.
- Introduce the tmux monitor route and pane, plus related layout updates for operations and project surfaces.
- Update the tmux dispatcher/runtime integration and associated session prompt, abort, and event handling paths.
- Add and refresh regression coverage across hooks, server libraries, API routes, and monitor UI components.

## Testing

- `bash .opencode/skills/pr-assistant/scripts/quality_checks.sh`
- `npm run web:typecheck`
- `npm run web:test`
- `npm run web:lint`

## Screenshots

- Not included. This PR adds a new monitor surface and layout changes, but no screenshots were captured during preparation.

## Related Issues

None.

## Checklist

- [x] Self-reviewed the generated PR draft and validation results
- [x] Automated tests added or updated as appropriate
- [x] Config impact reviewed (`web/package.json` changed)
- [ ] UI screenshots added if useful
- [ ] Breaking changes documented (not expected)

## Notes

- `web:test` passed with 170 test files / 721 tests.
- `web:lint` completed without errors and reported 6 warnings, including non-null assertions in tests and type-only import suggestions.
