### PR TITLE
Add active step resume controls to Noctis team view

### DIFF
--- a/web/app/components/ui/context-menu.tsx
+++ b/web/app/components/ui/context-menu.tsx
@@ -1,0 +1,198 @@
+import * as React from "react"
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ContextMenu = ContextMenuPrimitive.Root
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger
+
+const ContextMenuGroup = ContextMenuPrimitive.Group
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal
+
+const ContextMenuSub = ContextMenuPrimitive.Sub
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+))
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+))
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+))
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+))
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+ContextMenuShortcut.displayName = "ContextMenuShortcut"
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}

--- a/web/app/lib/operation-runtime/active-step.ts
+++ b/web/app/lib/operation-runtime/active-step.ts
@@ -1,0 +1,18 @@
+import type { OperationState, StepHistoryEntry } from "@/lib/types/mission";
+
+export function getActiveStepRecord(state: OperationState): StepHistoryEntry | undefined {
+  const latestEntry = state.stepHistory.at(-1);
+  if (!latestEntry) {
+    return undefined;
+  }
+
+  if (latestEntry.step !== state.currentStep || latestEntry.status !== "dispatched") {
+    return undefined;
+  }
+
+  return latestEntry;
+}
+
+export function getActiveStepTaskId(state: OperationState): string | undefined {
+  return getActiveStepRecord(state)?.taskId;
+}

--- a/web/app/lib/operation-runtime/state.ts
+++ b/web/app/lib/operation-runtime/state.ts
@@ -6,6 +6,7 @@ import type {
   StepHistoryEntry,
   WorkerAgentId,
 } from "@/lib/types/mission";
+import { getActiveStepRecord } from "./active-step";
 import type { StateTransition } from "./types";
 
 const DEFAULT_REPORT_DIR = "docs/reports";
@@ -67,22 +68,7 @@ function createStepTaskId(state: OperationState): string {
   return `step_${state.currentStep}_${state.iteration + 1}`;
 }
 
-export function getActiveStepRecord(state: OperationState): StepHistoryEntry | undefined {
-  const latestEntry = state.stepHistory.at(-1);
-  if (!latestEntry) {
-    return undefined;
-  }
-
-  if (latestEntry.step !== state.currentStep || latestEntry.status !== "dispatched") {
-    return undefined;
-  }
-
-  return latestEntry;
-}
-
-export function getActiveStepTaskId(state: OperationState): string | undefined {
-  return getActiveStepRecord(state)?.taskId;
-}
+export { getActiveStepRecord, getActiveStepTaskId } from "./active-step";
 
 export function ensureActiveStepTaskId(state: OperationState, agent: AgentId): string {
   const activeEntry = getActiveStepRecord(state);

--- a/web/app/lib/operation-runtime/state.ts
+++ b/web/app/lib/operation-runtime/state.ts
@@ -3,7 +3,6 @@ import type {
   AgentId,
   DelegatedTaskRecord,
   OperationState,
-  StepHistoryEntry,
   WorkerAgentId,
 } from "@/lib/types/mission";
 import { getActiveStepRecord } from "./active-step";

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
@@ -526,6 +526,55 @@ describe("noctis-team-screen", () => {
     expect(markup).not.toContain("Workspace: Ready");
   });
 
+  it("shows the working branch in mission details for mission workspaces", () => {
+    paramsMock.mockReturnValue({ id: "mission-1" });
+
+    const markup = renderToStaticMarkup(
+      <NoctisTeamScreen
+        activeMissionId="mission-1"
+        initialMissionData={buildMission()}
+        language="other"
+      />,
+    );
+
+    expect(markup).toContain("Working branch");
+    expect(markup).toContain("mission/20260401-mission-one");
+  });
+
+  it("shows the execution project head branch alongside mission workspace details", () => {
+    paramsMock.mockReturnValue({ id: "mission-1" });
+    projectRegistryStateMock.mockReturnValue({
+      data: {
+        projects: [
+          {
+            id: "core-repo",
+            displayName: "Core Repo",
+            path: "/repos/core",
+            branchName: "feature/active-work",
+          },
+          {
+            id: "docs-repo",
+            displayName: "Reference Docs",
+            path: "/repos/docs",
+          },
+        ],
+      },
+      error: null,
+      loading: false,
+    });
+
+    const markup = renderToStaticMarkup(
+      <NoctisTeamScreen
+        activeMissionId="mission-1"
+        initialMissionData={buildMission()}
+        language="other"
+      />,
+    );
+
+    expect(markup).toContain("Execution project HEAD");
+    expect(markup).toContain("feature/active-work");
+  });
+
   it("passes mission-start pending state to chat area and suppresses abort during startup", () => {
     agentSessionStateMock.mockReturnValue({
       messages: [],
@@ -630,6 +679,46 @@ describe("noctis-team-screen", () => {
     expect(markup).toContain("Registered project");
     expect(markup).toContain("This mission is using the execution project directly without a dedicated workspace.");
     expect(markup).toContain("/repos/core");
+  });
+
+  it("shows the execution project branch as the working branch in direct mode", () => {
+    paramsMock.mockReturnValue({ id: "mission-1" });
+    projectRegistryStateMock.mockReturnValue({
+      data: {
+        projects: [
+          {
+            id: "core-repo",
+            displayName: "Core Repo",
+            path: "/repos/core",
+            branchName: "feature/direct-mode",
+          },
+          {
+            id: "docs-repo",
+            displayName: "Reference Docs",
+            path: "/repos/docs",
+          },
+        ],
+      },
+      error: null,
+      loading: false,
+    });
+
+    const markup = renderToStaticMarkup(
+      <NoctisTeamScreen
+        activeMissionId="mission-1"
+        initialMissionData={buildMission({
+          executionTargetMode: "execution_project",
+          branch: null,
+          baseBranch: null,
+          workspacePath: null,
+          workspaceStatus: null,
+        })}
+        language="other"
+      />,
+    );
+
+    expect(markup).toContain("Working branch");
+    expect(markup).toContain("feature/direct-mode");
   });
 
   it("passes initial workflow progress into the chat area for existing missions", () => {

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MissionResumePayload } from "@/hooks/use-agent-session";
+import { createOperationState } from "@/lib/operation-runtime/state";
 
 const {
   projectRegistryStateMock,
@@ -10,6 +11,7 @@ const {
   matchMock,
   navigateMock,
   paramsMock,
+  partyStatusPropsSpy,
   toastErrorMock,
   toastSuccessMock,
 } = vi.hoisted(() => ({
@@ -19,6 +21,7 @@ const {
   matchMock: vi.fn(),
   navigateMock: vi.fn(),
   paramsMock: vi.fn(),
+  partyStatusPropsSpy: vi.fn(),
   toastErrorMock: vi.fn(),
   toastSuccessMock: vi.fn(),
 }));
@@ -202,7 +205,10 @@ vi.mock("./mission-output-browser", () => ({
 }));
 
 vi.mock("./party-status-panel", () => ({
-  PartyStatusPanel: () => <div>party-status-panel</div>,
+  PartyStatusPanel: (props: Record<string, unknown>) => {
+    partyStatusPropsSpy(props);
+    return <div>party-status-panel</div>;
+  },
 }));
 
 vi.mock("./lunafreya-status-panel", () => ({
@@ -258,6 +264,7 @@ describe("noctis-team-screen", () => {
     paramsMock.mockReturnValue({});
     matchMock.mockReturnValue(null);
     lunafreyaStatusPropsSpy.mockReset();
+    partyStatusPropsSpy.mockReset();
     navigateMock.mockReset();
     toastErrorMock.mockReset();
     toastSuccessMock.mockReset();
@@ -368,6 +375,46 @@ describe("noctis-team-screen", () => {
 
     expect(markup).toContain("cannot resume until an execution project is assigned");
     expect(markup).toContain("Assign Execution Project");
+  });
+
+  it("passes mission resume context into the party status panel", () => {
+    const activeOperationState = createOperationState(
+      "review-cycle-test",
+      "implement",
+      "builtin:ja:review-cycle-test.yaml",
+    );
+    activeOperationState.currentStep = "implement";
+    activeOperationState.status = "waiting_for_report";
+    activeOperationState.stepHistory = [
+      {
+        step: "implement",
+        agent: "gladiolus",
+        taskId: "task-1",
+        status: "dispatched",
+        dispatchedAt: "2026-05-01T00:00:00.000Z",
+      },
+    ];
+
+    agentSessionStateMock.mockReturnValue({
+      ...agentSessionStateMock(),
+      activeOperationState,
+    });
+
+    renderToStaticMarkup(
+      <NoctisTeamScreen
+        activeMissionId="mission-1"
+        initialMissionData={buildMission()}
+        language="other"
+      />,
+    );
+
+    const props = partyStatusPropsSpy.mock.calls.at(-1)?.[0] as {
+      missionId?: string | null;
+      activeOperationState?: unknown;
+    };
+
+    expect(props.missionId).toBe("mission-1");
+    expect(props.activeOperationState).toBe(activeOperationState);
   });
 
   it("passes only the latest retryable failed delivery into the chat area", () => {

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -1328,7 +1328,12 @@ export function NoctisTeamScreen({
               ) : null}
 
               {surface.supportsPartyStatus ? (
-                <PartyStatusPanel members={partyMembers} speakingAgentId={speakingAgentId} />
+                <PartyStatusPanel
+                  members={partyMembers}
+                  missionId={effectiveMissionId}
+                  activeOperationState={activeOperationState}
+                  speakingAgentId={speakingAgentId}
+                />
               ) : (
                 <LunafreyaStatusPanel
                   contextUsage={primaryContextUsage}

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -294,6 +294,15 @@ export function NoctisTeamScreen({
   const isLegacyMissionBlocked =
     resumeBlockedCode === "missing_execution_project";
   const isUnsupportedMission = resumeBlockedCode === "unsupported_mission_runtime";
+  const executionProjectBranchName = selectedExecutionProject?.branchName ?? null;
+  const missionWorkingBranch =
+    effectiveMissionId
+      ? isDirectExecutionMission
+        ? executionProjectBranchName
+        : missionDetail?.branch ?? null
+      : null;
+  const executionProjectHeadBranch =
+    effectiveMissionId && !isDirectExecutionMission ? executionProjectBranchName : null;
   const workspaceStatusLabel =
     isDirectExecutionMission
       ? "Registered project"
@@ -1480,6 +1489,24 @@ export function NoctisTeamScreen({
                 <p className="font-medium text-sm">Execution mode</p>
                 <p className="text-muted-foreground text-sm">
                   {getMissionExecutionTargetModeLabel(missionExecutionTargetMode)}
+                </p>
+              </div>
+            ) : null}
+
+            {missionWorkingBranch ? (
+              <div className="space-y-1">
+                <p className="font-medium text-sm">Working branch</p>
+                <p className="break-all font-mono text-[11px] text-muted-foreground">
+                  {missionWorkingBranch}
+                </p>
+              </div>
+            ) : null}
+
+            {executionProjectHeadBranch && executionProjectHeadBranch !== missionWorkingBranch ? (
+              <div className="space-y-1">
+                <p className="font-medium text-sm">Execution project HEAD</p>
+                <p className="break-all font-mono text-[11px] text-muted-foreground">
+                  {executionProjectHeadBranch}
                 </p>
               </div>
             ) : null}

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createOperationState } from "@/lib/operation-runtime/state";
+import type { PartyMember } from "@/lib/noctis-team-ui-types";
+
+const { chatStoreStateMock } = vi.hoisted(() => ({
+  chatStoreStateMock: vi.fn(),
+}));
+
+vi.mock("@/components/compact-model-variant-picker", () => ({
+  CompactModelVariantPicker: () => <div>model-picker</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/command", () => ({
+  Command: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CommandGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CommandInput: (props: Record<string, unknown>) => <input {...props} />,
+  CommandItem: ({ children, ...props }: { children?: ReactNode }) => <div {...props}>{children}</div>,
+  CommandList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...props
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onSelect?: (event: { preventDefault: () => void }) => void;
+  }) => (
+    <button
+      data-disabled={disabled ? "true" : "false"}
+      disabled={disabled}
+      onClick={() => onSelect?.({ preventDefault: () => undefined })}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
+  ContextMenuLabel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@/stores/chat-store", () => ({
+  useChatStore: (
+    selector: (state: {
+      agentModels: Record<string, null>;
+      workingParty: Record<string, boolean>;
+      setAgentModel: (agentId: string, model: unknown) => void;
+      setAgentModels: (models: Record<string, unknown>) => void;
+      setWorkingPartyMember: (agentId: string, included: boolean) => void;
+    }) => unknown,
+  ) => selector(chatStoreStateMock()),
+}));
+
+vi.mock("./character-card", () => ({
+  CharacterCard: ({
+    name,
+    statusAccessory,
+    metaAccessory,
+  }: {
+    name: string;
+    statusAccessory?: ReactNode;
+    metaAccessory?: ReactNode;
+  }) => (
+    <section>
+      <h2>{name}</h2>
+      {statusAccessory}
+      {metaAccessory}
+    </section>
+  ),
+}));
+
+import { PartyStatusPanel } from "./party-status-panel";
+
+const partyMembers: PartyMember[] = [
+  { id: "noctis", name: "Noctis", role: "Leader", status: "idle", imageSrc: "/noctis.png" },
+  { id: "ignis", name: "Ignis", role: "Analyst", status: "idle", imageSrc: "/ignis.png" },
+  {
+    id: "gladiolus",
+    name: "Gladiolus",
+    role: "Implementer",
+    status: "working",
+    imageSrc: "/gladiolus.png",
+  },
+  { id: "prompto", name: "Prompto", role: "Reviewer", status: "idle", imageSrc: "/prompto.png" },
+];
+
+function createActiveOperationState(agent: "noctis" | "ignis" | "gladiolus" | "prompto") {
+  const state = createOperationState("review-cycle-test", "implement", "builtin:ja:review-cycle-test.yaml");
+  state.currentStep = "implement";
+  state.status = "waiting_for_report";
+  state.stepHistory = [
+    {
+      step: "implement",
+      agent,
+      taskId: "task-1",
+      status: "dispatched",
+      dispatchedAt: "2026-05-01T00:00:00.000Z",
+    },
+  ];
+  return state;
+}
+
+describe("PartyStatusPanel", () => {
+  beforeEach(() => {
+    chatStoreStateMock.mockReturnValue({
+      agentModels: {
+        noctis: null,
+        ignis: null,
+        gladiolus: null,
+        prompto: null,
+      },
+      workingParty: {
+        ignis: true,
+        gladiolus: true,
+        prompto: true,
+      },
+      setAgentModel: () => undefined,
+      setAgentModels: () => undefined,
+      setWorkingPartyMember: () => undefined,
+    });
+  });
+
+  it("enables resume only on the worker card that owns the active step", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("gladiolus")}
+        speakingAgentId={null}
+      />,
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/,
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Resume active worker step for Gladiolus"/,
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/,
+    );
+  });
+
+  it("disables worker resume actions when the active step is not worker-owned", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+      />,
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/,
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Gladiolus"/,
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/,
+    );
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronsUpDown, Cpu, Sparkles } from "lucide-react";
 import { memo, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { CompactModelVariantPicker } from "@/components/compact-model-variant-picker";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,6 +11,14 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { normalizeBanterAgentId } from "@/lib/banter/runtime";
 import { areModelSelectionsEqual } from "@/lib/model-variant-selection";
@@ -25,11 +34,16 @@ import {
   isWorkingPartyMemberId,
   normalizeWorkingPartyMemberId,
 } from "@/lib/noctis-working-party";
+import { getActiveStepRecord } from "@/lib/operation-runtime/active-step";
 import type { PartyMember } from "@/lib/noctis-team-ui-types";
-import type { ModelSelection } from "@/lib/types/mission";
+import type { ModelSelection, OperationState } from "@/lib/types/mission";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
 import { CharacterCard } from "./character-card";
+import {
+  formatResumeActiveWorkerStepSuccessMessage,
+  resumeActiveWorkerStep,
+} from "./resume-active-worker-step";
 
 const PRESET_AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto"] as const;
 
@@ -175,12 +189,20 @@ AgentModelPicker.displayName = "AgentModelPicker";
 
 interface PartyStatusPanelProps {
   members: PartyMember[];
+  missionId?: string | null;
+  activeOperationState?: OperationState | null;
   speakingAgentId?: string | null;
 }
 
-export const PartyStatusPanel = ({ members, speakingAgentId = null }: PartyStatusPanelProps) => {
+export const PartyStatusPanel = ({
+  members,
+  missionId = null,
+  activeOperationState = null,
+  speakingAgentId = null,
+}: PartyStatusPanelProps) => {
   const [providers, setProviders] = useState<OpencodeProvider[]>([]);
   const [presets, setPresets] = useState<ModelPreset[]>([]);
+  const [resumingAgentId, setResumingAgentId] = useState<PresetAgentId | null>(null);
   const [variantsByModel, setVariantsByModel] = useState<Record<string, string[]>>({});
   const agentModels = useChatStore((state) => state.agentModels);
   const workingParty = useChatStore((state) => state.workingParty);
@@ -229,6 +251,37 @@ export const PartyStatusPanel = ({ members, speakingAgentId = null }: PartyStatu
     () => getCompactWorkingPartySummary(allowedWorkers),
     [allowedWorkers]
   );
+  const activeWorkerStepAgentId = useMemo(() => {
+    if (!missionId || !activeOperationState) {
+      return null;
+    }
+
+    const activeStepRecord = getActiveStepRecord(activeOperationState);
+    if (!activeStepRecord || activeStepRecord.agent === "noctis" || activeStepRecord.agent === "lunafreya") {
+      return null;
+    }
+
+    return normalizePartyAgentId(activeStepRecord.agent);
+  }, [activeOperationState, missionId]);
+
+  const handleResumeActiveWorkerStep = async (agentId: PresetAgentId) => {
+    if (!missionId || !isWorkingPartyMemberId(agentId) || agentId !== activeWorkerStepAgentId) {
+      return;
+    }
+
+    setResumingAgentId(agentId);
+    try {
+      const result = await resumeActiveWorkerStep({
+        missionId,
+        agentId,
+      });
+      toast.success(formatResumeActiveWorkerStepSuccessMessage(result));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to resume active worker step");
+    } finally {
+      setResumingAgentId((current) => (current === agentId ? null : current));
+    }
+  };
 
   return (
     <div className="flex flex-col gap-3">
@@ -338,30 +391,58 @@ export const PartyStatusPanel = ({ members, speakingAgentId = null }: PartyStatu
 
           return (
             <div key={member.id}>
-              <CharacterCard
-                {...member}
-                agentId={normalizedAgentId ?? member.id}
-                isInParty={isWorker ? isInParty : true}
-                isSpeaking={normalizedAgentId === speakingAgentId}
-                statusAccessory={partyControl}
-                metaAccessory={
-                  <AgentModelPicker
-                    agentId={member.id}
-                    modelItems={modelItems}
-                    selectedModel={
-                      normalizedAgentId ? (agentModels[normalizedAgentId] ?? null) : null
-                    }
-                    variantsByModel={variantsByModel}
-                    onSelect={(model) => {
-                      if (!normalizedAgentId) {
-                        return;
-                      }
+              <ContextMenu>
+                <ContextMenuTrigger asChild>
+                  <div>
+                    <CharacterCard
+                      {...member}
+                      agentId={normalizedAgentId ?? member.id}
+                      isInParty={isWorker ? isInParty : true}
+                      isSpeaking={normalizedAgentId === speakingAgentId}
+                      statusAccessory={partyControl}
+                      metaAccessory={
+                        <AgentModelPicker
+                          agentId={member.id}
+                          modelItems={modelItems}
+                          selectedModel={
+                            normalizedAgentId ? (agentModels[normalizedAgentId] ?? null) : null
+                          }
+                          variantsByModel={variantsByModel}
+                          onSelect={(model) => {
+                            if (!normalizedAgentId) {
+                              return;
+                            }
 
-                      setAgentModel(normalizedAgentId, model);
-                    }}
-                  />
-                }
-              />
+                            setAgentModel(normalizedAgentId, model);
+                          }}
+                        />
+                      }
+                    />
+                  </div>
+                </ContextMenuTrigger>
+
+                {isWorker ? (
+                  <ContextMenuContent>
+                    <ContextMenuLabel>Worker Actions</ContextMenuLabel>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem
+                      aria-label={`Resume active worker step for ${member.name}`}
+                      disabled={
+                        normalizedAgentId !== activeWorkerStepAgentId || resumingAgentId !== null
+                      }
+                      onSelect={() => {
+                        if (!normalizedAgentId) {
+                          return;
+                        }
+
+                        void handleResumeActiveWorkerStep(normalizedAgentId);
+                      }}
+                    >
+                      Resume Active Step
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                ) : null}
+              </ContextMenu>
             </div>
           );
         })}

--- a/web/app/routes/_layout.noctis-team/components/resume-active-worker-step.test.ts
+++ b/web/app/routes/_layout.noctis-team/components/resume-active-worker-step.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  formatResumeActiveWorkerStepSuccessMessage,
+  resumeActiveWorkerStep,
+} from "./resume-active-worker-step";
+
+describe("resumeActiveWorkerStep", () => {
+  it("posts the selected worker to the mission resume route and returns the payload", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          agentId: "gladiolus",
+          stepName: "implement",
+          taskId: "task-1",
+          sessionId: "worker-session",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(
+      resumeActiveWorkerStep({
+        missionId: "mission-123",
+        agentId: "gladiolus",
+        fetchImpl: fetchMock as typeof fetch,
+      }),
+    ).resolves.toMatchObject({
+      agentId: "gladiolus",
+      stepName: "implement",
+      taskId: "task-1",
+      sessionId: "worker-session",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/missions/mission-123/resume-active-step", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: "gladiolus" }),
+    });
+  });
+
+  it("throws the route error message when the resume request fails", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: "Active step changed" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(
+      resumeActiveWorkerStep({
+        missionId: "mission-123",
+        agentId: "gladiolus",
+        fetchImpl: fetchMock as typeof fetch,
+      }),
+    ).rejects.toThrow("Active step changed");
+  });
+});
+
+describe("formatResumeActiveWorkerStepSuccessMessage", () => {
+  it("formats a compact success toast message", () => {
+    expect(
+      formatResumeActiveWorkerStepSuccessMessage({
+        agentId: "gladiolus",
+        stepName: "implement",
+        taskId: "task-1",
+        sessionId: "worker-session",
+      }),
+    ).toBe("Resumed Gladiolus for implement.");
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/resume-active-worker-step.ts
+++ b/web/app/routes/_layout.noctis-team/components/resume-active-worker-step.ts
@@ -1,0 +1,68 @@
+import type { WorkerAgentId } from "@/lib/types/mission";
+
+export interface ResumeActiveWorkerStepResult {
+  agentId: WorkerAgentId;
+  stepName: string;
+  taskId: string;
+  sessionId: string;
+}
+
+type ResumeActiveWorkerStepPayload = Partial<ResumeActiveWorkerStepResult> & {
+  error?: unknown;
+};
+
+const AGENT_LABELS: Record<WorkerAgentId, string> = {
+  ignis: "Ignis",
+  gladiolus: "Gladiolus",
+  prompto: "Prompto",
+};
+
+export async function resumeActiveWorkerStep(input: {
+  missionId: string;
+  agentId: WorkerAgentId;
+  fetchImpl?: typeof fetch;
+}): Promise<ResumeActiveWorkerStepResult> {
+  const response = await (input.fetchImpl ?? fetch)(
+    `/api/missions/${input.missionId}/resume-active-step`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: input.agentId }),
+    },
+  );
+
+  const payload = (await response.json().catch(() => null)) as
+    | ResumeActiveWorkerStepPayload
+    | null;
+
+  if (!response.ok) {
+    const errorMessage =
+      payload && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : "Unable to resume active worker step";
+    throw new Error(errorMessage);
+  }
+
+  if (
+    !payload ||
+    payload.agentId !== input.agentId ||
+    typeof payload.stepName !== "string" ||
+    typeof payload.taskId !== "string" ||
+    typeof payload.sessionId !== "string"
+  ) {
+    throw new Error("Resume route returned an invalid payload");
+  }
+
+  return {
+    agentId: payload.agentId,
+    stepName: payload.stepName,
+    taskId: payload.taskId,
+    sessionId: payload.sessionId,
+  };
+}
+
+export function formatResumeActiveWorkerStepSuccessMessage(
+  result: ResumeActiveWorkerStepResult,
+): string {
+  return `Resumed ${AGENT_LABELS[result.agentId]} for ${result.stepName}.`;
+}

--- a/web/app/routes/api.missions.$missionId.resume-active-step/route.test.ts
+++ b/web/app/routes/api.missions.$missionId.resume-active-step/route.test.ts
@@ -1,0 +1,163 @@
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getProjectRoot } from "@/lib/get-project-root.server";
+import { createMission, deleteMission } from "@/lib/mission-store";
+import { buildBuiltinOperationRef } from "@/lib/operation-definition/operation-catalog";
+import { createOperationState } from "@/lib/operation-runtime/state";
+import {
+  REVIEW_CYCLE_TEST_OPERATION_NAME,
+  writeReviewCycleTestOperation,
+} from "@/lib/test-fixtures/operation-fixtures";
+
+vi.mock("@/lib/task-dispatch.server", () => ({
+  dispatchCurrentOperationStepToWorker: vi.fn(),
+}));
+
+import { dispatchCurrentOperationStepToWorker } from "@/lib/task-dispatch.server";
+import { action } from "./route";
+
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+const repoRoot = getProjectRoot();
+const opencodeTemplatePath = join(repoRoot, "config", "opencode.template.json");
+
+function createTempRootWithBuiltins(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-resume-route-"));
+  tempRoots.push(root);
+  cpSync(join(repoRoot, "scripts"), join(root, "scripts"), { recursive: true });
+  cpSync(join(repoRoot, "config"), join(root, "config"), { recursive: true });
+  cpSync(join(repoRoot, "builtins"), join(root, "builtins"), { recursive: true });
+  cpSync(opencodeTemplatePath, join(root, "opencode.json"));
+  writeReviewCycleTestOperation(root);
+  return root;
+}
+
+function seedMission(input: {
+  missionId: string;
+  currentStep: string;
+  agent: "noctis" | "ignis" | "gladiolus" | "prompto";
+  taskId: string;
+}) {
+  const mission = createMission(input.missionId, `session-${input.missionId}`, {
+    title: input.missionId,
+    objective: "Test mission",
+    allowedWorkers: ["ignis", "gladiolus", "prompto"],
+  });
+  missionIds.push(input.missionId);
+
+  const state = createOperationState(
+    REVIEW_CYCLE_TEST_OPERATION_NAME,
+    input.currentStep,
+    buildBuiltinOperationRef("ja", `${REVIEW_CYCLE_TEST_OPERATION_NAME}.yaml`),
+  );
+  state.currentStep = input.currentStep;
+  state.status = "waiting_for_report";
+  state.stepHistory = [
+    {
+      step: input.currentStep,
+      agent: input.agent,
+      taskId: input.taskId,
+      status: "dispatched",
+      dispatchedAt: "2026-05-01T00:00:00.000Z",
+    },
+  ];
+  mission.operationState = state;
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("api.missions.$missionId.resume-active-step", () => {
+  it("resumes the active worker step for the matching worker card", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRootWithBuiltins();
+    const missionId = `mission-resume-${crypto.randomUUID()}`;
+    seedMission({
+      missionId,
+      currentStep: "implement",
+      agent: "gladiolus",
+      taskId: "task-implement",
+    });
+    vi.mocked(dispatchCurrentOperationStepToWorker).mockResolvedValue({
+      agentId: "gladiolus",
+      stepName: "implement",
+      taskId: "task-implement",
+      sessionId: "worker-session",
+    });
+
+    const response = await action({
+      request: new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: "gladiolus" }),
+      }),
+      params: { missionId },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({
+      agentId: "gladiolus",
+      stepName: "implement",
+      taskId: "task-implement",
+      sessionId: "worker-session",
+    });
+    expect(dispatchCurrentOperationStepToWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        missionId,
+        fromAgent: "noctis",
+        orchestratedBy: "noctis",
+      }),
+    );
+  });
+
+  it("rejects the request when the selected worker no longer owns the active step", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRootWithBuiltins();
+    const missionId = `mission-stale-${crypto.randomUUID()}`;
+    seedMission({
+      missionId,
+      currentStep: "implement",
+      agent: "gladiolus",
+      taskId: "task-implement",
+    });
+
+    const response = await action({
+      request: new Request("http://localhost/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: "ignis" }),
+      }),
+      params: { missionId },
+    } as never);
+
+    expect(response.status).toBe(409);
+    await expect(readJson(response)).resolves.toMatchObject({
+      error: "Active step changed",
+      activeAgentId: "gladiolus",
+      requestedAgentId: "ignis",
+      stepName: "implement",
+    });
+    expect(dispatchCurrentOperationStepToWorker).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/routes/api.missions.$missionId.resume-active-step/route.test.ts
+++ b/web/app/routes/api.missions.$missionId.resume-active-step/route.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/web/app/routes/api.missions.$missionId.resume-active-step/route.ts
+++ b/web/app/routes/api.missions.$missionId.resume-active-step/route.ts
@@ -1,0 +1,88 @@
+import { getMission } from "@/lib/mission-store";
+import { loadOperationByRef } from "@/lib/operation-definition/operation-catalog";
+import {
+  getActiveStepRecord,
+  getOperationRef,
+  getOperationState,
+} from "@/lib/operation-runtime/state";
+import { dispatchCurrentOperationStepToWorker } from "@/lib/task-dispatch.server";
+import type { WorkerAgentId } from "@/lib/types/mission";
+import type { Route } from "./+types/route";
+
+const WORKER_AGENT_IDS: ReadonlySet<string> = new Set<WorkerAgentId>([
+  "ignis",
+  "gladiolus",
+  "prompto",
+]);
+
+function isWorkerAgentId(value: unknown): value is WorkerAgentId {
+  return typeof value === "string" && WORKER_AGENT_IDS.has(value);
+}
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const missionId = params.missionId;
+  if (!missionId) {
+    return Response.json({ error: "Missing missionId" }, { status: 400 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    agentId?: unknown;
+  } | null;
+
+  if (!body || !isWorkerAgentId(body.agentId)) {
+    return Response.json({ error: "Invalid agentId" }, { status: 400 });
+  }
+
+  if (!getMission(missionId)) {
+    return Response.json({ error: "Mission not found" }, { status: 404 });
+  }
+
+  const operationState = getOperationState(missionId);
+  if (!operationState) {
+    return Response.json({ error: "No active worker step" }, { status: 409 });
+  }
+
+  const operation = loadOperationByRef(getOperationRef(operationState));
+  const currentStep = operation.steps.find((step) => step.name === operationState.currentStep) ?? null;
+  const activeRecord = getActiveStepRecord(operationState) ?? null;
+
+  if (
+    !currentStep ||
+    !isWorkerAgentId(currentStep.agent) ||
+    !activeRecord ||
+    activeRecord.agent !== currentStep.agent ||
+    activeRecord.step !== currentStep.name ||
+    !activeRecord.taskId
+  ) {
+    return Response.json({ error: "No active worker step" }, { status: 409 });
+  }
+
+  if (body.agentId !== currentStep.agent) {
+    return Response.json(
+      {
+        error: "Active step changed",
+        activeAgentId: currentStep.agent,
+        requestedAgentId: body.agentId,
+        stepName: currentStep.name,
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const result = await dispatchCurrentOperationStepToWorker({
+      missionId,
+      fromAgent: "noctis",
+      orchestratedBy: "noctis",
+    });
+    return Response.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to resume active worker step";
+    const status = message === "Mission not found" ? 404 : 503;
+    return Response.json({ error: message }, { status });
+  }
+};

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "web",
       "dependencies": {
         "@opencode-ai/sdk": "^1.2.27",
+        "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-hover-card": "^1.1.15",
@@ -1521,6 +1522,34 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.2.27",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.2.27
         version: 1.2.27
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.16
+        version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -53,6 +56,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@react-router/express':
+        specifier: 7.13.1
+        version: 7.13.1(express@4.22.1)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@react-router/fs-routes':
         specifier: ^7.13.1
         version: 7.13.1(@react-router/dev@7.13.1(@react-router/serve@7.13.1(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
@@ -71,6 +77,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      express:
+        specifier: ^4.22.1
+        version: 4.22.1
       isbot:
         specifier: ^5.1.36
         version: 5.1.36
@@ -647,6 +656,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -3193,6 +3215,20 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## 📝 Summary

- Add a "Resume Active Step" action to the Noctis team view for the worker that owns the current mission step
- Show the mission working branch and execution project HEAD together so branch drift is visible before resuming work
- Add the shared context-menu primitive and supporting tests for the new mission controls
- Diff scope: 13 files changed, 1107 insertions, 42 deletions

## 🎯 Motivation

The Noctis mission view already exposed mission state, but it did not provide a direct way to re-dispatch the currently active worker step from the party panel. It also hid useful branch context when the persisted mission branch and the execution project branch diverged.

This change adds a focused resume action for the active worker step and surfaces the working-branch versus execution-project HEAD information so mission operators can make safer resume decisions with less guesswork.

## 🔧 Changes Overview

- Added a new mission resume endpoint that validates the selected worker still owns the active step before dispatching it back to the worker session.
- Added client-side helpers and party-panel UI for resuming the active worker step, including success/error handling around the new API.
- Updated the Noctis mission screen to display both the mission working branch and the execution project HEAD when they differ.
- Introduced the shared Radix context-menu primitive and added the new `@radix-ui/react-context-menu` dependency.
- Expanded component and route coverage for the new resume flow and branch metadata rendering.

## ✅ Testing

- `bash .opencode/skills/pr-assistant/scripts/quality_checks.sh main`
- `./node_modules/.bin/vitest run app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx app/routes/_layout.noctis-team/components/party-status-panel.test.tsx app/routes/_layout.noctis-team/components/resume-active-worker-step.test.ts`
- `./node_modules/.bin/vitest run app/routes/api\.missions\.\$missionId\.resume-active-step/route\.test\.ts`
- `npm run web:typecheck`

## 📸 Screenshots

Not included. The UI change is limited to an inline mission metadata display and a new contextual action in the party panel.

## 🔗 Related Issues

None

## 📋 Checklist

- [x] Self-reviewed the code
- [x] Breaking changes documented (if any)
- [x] Automated tests added or updated as appropriate
- [x] UI changes reviewed; screenshots added if useful
- [x] Config, CI, or deployment impact reviewed

## 📌 Notes

- Quality checks reported one warning because `web/package.json` and `web/pnpm-lock.yaml` changed for the new context-menu dependency.
