### PR TITLE
Prepare 0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.12.0] - 2026-05-01
+
+### Added
+- **Operation system and authoring surfaces** - Added operation catalog loading, prompt composition and preview/apply flows, built-in English and Japanese facets, jobs, output contracts, and Iris-facing authoring and debug tools for customizable workflows
+- **Lunafreya mission runtime** - Added Lunafreya mission routes, ambient banter, tmux transport runtime and dispatcher support, owned-session routing, mission output browsing, and execution workspace handling across the web app and scripts
+- **Project and server management tools** - Added project rename/delete helpers, shared skills configuration, OpenCode SDK Lab routes, and dedicated web/OpenCode server control helpers with tests
+
+### Changed
+- **Chat and mission UX** - Improved session rendering, draft persistence, message detail sheets, output detail routing, mission summaries, prompt inspection, and model selection flows across Noctis Team, OpenCode, and operations screens
+- **Setup and runtime plumbing** - Updated `first_setup.sh`, `standby.sh`, config templates, model definitions, and transport/bootstrap logic to support managed sessions, tmux-based missions, and browser-driven operations
+- **Agent and workflow assets** - Expanded Copilot/OpenCode prompts, skills, and agent definitions to cover PR assistance, TDD, architecture review, PRD flows, and operation customization workflows
+
+### Fixed
+- **Session and transport reliability** - Fixed owned-session reads, dispatch abort and cancellation handling, transport readiness, pending transcript resync, and mission recovery behavior in the tmux-backed runtime
+- **Configuration and server handling** - Fixed web origin resolution, local config bootstrap, API status/error handling, and server control flows for browser-first operation
+- **Message and report presentation** - Fixed live draft rendering, copy interactions, detail-sheet APIs, manual verification/report handling, and workflow message presentation edge cases
+
+### Deprecated
+- None
+
+### Removed
+- **Deprecated skill scaffolds and command aliases** - Removed superseded skill scaffolding assets and old `.opencode/command/*` paths after migrating to the consolidated `.opencode/commands/*` layout
+
+### Security
+- None
+
 ## [0.11.0] - 2026-03-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0",
+  "version": "0.12.0",
   "name": "multi-agent-ff15",
   "scripts": {
     "web:install": "cd web && npm install",


### PR DESCRIPTION
## Summary

- bump the root package version to 0.12.0
- add the 0.12.0 changelog entry for the GitHub release workflow
- prepare the release changes in an isolated branch instead of pushing to main

## Motivation

The release workflow expects the requested release version to already exist in both package.json and CHANGELOG.md on main. This PR prepares those release artifacts so the 0.12.0 release can be created through the existing workflow without a direct push to main.

## Changes Overview

- updated the root version in package.json from 0.11.0 to 0.12.0
- added a 0.12.0 changelog section summarizing the changes since v0.11.0
- verified that the changelog entry can be extracted by the release workflow format

## Testing

- npm run web:lint
- npm run web:test
- npm run web:typecheck
- npm run web:build

- [x] Tested locally
- [ ] Manual testing completed
- [x] Edge cases considered

## Screenshots

N/A

## Related Issues

None.

## Checklist

- [x] Version and changelog are aligned for the release workflow
- [x] Release checks passed locally
- [x] Changes are limited to release preparation files

## Notes

After this PR is merged to main, run the GitHub Actions release workflow with version `0.12.0`.