### PR TITLE
Add mission session controls and UI state improvements for Noctis team

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -9,86 +9,35 @@ model_definitions:
   github-copilot/gemini-3-flash-preview: "Gemini 3 Flash"
   github-copilot/gemini-3.1-pro-preview: "Gemini 3.1 Pro Preview"
   github-copilot/gpt-5-mini: "GPT-5-mini"
-  opencode/minimax-m2.5-free: "MiniMax M2.5 Free"
-  opencode/trinity-large-preview-free: "Trinity Large Preview"
 
 # Model configuration by mode
 # Each agent has: model (OpenCode model ID), variant (optional named variant), agent (optional, for future use)
 # Comrades: ignis, gladiolus, prompto / Independent: lunafreya / Guardian: iris
 # _description: Mode description shown in help text and startup banner
 modes:
-  normal:
-    _description: Standard configuration
+  gpt5mini-low:
+    _description: All agents use GPT-5 Mini Low
     noctis:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
+      model: github-copilot/gpt-5-mini
+      variant: low
     ignis:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
+      model: github-copilot/gpt-5-mini
+      variant: low
     gladiolus:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
+      model: github-copilot/gpt-5-mini
+      variant: low
     prompto:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
+      model: github-copilot/gpt-5-mini
+      variant: low
     lunafreya:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
+      model: github-copilot/gpt-5-mini
+      variant: low
     iris:
       model: github-copilot/gpt-5-mini
-      variant: high
+      variant: low
 
-  fullpower:
-    _description: High-performance configuration
-    noctis:
-      model: github-copilot/claude-opus-4.6
-    ignis:
-      model: github-copilot/claude-opus-4.6
-    gladiolus:
-      model: github-copilot/claude-opus-4.6
-    prompto:
-      model: github-copilot/claude-opus-4.6
-    lunafreya:
-      model: github-copilot/gpt-5.4
-      variant: xhigh
-    iris:
-      model: github-copilot/gpt-5-mini
-      variant: high
-
-  lite:
-    _description: Low-cost configuration
-    noctis:
-      model: github-copilot/claude-haiku-4.5
-    ignis:
-      model: github-copilot/claude-haiku-4.5
-    gladiolus:
-      model: github-copilot/gemini-3-flash-preview
-    prompto:
-      model: github-copilot/gemini-3-flash-preview
-    lunafreya:
-      model: github-copilot/claude-haiku-4.5
-    iris:
-      model: github-copilot/gpt-5-mini
-      variant: high
-
-  free:
-    _description: Free (minimax-m2.5-free)
-    noctis:
-      model: opencode/minimax-m2.5-free
-    ignis:
-      model: opencode/minimax-m2.5-free
-    gladiolus:
-      model: opencode/minimax-m2.5-free
-    prompto:
-      model: opencode/minimax-m2.5-free
-    lunafreya:
-      model: opencode/minimax-m2.5-free
-    iris:
-      model: github-copilot/gpt-5-mini
-      variant: high
-
-  gpt5mini:
-    _description: All agents use GPT-5 Mini
+  gpt5mini-high:
+    _description: All agents use GPT-5 Mini High
     noctis:
       model: github-copilot/gpt-5-mini
       variant: high
@@ -108,8 +57,29 @@ modes:
       model: github-copilot/gpt-5-mini
       variant: high
 
-  gpt5.4:
-    _description: All agents use GPT-5.4 except Iris
+  gpt5.4-medium:
+    _description: All agents use GPT-5.4 Medium
+    noctis:
+      model: github-copilot/gpt-5.4
+      variant: medium
+    ignis:
+      model: github-copilot/gpt-5.4
+      variant: medium
+    gladiolus:
+      model: github-copilot/gpt-5.4
+      variant: medium
+    prompto:
+      model: github-copilot/gpt-5.4
+      variant: medium
+    lunafreya:
+      model: github-copilot/gpt-5.4
+      variant: medium
+    iris:
+      model: github-copilot/gpt-5.4
+      variant: medium
+
+  gpt5.4-xhigh:
+    _description: All agents use GPT-5.4 XHigh
     noctis:
       model: github-copilot/gpt-5.4
       variant: xhigh
@@ -126,5 +96,5 @@ modes:
       model: github-copilot/gpt-5.4
       variant: xhigh
     iris:
-      model: github-copilot/gpt-5-mini
-      variant: high
+      model: github-copilot/gpt-5.4
+      variant: xhigh

--- a/config/opencode.template.json
+++ b/config/opencode.template.json
@@ -46,7 +46,7 @@
         "/bin/bash",
         "-l",
         "-c",
-        "uvx --from git+https://github.com/oraios/serena serena start-mcp-server --open-web-dashboard false --context ide-assistant"
+        "uvx --from git+https://github.com/oraios/serena serena start-mcp-server --open-web-dashboard false --context ide"
       ],
       "enabled": false
     }

--- a/scripts/tmux_transport_dispatcher.mts
+++ b/scripts/tmux_transport_dispatcher.mts
@@ -502,21 +502,8 @@ function readCatalogModelSelectionText(
 }
 
 function buildDispatchText(item: TmuxDispatchItem): string {
-  const header = [
-    `[tmux-dispatch] mission=${item.missionId}`,
-    `session=${item.payload.sessionId}`,
-    `agent=${item.payload.agent}`,
-  ].join(" ");
-
-  return [
-    header,
-    item.payload.model
-      ? `model=${item.payload.model.providerID}/${item.payload.model.modelID}`
-      : null,
-    item.payload.variant ? `variant=${item.payload.variant}` : null,
-    item.payload.system ?? null,
-    ...item.payload.parts.map((part) => part.text),
-  ]
+  return item.payload.parts
+    .map((part) => part.text)
     .filter((part): part is string => typeof part === "string" && part.length > 0)
     .join("\n\n");
 }

--- a/web/app/app.css
+++ b/web/app/app.css
@@ -320,6 +320,14 @@
       opacity: 1;
     }
   }
+  @keyframes step-owner-orbit-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 }
 
 /*
@@ -373,6 +381,55 @@
 }
 
 @layer components {
+  .step-owner-shell {
+    position: absolute;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 0;
+  }
+
+  .step-owner-shell::after {
+    content: "";
+    position: absolute;
+    width: 200%;
+    height: 200%;
+    top: -50%;
+    left: -50%;
+    animation: step-owner-orbit-spin 3.2s linear infinite;
+    background: conic-gradient(
+      from 78deg at 50% 50%,
+      transparent 0deg,
+      transparent 316deg,
+      color-mix(in srgb, var(--step-owner-orbit-color, rgba(224, 224, 255, 0.78)) 8%, transparent) 324deg,
+      color-mix(in srgb, var(--step-owner-orbit-color, rgba(224, 224, 255, 0.78)) 44%, transparent) 334deg,
+      color-mix(in srgb, var(--step-owner-orbit-color, rgba(224, 224, 255, 0.78)) 100%, transparent) 342deg,
+      color-mix(in srgb, var(--step-owner-orbit-color, rgba(224, 224, 255, 0.78)) 46%, transparent) 350deg,
+      color-mix(in srgb, var(--step-owner-orbit-color, rgba(224, 224, 255, 0.78)) 10%, transparent) 358deg,
+      transparent 360deg
+    );
+  }
+
+  .step-owner-layer-aura {
+    inset: -10px;
+    border-radius: 22px;
+    filter: blur(18px);
+    opacity: 0.42;
+  }
+
+  .step-owner-layer-vivid {
+    inset: -4px;
+    border-radius: 15px;
+    filter: blur(2.1px) brightness(1.28);
+    opacity: 0.8;
+  }
+
+  .step-owner-layer-main {
+    inset: -2px;
+    border-radius: 14px;
+    filter: blur(0.45px) brightness(1.12);
+    opacity: 0.92;
+  }
+
   .route-loading-progress::before {
     content: "";
     display: block;

--- a/web/app/hooks/use-agent-session.test.ts
+++ b/web/app/hooks/use-agent-session.test.ts
@@ -27,6 +27,11 @@ type HookProbeSnapshot = {
   isStreaming: boolean;
   abortSettlementPhase: string;
   messages: string[];
+  retainedHistory: {
+    isActive: boolean;
+    trimmedConversationUnitCount: number;
+    trimmedMessageCount: number;
+  };
   streamingContent: string;
   abort: () => Promise<void>;
   send: ReturnType<typeof useAgentSession>["send"];
@@ -136,6 +141,23 @@ function createAssistantMessage(id: string, text: string): MessageInfo {
   };
 }
 
+function createAssistantMessages(count: number, prefix = "Reply"): MessageInfo[] {
+  return Array.from({ length: count }, (_, index) =>
+    createAssistantMessage(`message-${index + 1}`, `${prefix} ${index + 1}`),
+  );
+}
+
+function createAssistantToolMessage(id: string): MessageInfo {
+  return {
+    info: {
+      id,
+      role: "assistant",
+      time: { created: Date.parse("2026-04-19T00:00:00.000Z") },
+    },
+    parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
+  };
+}
+
 function createAbortedAssistantMessage(id: string): MessageInfo {
   return {
     info: {
@@ -227,6 +249,7 @@ function HookProbe({
       isStreaming: state.isStreaming,
       abortSettlementPhase: state.abortSettlementPhase,
       messages: state.messages.map((message) => message.content),
+      retainedHistory: state.retainedHistory,
       streamingContent: state.streamingContent,
       abort: state.abort,
       send: state.send,
@@ -242,6 +265,7 @@ function HookProbe({
     state.isStreaming,
     state.liveDraft,
     state.messages,
+    state.retainedHistory,
     state.streamingContent,
     state.send,
   ]);
@@ -439,6 +463,230 @@ describe("useAgentSession", () => {
       isLoadingHistory: false,
       messages: ["Mission two reply"],
       streamingContent: "",
+    });
+  });
+
+  it("retains only the most recent mission transcript window when preloaded history exceeds the cap", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const preloadedMessages = createAssistantMessages(170);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: preloadedMessages,
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+    const readySnapshot = requireSnapshot(latestSnapshot, "Expected preloaded retention snapshot.");
+
+    expect(readySnapshot.messages).toHaveLength(120);
+    expect(readySnapshot.messages[0]).toBe("Reply 51");
+    expect(readySnapshot.messages.at(-1)).toBe("Reply 170");
+    expect(readySnapshot.retainedHistory).toEqual({
+      isActive: true,
+      trimmedConversationUnitCount: 50,
+      trimmedMessageCount: 50,
+    });
+  });
+
+  it("retains only the most recent mission transcript window after authoritative history sync", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const persistedMessages = createAssistantMessages(170);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      if (url === "/api/session/session-1") {
+        return createJsonResponse({ messages: persistedMessages });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+    const readySnapshot = requireSnapshot(latestSnapshot, "Expected synced retention snapshot.");
+
+    expect(readySnapshot.messages).toHaveLength(120);
+    expect(readySnapshot.messages[0]).toBe("Reply 51");
+    expect(readySnapshot.messages.at(-1)).toBe("Reply 170");
+    expect(readySnapshot.retainedHistory).toEqual({
+      isActive: true,
+      trimmedConversationUnitCount: 50,
+      trimmedMessageCount: 50,
+    });
+  });
+
+  it("retains complete conversation units when grouped assistant activity crosses the cap", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const preloadedMessages = [
+      ...createAssistantMessages(160),
+      createAssistantToolMessage("message-161"),
+      createAssistantMessage("message-162", "Grouped reply"),
+    ];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: preloadedMessages,
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+    const readySnapshot = requireSnapshot(
+      latestSnapshot,
+      "Expected grouped retention snapshot.",
+    );
+
+    expect(readySnapshot.messages).toHaveLength(121);
+    expect(readySnapshot.messages[0]).toBe("Reply 42");
+    expect(readySnapshot.messages.slice(-2)).toEqual(["", "Grouped reply"]);
+    expect(readySnapshot.retainedHistory).toEqual({
+      isActive: true,
+      trimmedConversationUnitCount: 41,
+      trimmedMessageCount: 41,
+    });
+  });
+
+  it("clears retained-history mode when transcript ownership changes to a new mission", async () => {
+    const missionOne = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const missionTwo = createMission({ missionId: "mission-2", primarySessionId: "session-2" });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(missionOne));
+      }
+
+      if (url === "/api/noctis/missions/mission-2/runtime") {
+        return createJsonResponse(createRuntimePayload(missionTwo));
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: createAssistantMessages(170),
+          initialMissionData: missionOne,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+    const firstMissionSnapshot = requireSnapshot(
+      latestSnapshot,
+      "Expected first mission retention snapshot.",
+    );
+
+    expect(firstMissionSnapshot.retainedHistory.isActive).toBe(true);
+
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-2",
+          initialMessageInfos: [createAssistantMessage("message-201", "Mission two reply")],
+          initialMissionData: missionTwo,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+    const secondMissionSnapshot = requireSnapshot(
+      latestSnapshot,
+      "Expected second mission retention snapshot.",
+    );
+
+    expect(secondMissionSnapshot.messages).toEqual(["Mission two reply"]);
+    expect(secondMissionSnapshot.retainedHistory).toEqual({
+      isActive: false,
+      trimmedConversationUnitCount: 0,
+      trimmedMessageCount: 0,
     });
   });
 
@@ -2312,6 +2560,66 @@ describe("useAgentSession", () => {
     expect(fetchMock.mock.calls.some(([input]) => String(input) === "/api/noctis/mission/continue")).toBe(
       true,
     );
+  });
+
+  it("retains only the most recent mission transcript window after optimistic user and error appends exceed the cap", async () => {
+    const mission = createMission({ missionId: "mission-1", primarySessionId: "session-1" });
+    const preloadedMessages = createAssistantMessages(159);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/noctis/operations")) {
+        return createJsonResponse({ operations: [] });
+      }
+
+      if (url === "/api/noctis/missions/mission-1/runtime") {
+        return createJsonResponse(createRuntimePayload(mission));
+      }
+
+      if (url === "/api/noctis/mission/continue") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { missionId?: string };
+        expect(body.missionId).toBe("mission-1");
+        return createJsonResponse({ error: "Continue failed." }, { ok: false, status: 500 });
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latestSnapshot: HookProbeSnapshot | null = null;
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(HookProbe, {
+          activeMissionId: "mission-1",
+          initialMessageInfos: preloadedMessages,
+          initialMissionData: mission,
+          onSnapshot: (snapshot: HookProbeSnapshot) => {
+            latestSnapshot = snapshot;
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => latestSnapshot?.historyPhase === "ready");
+
+    await act(async () => {
+      await latestSnapshot?.send([{ type: "text", text: "Retry request" }]);
+    });
+
+    await flushEffects();
+    const postSendSnapshot = requireSnapshot(latestSnapshot, "Expected post-send retention snapshot.");
+
+    expect(postSendSnapshot.messages).toHaveLength(120);
+    expect(postSendSnapshot.messages[0]).toBe("Reply 42");
+    expect(postSendSnapshot.messages).toContain("Retry request");
+    expect(postSendSnapshot.messages.at(-1)).toBe("Something went wrong. Continue failed.");
+    expect(postSendSnapshot.retainedHistory).toEqual({
+      isActive: true,
+      trimmedConversationUnitCount: 41,
+      trimmedMessageCount: 41,
+    });
   });
 
   it("backs off idle runtime polling after the primary stream is healthy", async () => {

--- a/web/app/hooks/use-agent-session.ts
+++ b/web/app/hooks/use-agent-session.ts
@@ -19,7 +19,11 @@ import {
   isSessionStatusActive,
   type SessionStatus,
 } from "@/lib/session-status";
-import { normalizeSessionMessages } from "@/lib/session-message-presentation";
+import {
+  buildRenderedSessionMessages,
+  normalizeSessionMessages,
+  type SessionPresentationMessage,
+} from "@/lib/session-message-presentation";
 import {
   mergeSessionLiveDraft,
   mergeStreamingText,
@@ -64,6 +68,8 @@ const MISSION_RUNTIME_ACTIVE_POLL_MS = 3000;
 const MISSION_RUNTIME_IDLE_POLL_MS = 15000;
 const MISSION_RUNTIME_HIDDEN_POLL_MS = 30000;
 const MISSION_SETTLED_BANTER_COOLDOWN_MS = 30000;
+const MISSION_TRANSCRIPT_RETENTION_SOFT_LIMIT = 160;
+const MISSION_TRANSCRIPT_RETENTION_TARGET = 120;
 
 const INITIAL_BANTER_REVEAL_DELAY_MS = 90;
 const SPEAKING_INDICATOR_MS = 980;
@@ -468,6 +474,18 @@ function normalizeDelegationLedger(
 export type MissionTranscriptPhase = "idle" | "loading" | "pending" | "ready" | "empty" | "error";
 export type AbortSettlementPhase = "idle" | "settling" | "delayed";
 
+export type MissionTranscriptRetentionState = {
+  isActive: boolean;
+  trimmedConversationUnitCount: number;
+  trimmedMessageCount: number;
+};
+
+const EMPTY_MISSION_TRANSCRIPT_RETENTION_STATE: MissionTranscriptRetentionState = {
+  isActive: false,
+  trimmedConversationUnitCount: 0,
+  trimmedMessageCount: 0,
+};
+
 type MissionTranscriptState = {
   errorMessage: string | null;
   missionId: string | null;
@@ -675,6 +693,72 @@ function mergeRuntimeSessionMessages(
   return optimisticTail.length > 0 ? [...merged, ...optimisticTail] : merged;
 }
 
+function toMissionTranscriptPresentationMessage(message: ChatMessage): SessionPresentationMessage {
+  return {
+    id: message.id,
+    role: message.sender === "user" ? "user" : "assistant",
+    sender: message.sender,
+    senderLabel: getActivityActorLabel(message.sender),
+    kind: message.kind,
+    content: message.content,
+    detailContent: message.detailContent,
+    detailState: message.detailState,
+    rawText: message.rawText,
+    parts: message.parts,
+    timestamp: message.timestamp,
+    source: message.source,
+  };
+}
+
+function applyMissionTranscriptRetention(
+  messages: ChatMessage[],
+  primaryAgentId: MissionPrimaryAgentId,
+): {
+  messages: ChatMessage[];
+  retainedHistory: MissionTranscriptRetentionState;
+} {
+  if (messages.length === 0) {
+    return {
+      messages,
+      retainedHistory: EMPTY_MISSION_TRANSCRIPT_RETENTION_STATE,
+    };
+  }
+
+  const renderedMessages = buildRenderedSessionMessages(
+    messages.map(toMissionTranscriptPresentationMessage),
+    {
+      continuityAssistant: {
+        sender: primaryAgentId,
+        senderLabel: getActivityActorLabel(primaryAgentId),
+      },
+    },
+  );
+
+  if (renderedMessages.length <= MISSION_TRANSCRIPT_RETENTION_SOFT_LIMIT) {
+    return {
+      messages,
+      retainedHistory: EMPTY_MISSION_TRANSCRIPT_RETENTION_STATE,
+    };
+  }
+
+  const retainedRenderedMessages = renderedMessages.slice(-MISSION_TRANSCRIPT_RETENTION_TARGET);
+
+  const retainedSourceMessageIds = new Set(
+    retainedRenderedMessages.flatMap((message) => message.sourceMessageIds),
+  );
+
+  const retainedMessages = messages.filter((message) => retainedSourceMessageIds.has(message.id));
+
+  return {
+    messages: retainedMessages,
+    retainedHistory: {
+      isActive: true,
+      trimmedConversationUnitCount: renderedMessages.length - retainedRenderedMessages.length,
+      trimmedMessageCount: messages.length - retainedMessages.length,
+    },
+  };
+}
+
 function toSessionChatMessages(
   messages: MessageInfo[],
   primaryAgentId: MissionPrimaryAgentId,
@@ -729,6 +813,27 @@ async function loadSessionMessages(
   return convertedMessages;
 }
 
+function getInitialTranscriptRetentionState(
+  activeMissionId: string | null,
+  initialMissionData: MissionResumePayload | null | undefined,
+  initialMessageInfos: MessageInfo[] | null | undefined,
+  primaryAgentId: MissionPrimaryAgentId,
+): MissionTranscriptRetentionState {
+  if (
+    activeMissionId &&
+    initialMissionData?.missionId === activeMissionId &&
+    Array.isArray(initialMessageInfos) &&
+    initialMessageInfos.length > 0
+  ) {
+    return applyMissionTranscriptRetention(
+      toSessionChatMessages(initialMessageInfos, primaryAgentId),
+      primaryAgentId,
+    ).retainedHistory;
+  }
+
+  return EMPTY_MISSION_TRANSCRIPT_RETENTION_STATE;
+}
+
 function getInitialTranscriptMessages(
   activeMissionId: string | null,
   initialMissionData: MissionResumePayload | null | undefined,
@@ -742,7 +847,10 @@ function getInitialTranscriptMessages(
     Array.isArray(initialMessageInfos) &&
     initialMessageInfos.length > 0
   ) {
-    const preloadedMessages = toSessionChatMessages(initialMessageInfos, primaryAgentId);
+    const preloadedMessages = applyMissionTranscriptRetention(
+      toSessionChatMessages(initialMessageInfos, primaryAgentId),
+      primaryAgentId,
+    ).messages;
     return preloadedMessages.length > 0 ? preloadedMessages : [];
   }
 
@@ -836,6 +944,7 @@ export interface UseAgentSessionOptions {
 export interface UseAgentSessionReturn {
   sessionId: string | null;
   messages: ChatMessage[];
+  retainedHistory: MissionTranscriptRetentionState;
   liveDraft: SessionLiveDraft | null;
   streamingMessageId: string | null;
   streamingContent: string;
@@ -923,6 +1032,14 @@ export function useAgentSession({
       primaryAgentId,
     )
   );
+  const [retainedHistory, setRetainedHistory] = useState<MissionTranscriptRetentionState>(() =>
+    getInitialTranscriptRetentionState(
+      activeMissionId,
+      initialMissionData,
+      initialMessageInfos,
+      primaryAgentId,
+    )
+  );
   const [availableOperations, setAvailableOperations] = useState<OperationOption[]>([]);
   const [selectedOperation, setSelectedOperation] = useState<string | null>(null);
   const [activeOperationState, setActiveOperationState] = useState<OperationState | null>(null);
@@ -969,6 +1086,8 @@ export function useAgentSession({
 
   const missionIdRef = useRef<string | null>(null);
   const activeMissionIdRef = useRef<string | null>(activeMissionId);
+  const sessionMessagesRef = useRef<ChatMessage[]>(sessionMessages);
+  const retainedHistoryRef = useRef<MissionTranscriptRetentionState>(retainedHistory);
   const noctisSessionIdRef = useRef<string | null>(null);
   const streamingMessageIdRef = useRef<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -1035,6 +1154,45 @@ export function useAgentSession({
     setAbortSettlementPhase("idle");
   }, []);
 
+  const replaceSessionMessages = useCallback(
+    (nextMessages: ChatMessage[]): ChatMessage[] => {
+      const retained = applyMissionTranscriptRetention(nextMessages, primaryAgentId);
+      sessionMessagesRef.current = retained.messages;
+      retainedHistoryRef.current = retained.retainedHistory;
+      setSessionMessages(retained.messages);
+      setRetainedHistory(retained.retainedHistory);
+      return retained.messages;
+    },
+    [primaryAgentId],
+  );
+
+  const updateSessionMessages = useCallback(
+    (updater: (current: ChatMessage[]) => ChatMessage[]): ChatMessage[] => {
+      const nextMessages = updater(sessionMessagesRef.current);
+      const retained = applyMissionTranscriptRetention(nextMessages, primaryAgentId);
+      const nextRetainedHistory = retained.retainedHistory.isActive
+        ? {
+            isActive: true,
+            trimmedConversationUnitCount:
+              retainedHistoryRef.current.trimmedConversationUnitCount +
+              retained.retainedHistory.trimmedConversationUnitCount,
+            trimmedMessageCount:
+              retainedHistoryRef.current.trimmedMessageCount +
+              retained.retainedHistory.trimmedMessageCount,
+          }
+        : retainedHistoryRef.current.isActive
+          ? retainedHistoryRef.current
+          : retained.retainedHistory;
+
+      sessionMessagesRef.current = retained.messages;
+      retainedHistoryRef.current = nextRetainedHistory;
+      setSessionMessages(retained.messages);
+      setRetainedHistory(nextRetainedHistory);
+      return retained.messages;
+    },
+    [primaryAgentId],
+  );
+
   const beginAbortSettlement = useCallback(() => {
     if (abortSettlementTimerRef.current) {
       clearTimeout(abortSettlementTimerRef.current);
@@ -1063,6 +1221,14 @@ export function useAgentSession({
   useEffect(() => {
     transcriptStateRef.current = transcriptState;
   }, [transcriptState]);
+
+  useEffect(() => {
+    sessionMessagesRef.current = sessionMessages;
+  }, [sessionMessages]);
+
+  useEffect(() => {
+    retainedHistoryRef.current = retainedHistory;
+  }, [retainedHistory]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1331,7 +1497,7 @@ export function useAgentSession({
     setWorkerSessionIds(initialWorkerSessionIds);
     setDelegationLedger(null);
     clearStreamingState();
-    setSessionMessages(
+    replaceSessionMessages(
       getInitialTranscriptMessages(
         activeMissionId,
         initialMissionData,
@@ -1376,6 +1542,7 @@ export function useAgentSession({
     primaryAgentId,
     clearAbortSettlement,
     clearStreamingState,
+    replaceSessionMessages,
   ]);
 
   const scheduleIdleReset = useCallback(() => {
@@ -1419,28 +1586,30 @@ export function useAgentSession({
         const effectiveSessionStatus =
           useChatStore.getState().sessionStates[sessionId] ?? sessionStatusRef.current;
 
-        setSessionMessages((current) => {
-          if (nextMessages.length === 0) {
-            return options?.preserveStreaming || options?.trackStreamingMessage
-              ? current
-              : (transcriptMissionId ? [] : initialMessages);
-          }
+        const shouldPreserveCurrentMessages =
+          shouldKeepPendingTrackedReply ||
+          (nextMessages.length === 0 && (options?.preserveStreaming || options?.trackStreamingMessage));
 
-          if (shouldKeepPendingTrackedReply) {
-            return current;
-          }
-
-          return options?.preserveStreaming
-            ? mergeRuntimeSessionMessages(current, nextMessages, primaryAgentId)
-            : nextMessages;
-        });
+        const retainedMessages = shouldPreserveCurrentMessages
+          ? sessionMessagesRef.current
+          : replaceSessionMessages(
+              nextMessages.length === 0
+                ? (transcriptMissionId ? [] : initialMessages)
+                : options?.preserveStreaming
+                  ? mergeRuntimeSessionMessages(
+                      sessionMessagesRef.current,
+                      nextMessages,
+                      primaryAgentId,
+                    )
+                  : nextMessages,
+            );
 
         setTranscriptState(
           shouldKeepPendingTrackedReply
             ? createMissionTranscriptState(transcriptMissionId, "pending", null, sessionId)
             : createMissionTranscriptState(
                 transcriptMissionId,
-                resolveMissionTranscriptPhase(nextMessages),
+                resolveMissionTranscriptPhase(retainedMessages),
               )
         );
 
@@ -1493,7 +1662,7 @@ export function useAgentSession({
         throw error;
       }
     },
-    [clearStreamingState, initialMessages, missionRouteBase, primaryAgentId]
+    [clearStreamingState, initialMessages, missionRouteBase, primaryAgentId, replaceSessionMessages]
   );
 
   const requestSessionHistorySync = useCallback(
@@ -1981,7 +2150,7 @@ export function useAgentSession({
         clearStreamingState();
         if (nextPrimarySessionId) {
           if (shouldClearVisibleTranscriptOnSessionSwitch) {
-            setSessionMessages([]);
+            replaceSessionMessages([]);
           }
           setTranscriptState(createMissionTranscriptState(transcriptMissionId, "loading"));
           subscribeToSession(nextPrimarySessionId);
@@ -2001,7 +2170,7 @@ export function useAgentSession({
           eventSourceRef.current?.close();
           eventSourceRef.current = null;
           setIsPrimaryStreamConnected(false);
-          setSessionMessages([]);
+          replaceSessionMessages([]);
           clearStreamingState();
           setTranscriptState(createMissionTranscriptState(transcriptMissionId, "empty"));
         }
@@ -2122,6 +2291,7 @@ export function useAgentSession({
       syncSessionMessages,
       syncPersistedBanterTimeline,
       clearStreamingState,
+      replaceSessionMessages,
     ]
   );
 
@@ -2277,7 +2447,7 @@ export function useAgentSession({
         setContextUsageByAgent(createInitialContextUsageByAgent());
         clearAbortSettlement();
         clearStreamingState();
-        setSessionMessages(initialMessages);
+        replaceSessionMessages(initialMessages);
         setTranscriptState(createMissionTranscriptState(null, "idle"));
         clearBanterEntries();
         setPartyRuntime(createInitialPartyRuntimeState());
@@ -2370,11 +2540,9 @@ export function useAgentSession({
           setWorkerSessionIds(toWorkerSessionIds(initialMissionData.sessions));
           setContextUsageByAgent(createInitialContextUsageByAgent());
           if (hasPreloadedMessages) {
-            const preloadedMessages = toSessionChatMessages(
-              initialMessageInfos ?? [],
-              primaryAgentId,
+            const preloadedMessages = replaceSessionMessages(
+              toSessionChatMessages(initialMessageInfos ?? [], primaryAgentId),
             );
-            setSessionMessages(preloadedMessages);
             setTranscriptState(
               createMissionTranscriptState(
                 activeMissionId,
@@ -2438,7 +2606,7 @@ export function useAgentSession({
               signature,
             },
           });
-          setSessionMessages([]);
+          replaceSessionMessages([]);
           clearStreamingState();
           setTranscriptState(createMissionTranscriptState(activeMissionId, "empty"));
         }
@@ -2457,7 +2625,7 @@ export function useAgentSession({
         setWorkerSessionIds(createInitialWorkerSessionIds());
         setDelegationLedger(null);
         setContextUsageByAgent(createInitialContextUsageByAgent());
-        setSessionMessages([]);
+        replaceSessionMessages([]);
         clearStreamingState();
         setTranscriptState(
           createMissionTranscriptState(
@@ -2495,6 +2663,7 @@ export function useAgentSession({
     subscribeToSession,
     clearAbortSettlement,
     clearStreamingState,
+    replaceSessionMessages,
   ]);
 
   const send = useCallback(
@@ -2524,7 +2693,7 @@ export function useAgentSession({
         timestamp: new Date(),
         source: "session",
       };
-      setSessionMessages((prev) => [...prev, userMessage]);
+      updateSessionMessages((prev) => [...prev, userMessage]);
       clearStreamingState();
 
       const agentModels = useChatStore.getState().agentModels;
@@ -2680,7 +2849,7 @@ export function useAgentSession({
           timestamp: new Date(),
           source: "session",
         };
-        setSessionMessages((prev) => [...prev, errorMessage]);
+        updateSessionMessages((prev) => [...prev, errorMessage]);
         clearStreamingState();
         setIsStreaming(false);
         clearProgressBanter();
@@ -2708,6 +2877,7 @@ export function useAgentSession({
       selectedContextProjectIds,
       selectedExecutionProjectId,
       selectedExecutionTargetMode,
+      updateSessionMessages,
     ]
   );
 
@@ -2726,18 +2896,18 @@ export function useAgentSession({
         throw new Error(`abort failed: ${response.status}`);
       }
 
-          const nextMessages = await loadSessionMessages(sessionId, primaryAgentId).catch(() => null);
+      const nextMessages = await loadSessionMessages(sessionId, primaryAgentId).catch(() => null);
 
       if (nextMessages && nextMessages.length > 0) {
-        setSessionMessages(nextMessages);
+        const retainedMessages = replaceSessionMessages(nextMessages);
         setTranscriptState(
           createMissionTranscriptState(
             activeMissionIdRef.current,
-            resolveMissionTranscriptPhase(nextMessages),
+            resolveMissionTranscriptPhase(retainedMessages),
           )
         );
       } else {
-        setSessionMessages([]);
+        replaceSessionMessages([]);
         setTranscriptState(createMissionTranscriptState(activeMissionIdRef.current, "empty"));
       }
 
@@ -2765,13 +2935,21 @@ export function useAgentSession({
         timestamp: new Date(),
         source: "session",
       };
-      setSessionMessages((prev) => [...prev, errorMessage]);
+      updateSessionMessages((prev) => [...prev, errorMessage]);
     }
-  }, [beginAbortSettlement, clearProgressBanter, clearStreamingState, primaryAgentId]);
+  }, [
+    beginAbortSettlement,
+    clearProgressBanter,
+    clearStreamingState,
+    primaryAgentId,
+    replaceSessionMessages,
+    updateSessionMessages,
+  ]);
 
   return {
     sessionId: noctisSessionId,
     messages,
+    retainedHistory,
     liveDraft,
     streamingMessageId: liveDraft?.messageId ?? streamingMessageIdRef.current,
     streamingContent,

--- a/web/app/lib/execution-workspace-sessions.test.ts
+++ b/web/app/lib/execution-workspace-sessions.test.ts
@@ -214,6 +214,24 @@ describe("execution workspace sessions", () => {
     );
   });
 
+  it("does not prepend delegation-ledger system text to the first direct worker dispatch", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    const { missionId } = createExecutionMission(root);
+    sessionCreateMock.mockResolvedValue({ data: { id: "session-ignis" } });
+    promptAsyncMock.mockResolvedValue({ data: { id: "prompt-worker" } });
+
+    await dispatchTaskToWorker({
+      missionId,
+      agentId: "ignis",
+      message: "Handle the task without bootstrap metadata.",
+    });
+
+    const promptInput = promptAsyncMock.mock.calls.at(-1)?.[0];
+    expect(promptInput).toBeTruthy();
+    expect(promptInput).not.toHaveProperty("system");
+  });
+
   it("records directed handoff banter from the actual handoff source", async () => {
     const root = createTempRoot();
     process.env.MULTI_AGENT_FF15_ROOT = root;
@@ -422,6 +440,7 @@ describe("execution workspace sessions", () => {
         }),
       }),
     ]);
+    expect(listTmuxDispatchItems(missionId)[0]?.payload).not.toHaveProperty("system");
   });
 
   it("records queued transport state for tmux worker dispatches", async () => {

--- a/web/app/lib/task-dispatch.server.ts
+++ b/web/app/lib/task-dispatch.server.ts
@@ -5,7 +5,6 @@ import { resolveMissionExecutionRoot } from "@/lib/mission-execution-workspace.s
 import {
   addTask,
   appendMissionMessage,
-  buildDelegationLedger,
   clearMissionSessions,
   getMission,
   setWorkerSession,
@@ -282,8 +281,6 @@ export async function dispatchTaskToWorker(input: {
     saveOperationState(input.missionId, operationState);
   };
 
-  const ledger = buildDelegationLedger(mission);
-
   const appendLog = (
     sessionId: string,
     deliveryStatus: "queued" | "sent" | "failed",
@@ -347,7 +344,6 @@ export async function dispatchTaskToWorker(input: {
           sessionId: existingSessionId,
           sessionTitle: tmuxWriteTarget.sessionTitle,
           parts: composed.payloadParts,
-          ...(tmuxWriteTarget.createdSession ? { system: ledger } : {}),
           ...(model ? { model } : {}),
           ...(variant ? { variant } : {}),
           activityBody: "Queued tmux worker delivery.",
@@ -441,7 +437,6 @@ export async function dispatchTaskToWorker(input: {
       sessionID: sessionId,
       parts: composed.payloadParts,
       agent: input.agentId,
-      system: ledger,
       ...(model ? { model } : {}),
       ...(variant ? { variant } : {}),
     });

--- a/web/app/lib/tmux-pane-session-switch.server.test.ts
+++ b/web/app/lib/tmux-pane-session-switch.server.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { switchTmuxPaneSession } from "./tmux-pane-session-switch.server";
+
+const originalPath = process.env.PATH ?? "";
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-pane-switch-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "bin"), { recursive: true });
+  return root;
+}
+
+function installFakeCommands(root: string): string {
+  const logPath = join(root, "commands.log");
+
+  writeFileSync(
+    join(root, "bin", "tmux"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'tmux %s\n' "$*" >> "${logPath}"
+`,
+    { encoding: "utf-8", mode: 0o755 }
+  );
+
+  writeFileSync(
+    join(root, "bin", "sleep"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'sleep %s\n' "$*" >> "${logPath}"
+`,
+    { encoding: "utf-8", mode: 0o755 }
+  );
+
+  process.env.PATH = `${join(root, "bin")}:${originalPath}`;
+  return logPath;
+}
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("switchTmuxPaneSession", () => {
+  it("waits between tmux inputs so the session switch command is fully applied", () => {
+    const root = createTempRoot();
+    const logPath = installFakeCommands(root);
+
+    switchTmuxPaneSession({
+      agentId: "ignis",
+      root,
+      sessionTitle: "mission:mission-123:ignis",
+    });
+
+    expect(readFileSync(logPath, "utf-8").trim().split("\n")).toEqual([
+      "tmux send-keys -t ff15:main.1 C-p",
+      "sleep 0.5",
+      "tmux send-keys -t ff15:main.1 -l Switch session",
+      "sleep 0.5",
+      "tmux send-keys -t ff15:main.1 Enter",
+      "sleep 0.5",
+      "tmux send-keys -t ff15:main.1 -l mission:mission-123:ignis",
+      "sleep 0.5",
+      "tmux send-keys -t ff15:main.1 Enter",
+    ]);
+  });
+});

--- a/web/app/lib/tmux-pane-session-switch.server.ts
+++ b/web/app/lib/tmux-pane-session-switch.server.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+
+import { getProjectRoot } from "@/lib/get-project-root.server";
+import type { AgentId } from "@/lib/types/mission";
+
+const TMUX_SESSION_NAME = "ff15";
+const TMUX_INTERACTION_DELAY_SECONDS = "0.5";
+
+const TMUX_AGENT_PANE_INDEX: Record<AgentId | "iris", number> = {
+  noctis: 0,
+  ignis: 1,
+  gladiolus: 2,
+  prompto: 3,
+  lunafreya: 4,
+  iris: 5,
+};
+
+function runTmux(root: string, args: string[]): void {
+  const result = spawnSync("tmux", args, {
+    cwd: root,
+    encoding: "utf-8",
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(result.stderr || `Failed to run tmux ${args.join(" ")}`);
+  }
+}
+
+function waitForTmuxInteraction(root: string): void {
+  const result = spawnSync("sleep", [TMUX_INTERACTION_DELAY_SECONDS], {
+    cwd: root,
+    encoding: "utf-8",
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      result.stderr ?? `Failed to wait ${TMUX_INTERACTION_DELAY_SECONDS}s between tmux inputs`
+    );
+  }
+}
+
+function sendTmuxKeys(
+  root: string,
+  target: string,
+  args: string[],
+  hasSentInput: { current: boolean }
+): void {
+  if (hasSentInput.current) {
+    waitForTmuxInteraction(root);
+  }
+
+  runTmux(root, ["send-keys", "-t", target, ...args]);
+  hasSentInput.current = true;
+}
+
+export function getTmuxPaneTargetForAgent(agentId: AgentId): string {
+  return `${TMUX_SESSION_NAME}:main.${TMUX_AGENT_PANE_INDEX[agentId]}`;
+}
+
+export function switchTmuxPaneSession(input: {
+  agentId: AgentId;
+  root?: string;
+  sessionTitle: string;
+}): void {
+  const root = input.root ?? getProjectRoot();
+  const target = getTmuxPaneTargetForAgent(input.agentId);
+  const hasSentInput = { current: false };
+
+  sendTmuxKeys(root, target, ["C-p"], hasSentInput);
+  sendTmuxKeys(root, target, ["-l", "Switch session"], hasSentInput);
+  sendTmuxKeys(root, target, ["Enter"], hasSentInput);
+  sendTmuxKeys(root, target, ["-l", input.sessionTitle], hasSentInput);
+  sendTmuxKeys(root, target, ["Enter"], hasSentInput);
+}

--- a/web/app/lib/tmux-transport-dispatcher.test.ts
+++ b/web/app/lib/tmux-transport-dispatcher.test.ts
@@ -108,4 +108,178 @@ describe("tmux_transport_dispatcher", () => {
       }),
     ]);
   });
+
+  it("types only the queued prompt body without transport metadata", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    spawnSyncMock.mockImplementation((file: string) => {
+      if (file === "tmux" || file === "sleep") {
+        return { status: 0, stderr: "", stdout: "" };
+      }
+
+      return { status: 1, stderr: `Unexpected command ${file}`, stdout: "" };
+    });
+
+    const dispatcherModulePath = "../../../scripts/tmux_transport_dispatcher";
+    const { submitClaimedItem } = (await import(dispatcherModulePath)) as {
+      submitClaimedItem: (root: string, item: ReturnType<typeof queueOwnedSessionTmuxDispatch>) => void;
+    };
+    const promptBody = [
+      "<operation-prompt>",
+      "<instruction>",
+      "Continue the workflow.",
+      "</instruction>",
+      "</operation-prompt>",
+    ].join("\n");
+    const item = queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: promptBody }],
+      system: '{"missionId":"mission-123"}',
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+      variant: "low",
+    });
+
+    submitClaimedItem(root, item);
+
+    const tmuxCalls = spawnSyncMock.mock.calls.filter(([file]) => file === "tmux");
+    const typedPayload = tmuxCalls.find(
+      ([, args]) =>
+        Array.isArray(args) &&
+        args[0] === "send-keys" &&
+        args[2] === "ff15:main.5" &&
+        args[3] === "-l" &&
+        args[4] === promptBody,
+    );
+
+    expect(typedPayload).toBeTruthy();
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          typeof args[4] === "string" &&
+          args[4].includes("[tmux-dispatch]"),
+      ),
+    ).toBe(false);
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          typeof args[4] === "string" &&
+          (args[4].includes("model=openai/gpt-5.4") ||
+            args[4].includes("variant=low") ||
+            args[4].includes('{"missionId":"mission-123"}')),
+      ),
+    ).toBe(false);
+  });
+
+  it("types raw continue as a literal continue payload", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    spawnSyncMock.mockImplementation((file: string) => {
+      if (file === "tmux" || file === "sleep") {
+        return { status: 0, stderr: "", stdout: "" };
+      }
+
+      return { status: 1, stderr: `Unexpected command ${file}`, stdout: "" };
+    });
+
+    const dispatcherModulePath = "../../../scripts/tmux_transport_dispatcher";
+    const { submitClaimedItem } = (await import(dispatcherModulePath)) as {
+      submitClaimedItem: (root: string, item: ReturnType<typeof queueOwnedSessionTmuxDispatch>) => void;
+    };
+    const item = queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: "continue" }],
+      system: "[TEAM MESSAGE META]",
+    });
+
+    submitClaimedItem(root, item);
+
+    const tmuxCalls = spawnSyncMock.mock.calls.filter(([file]) => file === "tmux");
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          args[3] === "-l" &&
+          args[4] === "continue",
+      ),
+    ).toBe(true);
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          typeof args[4] === "string" &&
+          args[4].includes("[TEAM MESSAGE META]"),
+      ),
+    ).toBe(false);
+  });
+
+  it("omits serialized team-message metadata from pane-visible payloads", async () => {
+    const root = createTempRoot();
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+    spawnSyncMock.mockImplementation((file: string) => {
+      if (file === "tmux" || file === "sleep") {
+        return { status: 0, stderr: "", stdout: "" };
+      }
+
+      return { status: 1, stderr: `Unexpected command ${file}`, stdout: "" };
+    });
+
+    const dispatcherModulePath = "../../../scripts/tmux_transport_dispatcher";
+    const { submitClaimedItem } = (await import(dispatcherModulePath)) as {
+      submitClaimedItem: (root: string, item: ReturnType<typeof queueOwnedSessionTmuxDispatch>) => void;
+    };
+    const promptBody = [
+      '<team-message from="noctis" to="ignis" type="message">',
+      "Share the updated plan.",
+      "</team-message>",
+    ].join("\n");
+    const item = queueOwnedSessionTmuxDispatch({
+      ownerAgent: "iris",
+      sessionId: "session-iris",
+      sessionTitle: "iris:projects",
+      parts: [{ type: "text", text: promptBody }],
+      system: [
+        "[TEAM MESSAGE META]",
+        "message_id: msg-1",
+        "mission_id: mission-123",
+      ].join("\n"),
+    });
+
+    submitClaimedItem(root, item);
+
+    const tmuxCalls = spawnSyncMock.mock.calls.filter(([file]) => file === "tmux");
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          args[3] === "-l" &&
+          args[4] === promptBody,
+      ),
+    ).toBe(true);
+    expect(
+      tmuxCalls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args[0] === "send-keys" &&
+          args[2] === "ff15:main.5" &&
+          typeof args[4] === "string" &&
+          args[4].includes("[TEAM MESSAGE META]"),
+      ),
+    ).toBe(false);
+  });
 });

--- a/web/app/routes/_layout.noctis-team/components/character-card.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/character-card.test.tsx
@@ -56,4 +56,21 @@ describe("CharacterCard", () => {
     expect(markup).not.toContain("Window");
     expect(markup).not.toContain("144,000");
   });
+
+  it("adds persistent owner highlighting when the card owns the active step", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterCard
+        agentId="ignis"
+        imageSrc="/ignis.png"
+        isStepOwner
+        name="Ignis"
+        role="status"
+        status="idle"
+      />,
+    );
+
+    expect(markup).toContain('data-step-owner="true"');
+    expect(markup).toContain("ring-2");
+    expect(markup).toContain("ring-offset-1");
+  });
 });

--- a/web/app/routes/_layout.noctis-team/components/character-card.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/character-card.test.tsx
@@ -70,7 +70,11 @@ describe("CharacterCard", () => {
     );
 
     expect(markup).toContain('data-step-owner="true"');
-    expect(markup).toContain("ring-2");
-    expect(markup).toContain("ring-offset-1");
+    expect(markup).toContain('data-step-owner-shell="true"');
+    expect(markup).toContain('data-step-owner-layer="aura"');
+    expect(markup).toContain('data-step-owner-layer="vivid"');
+    expect(markup).toContain('data-step-owner-layer="main"');
+    expect(markup).not.toContain('data-step-owner-orbit="true"');
+    expect(markup).not.toContain("step-owner-orbit-svg");
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/character-card.tsx
+++ b/web/app/routes/_layout.noctis-team/components/character-card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getAgentTheme } from "@/lib/agent-theme";
 import type { AgentStatus } from "@/lib/noctis-team-ui-types";
@@ -91,6 +91,8 @@ export const CharacterCard = ({
   const config = statusConfig[status];
   const theme = getAgentTheme(agentId ?? name);
   const isBenched = !isInParty && !isSpeaking;
+  const stepOwnerRingColor = theme?.ring ?? "rgba(224,224,255,0.45)";
+  const stepOwnerGlowColor = theme?.glowSoft ?? "rgba(224,224,255,0.14)";
   const portraitGlowStrong = theme?.ring ?? theme?.accentStrong ?? "rgba(224,224,255,0.55)";
   const portraitGlowSoft = theme?.glow ?? theme?.surfaceStrong ?? "rgba(224,224,255,0.24)";
   const imageFilter = isBenched
@@ -105,47 +107,61 @@ export const CharacterCard = ({
       ]
         .filter(Boolean)
         .join(" ");
+  const wrapperStyle: CSSProperties | undefined = isStepOwner
+    ? ({
+        "--step-owner-orbit-color": stepOwnerRingColor,
+        "--step-owner-orbit-glow": theme?.glow ?? stepOwnerGlowColor,
+      }) as CSSProperties
+    : undefined;
+  const cardStyle: CSSProperties | undefined = isSpeaking
+    ? ({
+        borderColor: theme?.ring ?? "rgba(125,211,252,0.45)",
+        background: theme?.surface ?? "rgba(14,165,233,0.08)",
+        boxShadow: `0 0 26px ${theme?.glowSoft ?? "rgba(125,211,252,0.18)"}`,
+      }) as CSSProperties
+    : undefined;
 
   return (
     <div
       data-step-owner={isStepOwner ? "true" : undefined}
-      className={cn(
-        "relative flex flex-col gap-1.5 overflow-hidden rounded-xl border border-border/50 bg-card/60 px-3 py-2",
-        "transition-all duration-500 backdrop-blur-sm",
-        isStepOwner && "ring-2 ring-offset-1 ring-offset-background/40",
-        isBenched && "border-border/25 bg-background/35",
-        status === "working" && "border-primary/30 shadow-primary/10 shadow-lg",
-        status === "success" &&
-          "border-[hsl(var(--success)/0.3)] shadow-lg shadow-[hsl(var(--success)/0.08)]",
-        status === "blocked" && "border-destructive/30"
-      )}
-      style={
-        isSpeaking || isStepOwner
-          ? {
-              borderColor: isSpeaking
-                ? (theme?.ring ?? "rgba(125,211,252,0.45)")
-                : (theme?.ring ?? "rgba(224,224,255,0.45)"),
-              background: isSpeaking
-                ? (theme?.surface ?? "rgba(14,165,233,0.08)")
-                : undefined,
-              boxShadow: [
-                isStepOwner
-                  ? `0 0 0 1px ${theme?.ring ?? "rgba(224,224,255,0.4)"}`
-                  : null,
-                isStepOwner
-                  ? `0 0 18px ${theme?.glowSoft ?? "rgba(224,224,255,0.14)"}`
-                  : null,
-                isSpeaking
-                  ? `0 0 26px ${theme?.glowSoft ?? "rgba(125,211,252,0.18)"}`
-                  : null,
-              ]
-                .filter(Boolean)
-                .join(", "),
-            }
-          : undefined
-      }
+      className="relative"
+      style={wrapperStyle}
     >
-      <div className="flex min-w-0 flex-row items-center gap-3">
+      {isStepOwner ? (
+        <>
+          <span
+            aria-hidden="true"
+            className="step-owner-shell step-owner-layer-aura"
+            data-step-owner-shell="true"
+            data-step-owner-layer="aura"
+          />
+          <span
+            aria-hidden="true"
+            className="step-owner-shell step-owner-layer-vivid"
+            data-step-owner-shell="true"
+            data-step-owner-layer="vivid"
+          />
+          <span
+            aria-hidden="true"
+            className="step-owner-shell step-owner-layer-main"
+            data-step-owner-shell="true"
+            data-step-owner-layer="main"
+          />
+        </>
+      ) : null}
+      <div
+        className={cn(
+          "relative z-10 flex flex-col gap-1.5 overflow-hidden rounded-xl border border-border/50 bg-card/60 px-3 py-2",
+          "transition-all duration-500 backdrop-blur-sm",
+          isBenched && "border-border/25 bg-background/35",
+          status === "working" && "border-primary/30 shadow-primary/10 shadow-lg",
+          status === "success" &&
+            "border-[hsl(var(--success)/0.3)] shadow-lg shadow-[hsl(var(--success)/0.08)]",
+          status === "blocked" && "border-destructive/30"
+        )}
+        style={cardStyle}
+      >
+        <div className="relative flex min-w-0 flex-row items-center gap-3">
         <div className="relative flex h-14 w-10 shrink-0 items-end justify-center">
           {status === "working" && !isBenched ? (
             <span
@@ -377,6 +393,7 @@ export const CharacterCard = ({
           >
             {config.label}
           </div>
+        </div>
         </div>
       </div>
     </div>

--- a/web/app/routes/_layout.noctis-team/components/character-card.tsx
+++ b/web/app/routes/_layout.noctis-team/components/character-card.tsx
@@ -12,6 +12,7 @@ export interface CharacterCardProps {
   role: string;
   imageSrc: string;
   isInParty?: boolean;
+  isStepOwner?: boolean;
   isSpeaking?: boolean;
   statusAccessory?: ReactNode;
   status: AgentStatus;
@@ -79,6 +80,7 @@ export const CharacterCard = ({
   role,
   imageSrc,
   isInParty = true,
+  isStepOwner = false,
   isSpeaking = false,
   statusAccessory,
   status,
@@ -106,9 +108,11 @@ export const CharacterCard = ({
 
   return (
     <div
+      data-step-owner={isStepOwner ? "true" : undefined}
       className={cn(
         "relative flex flex-col gap-1.5 overflow-hidden rounded-xl border border-border/50 bg-card/60 px-3 py-2",
         "transition-all duration-500 backdrop-blur-sm",
+        isStepOwner && "ring-2 ring-offset-1 ring-offset-background/40",
         isBenched && "border-border/25 bg-background/35",
         status === "working" && "border-primary/30 shadow-primary/10 shadow-lg",
         status === "success" &&
@@ -116,11 +120,27 @@ export const CharacterCard = ({
         status === "blocked" && "border-destructive/30"
       )}
       style={
-        isSpeaking
+        isSpeaking || isStepOwner
           ? {
-              borderColor: theme?.ring ?? "rgba(125,211,252,0.45)",
-              background: theme?.surface ?? "rgba(14,165,233,0.08)",
-              boxShadow: `0 0 26px ${theme?.glowSoft ?? "rgba(125,211,252,0.18)"}`,
+              borderColor: isSpeaking
+                ? (theme?.ring ?? "rgba(125,211,252,0.45)")
+                : (theme?.ring ?? "rgba(224,224,255,0.45)"),
+              background: isSpeaking
+                ? (theme?.surface ?? "rgba(14,165,233,0.08)")
+                : undefined,
+              boxShadow: [
+                isStepOwner
+                  ? `0 0 0 1px ${theme?.ring ?? "rgba(224,224,255,0.4)"}`
+                  : null,
+                isStepOwner
+                  ? `0 0 18px ${theme?.glowSoft ?? "rgba(224,224,255,0.14)"}`
+                  : null,
+                isSpeaking
+                  ? `0 0 26px ${theme?.glowSoft ?? "rgba(125,211,252,0.18)"}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(", "),
             }
           : undefined
       }

--- a/web/app/routes/_layout.noctis-team/components/chat-area.detail-sheet-presence.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.detail-sheet-presence.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sessionChatRenderSnapshotMock } = vi.hoisted(() => ({
+  sessionChatRenderSnapshotMock: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  const maybeWindow = globalThis as typeof globalThis & {
+    window?: typeof globalThis & { __vite_plugin_react_preamble_installed__?: boolean };
+    __vite_plugin_react_preamble_installed__?: boolean;
+    $RefreshReg$?: (type: unknown, id: string) => void;
+    $RefreshSig$?: () => <T>(type: T) => T;
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  if (maybeWindow.window) {
+    maybeWindow.window.__vite_plugin_react_preamble_installed__ = true;
+  }
+  maybeWindow.__vite_plugin_react_preamble_installed__ = true;
+  maybeWindow.$RefreshReg$ = () => undefined;
+  maybeWindow.$RefreshSig$ = () => (type) => type;
+  maybeWindow.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+vi.mock("@/components/chat/message-markdown", () => ({
+  MessageMarkdown: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/chat/message-intermediate-details", () => ({
+  buildIntermediateDetailSummary: () => "",
+  MessageIntermediateDetails: () => null,
+  MessageIntermediateDetailsToggle: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/chat/prompt-composer", () => ({
+  PromptComposer: () => <div />,
+}));
+
+vi.mock("@/components/chat/thread-frame", () => ({
+  ChatThreadFrame: ({
+    header,
+    footer,
+    children,
+  }: {
+    header?: ReactNode;
+    footer?: ReactNode;
+    children?: (viewportRef: { current: HTMLDivElement | null }) => ReactNode;
+  }) => (
+    <div>
+      <div>{header}</div>
+      <div>{footer}</div>
+      <div>{children?.({ current: null })}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/workspace-launch-actions", () => ({
+  WorkspaceLaunchActions: () => null,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}));
+
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({ checked }: { checked?: boolean }) => (
+    <button data-state={checked ? "checked" : "unchecked"} type="button" />
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/hooks/use-conversation-unit-inspectability", () => ({
+  useConversationUnitInspectability: () => ({
+    getExpandedDetailEntries: () => ({}),
+    isConversationUnitExpanded: () => false,
+    expandedDetailEntriesByConversationUnit: {},
+    toggleConversationUnit: () => undefined,
+    toggleDetailEntry: () => undefined,
+  }),
+}));
+
+vi.mock("@/hooks/use-session-chat-render-snapshot", () => ({
+  useSessionChatRenderSnapshot: (input: unknown) => sessionChatRenderSnapshotMock(input),
+}));
+
+vi.mock("@/stores/chat-store", () => ({
+  useChatStore: (selector: (state: { workingParty: string[] }) => unknown) =>
+    selector({ workingParty: [] }),
+}));
+
+vi.mock("./message-detail-sheet", () => ({
+  default: ({
+    onOpenChange,
+    open,
+  }: {
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+  }) => (
+    <div data-message-detail-sheet={open ? "open" : "closed"}>
+      <button onClick={() => onOpenChange(false)} type="button">
+        Close detail
+      </button>
+    </div>
+  ),
+}));
+
+import { ChatArea } from "./chat-area";
+
+function createRenderedMessage() {
+  return {
+    id: "assistant-1",
+    conversationUnitId: "assistant-1",
+    role: "assistant",
+    sender: "noctis",
+    senderLabel: "Noctis",
+    kind: "assistant_message",
+    content: "Sliding detail.",
+    detailContent: "Sliding detail.",
+    rawText: "Sliding detail.",
+    parts: [{ type: "text", text: "Sliding detail." }],
+    timestamp: new Date("2026-05-08T10:30:00.000Z"),
+    source: "session",
+    sourceMessageIds: ["assistant-1"],
+    detailRawText: "Sliding detail.",
+    detailState: undefined,
+    messageDisplay: {
+      displayContent: "Sliding detail.",
+      promptContextSections: [],
+      promptContextSource: null,
+      rawWorkflowPrompt: null,
+      rawPromptPayload: null,
+      reportDetails: null,
+      selectionAdjustment: null,
+      resolvedSender: "noctis",
+      resolvedSenderIsUser: false,
+      resolvedSenderLabel: "Noctis",
+      workflowPresentation: null,
+    },
+  };
+}
+
+describe("chat-area detail sheet presence", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    sessionChatRenderSnapshotMock.mockReset();
+    sessionChatRenderSnapshotMock.mockReturnValue({
+      autoFollowKey: "message",
+      inspectabilityBoundaries: [],
+      scrollSignal: "none",
+      renderedMessages: [createRenderedMessage()],
+      streamingMessage: null,
+      showPendingIndicator: false,
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+
+    container.remove();
+  });
+
+  it("keeps the detail sheet wrapper mounted as closed after the user closes it", async () => {
+    await act(async () => {
+      root?.render(
+        <ChatArea
+          messages={[]}
+          isResponding={false}
+          sessionId="session-1"
+          primaryAgentId="noctis"
+          contextProjects={[]}
+          availableOperations={[]}
+          selectedOperation={null}
+          activeOperationState={null}
+          isOperationSelectionLocked={false}
+          onSelectedOperationChange={() => undefined}
+          onSend={() => undefined}
+        />,
+      );
+    });
+
+    const openButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Open detail"),
+    );
+
+    expect(openButton).not.toBeUndefined();
+
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.innerHTML).toContain('data-message-detail-sheet="open"');
+
+    const closeButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Close detail"),
+    );
+
+    expect(closeButton).not.toBeUndefined();
+
+    await act(async () => {
+      closeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.innerHTML).toContain('data-message-detail-sheet="closed"');
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
@@ -150,6 +150,8 @@ describe("chat-area", () => {
           { value: "docs-repo", label: "Reference Docs" },
         ]}
         selectedExecutionProjectId="core-repo"
+        executionProjectLaunchPath="/home/atman/repos/core-repo"
+        executionProjectVSCodePreference="auto"
         executionProjectHint="Secondary context starts with Projects page presets."
         selectedExecutionTargetMode="execution_project"
         contextProjects={[
@@ -159,6 +161,7 @@ describe("chat-area", () => {
         ]}
         contextActionLabel="Mission Context"
         onContextAction={() => undefined}
+        onExecutionProjectVSCodePreferenceChange={() => undefined}
         availableOperations={[]}
         selectedOperation={null}
         activeOperationState={null}
@@ -179,6 +182,8 @@ describe("chat-area", () => {
     expect(markup).toContain("Mission Context");
     expect(markup).toContain("Execution project help");
     expect(markup).toContain("Secondary context starts with Projects page presets.");
+    expect(markup).toContain("Open folder");
+    expect(markup).toContain("Open in VS Code (Auto -&gt; WSL)");
     expect(markup).toContain("Dedicated workspace");
     expect(markup).toContain("Execution mode help");
     expect(markup).toContain("Work directly in the registered project folder");

--- a/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.test.tsx
@@ -663,6 +663,77 @@ describe("chat-area", () => {
     expect(markup).not.toContain("No Session History Yet");
   });
 
+  it("shows a recent-history notice when older transcript turns are trimmed", () => {
+    const markup = renderToStaticMarkup(
+      <ChatArea
+        messages={[]}
+        retainedHistory={{
+          isActive: true,
+          trimmedConversationUnitCount: 50,
+          trimmedMessageCount: 50,
+        }}
+        historyPhase="ready"
+        isResponding={false}
+        missionExecutionLabel="Core Repo"
+        contextProjects={[]}
+        availableOperations={[]}
+        selectedOperation={null}
+        activeOperationState={null}
+        isOperationSelectionLocked={true}
+        onSelectedOperationChange={() => undefined}
+        onSend={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Recent History Only");
+    expect(markup).toContain(
+      "Only recent mission transcript history is currently retained in this live session.",
+    );
+    expect(markup).toContain(
+      "50 earlier transcript turns are hidden until transcript ownership resets.",
+    );
+  });
+
+  it("keeps the active tail visible while the recent-history notice is active", () => {
+    sessionChatRenderSnapshotMock.mockReturnValueOnce(
+      buildSessionChatRenderSnapshot({
+        assistantPending: true,
+        messages: [],
+        streamingText: {
+          content: "Mission two is responding",
+          fallbackSender: "noctis",
+          fallbackSenderLabel: "Noctis",
+        },
+      }),
+    );
+
+    const markup = renderToStaticMarkup(
+      <ChatArea
+        messages={[]}
+        retainedHistory={{
+          isActive: true,
+          trimmedConversationUnitCount: 50,
+          trimmedMessageCount: 50,
+        }}
+        streamingContent="Mission two is responding"
+        isResponding={true}
+        isSessionActive={true}
+        isStreaming={true}
+        contextProjects={[]}
+        availableOperations={[]}
+        selectedOperation={null}
+        activeOperationState={null}
+        isOperationSelectionLocked={false}
+        onSelectedOperationChange={() => undefined}
+        onSend={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Recent History Only");
+    expect(markup).toContain("Mission two is responding");
+    expect(markup).toContain("animate-bounce");
+  });
+
   it("renders temporary assistant streaming text through the shared snapshot while keeping the generic typing indicator visible", () => {
     sessionChatRenderSnapshotMock.mockReturnValueOnce(
       buildSessionChatRenderSnapshot({

--- a/web/app/routes/_layout.noctis-team/components/chat-area.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/chat/message-intermediate-details";
 import { PromptComposer } from "@/components/chat/prompt-composer";
 import { ChatThreadFrame } from "@/components/chat/thread-frame";
+import { WorkspaceLaunchActions } from "@/components/workspace-launch-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -44,6 +45,7 @@ import {
   EXECUTION_MODE_TOGGLE_LABEL,
   EXECUTION_MODE_TOOLTIP_COPY,
 } from "@/lib/mission-execution-target-mode";
+import type { VSCodePreference } from "@/lib/vscode-preferences";
 import { getAllowedWorkers, getWorkingPartySummary } from "@/lib/noctis-working-party";
 import {
   DEFAULT_AUTONOMOUS_OPERATION_LABEL,
@@ -92,10 +94,13 @@ interface ChatAreaProps {
     label: string;
   }>;
   selectedExecutionProjectId?: string | null;
+  executionProjectLaunchPath?: string | null;
+  executionProjectVSCodePreference?: VSCodePreference;
   selectedExecutionTargetMode?: MissionExecutionTargetMode;
   executionProjectHint?: string | null;
   executionProjectError?: string | null;
   onSelectedExecutionProjectChange?: (projectId: string) => void;
+  onExecutionProjectVSCodePreferenceChange?: (preference: VSCodePreference) => void;
   onSelectedExecutionTargetModeChange?: (mode: MissionExecutionTargetMode) => void;
   missionExecutionLabel?: string | null;
   contextProjects: Array<{
@@ -782,10 +787,13 @@ export const ChatArea = ({
   showExecutionProjectSelector = false,
   executionProjectOptions = [],
   selectedExecutionProjectId = null,
+  executionProjectLaunchPath = null,
+  executionProjectVSCodePreference = "auto",
   selectedExecutionTargetMode = DEFAULT_NEW_MISSION_EXECUTION_TARGET_MODE,
   executionProjectHint = null,
   executionProjectError = null,
   onSelectedExecutionProjectChange,
+  onExecutionProjectVSCodePreferenceChange,
   onSelectedExecutionTargetModeChange,
   missionExecutionLabel = null,
   contextProjects,
@@ -1140,22 +1148,34 @@ export const ChatArea = ({
                           </Tooltip>
                         ) : null}
                       </div>
-                      <Select
-                        disabled={isMissionStartPending}
-                        value={selectedExecutionProjectId ?? undefined}
-                        onValueChange={onSelectedExecutionProjectChange}
-                      >
-                        <SelectTrigger className="h-9 bg-background/70 font-mono text-xs uppercase tracking-[0.14em]">
-                          <SelectValue placeholder="Choose a project" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {executionProjectOptions.map((project) => (
-                            <SelectItem key={project.value} value={project.value}>
-                              {project.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <Select
+                            disabled={isMissionStartPending}
+                            value={selectedExecutionProjectId ?? undefined}
+                            onValueChange={onSelectedExecutionProjectChange}
+                          >
+                            <SelectTrigger className="h-9 bg-background/70 font-mono text-xs uppercase tracking-[0.14em]">
+                              <SelectValue placeholder="Choose a project" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {executionProjectOptions.map((project) => (
+                                <SelectItem key={project.value} value={project.value}>
+                                  {project.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+
+                        {executionProjectLaunchPath ? (
+                          <WorkspaceLaunchActions
+                            path={executionProjectLaunchPath}
+                            vscodePreference={executionProjectVSCodePreference}
+                            onVSCodePreferenceChange={onExecutionProjectVSCodePreferenceChange}
+                          />
+                        ) : null}
+                      </div>
                       {executionProjectError ? (
                         <p className="text-[11px] text-destructive">{executionProjectError}</p>
                       ) : null}

--- a/web/app/routes/_layout.noctis-team/components/chat-area.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.tsx
@@ -484,7 +484,7 @@ const MessageBubble = memo(
           ) : null
         }
         renderDetailSheet={({ open, onOpenChange }) =>
-          open ? (
+          (
             <MessageDetailSheet
               content={messageDisplay.displayContent}
               detailState={message.detailState}
@@ -497,7 +497,7 @@ const MessageBubble = memo(
               sessionId={sessionId}
               sender={message.sender}
             />
-          ) : null
+          )
         }
         senderLabel={senderLabel}
         timestamp={message.timestamp}

--- a/web/app/routes/_layout.noctis-team/components/chat-area.tsx
+++ b/web/app/routes/_layout.noctis-team/components/chat-area.tsx
@@ -35,6 +35,7 @@ import { useConversationUnitInspectability } from "@/hooks/use-conversation-unit
 import type {
   AbortSettlementPhase,
   MissionTranscriptPhase,
+  MissionTranscriptRetentionState,
 } from "@/hooks/use-agent-session";
 import { useSessionChatRenderSnapshot } from "@/hooks/use-session-chat-render-snapshot";
 import { getAgentTheme } from "@/lib/agent-theme";
@@ -77,6 +78,7 @@ interface ChatAreaProps {
   sessionId?: string | null;
   composerDraftKey?: string | null;
   messages: ChatMessage[];
+  retainedHistory?: MissionTranscriptRetentionState;
   currentStreamingMessageId?: string | null;
   liveDraft?: SessionLiveDraft | null;
   streamingContent?: string;
@@ -662,6 +664,7 @@ const TranscriptBody = memo(
     historyEmptyCallout,
     historyErrorCallout,
     historyLoadingCallout,
+    historyRetentionCallout,
     getExpandedDetailEntries,
     isConversationUnitExpanded,
     isStreaming,
@@ -677,6 +680,7 @@ const TranscriptBody = memo(
     historyEmptyCallout: ReactNode;
     historyErrorCallout: ReactNode;
     historyLoadingCallout: ReactNode;
+    historyRetentionCallout: ReactNode;
     getExpandedDetailEntries: (conversationUnitId: string) => Record<string, true>;
     isConversationUnitExpanded: (conversationUnitId: string) => boolean;
     isStreaming: boolean;
@@ -701,6 +705,7 @@ const TranscriptBody = memo(
       {historyLoadingCallout}
       {historyErrorCallout}
       {historyEmptyCallout}
+      {historyRetentionCallout}
 
       {topSpacerHeight > 0 ? (
         <div aria-hidden="true" style={{ height: `${topSpacerHeight}px` }} />
@@ -774,6 +779,7 @@ export const ChatArea = ({
   sessionId = null,
   composerDraftKey = null,
   messages,
+  retainedHistory,
   currentStreamingMessageId = null,
   streamingContent = "",
   historyErrorMessage = null,
@@ -826,6 +832,7 @@ export const ChatArea = ({
   const isAbortSettling = abortSettlementPhase !== "idle";
   const isTranscriptEmpty = historyPhase === "empty";
   const isTranscriptError = historyPhase === "error";
+  const isRetainedHistoryActive = retainedHistory?.isActive ?? false;
   const presentationMessages = useMemo(
     () => messages.map(toSessionPresentationMessage),
     [messages],
@@ -1009,6 +1016,26 @@ export const ChatArea = ({
         </div>
       ) : null,
     [historyErrorMessage, isTranscriptError],
+  );
+  const historyRetentionCallout = useMemo(
+    () =>
+      isRetainedHistoryActive ? (
+        <div className="rounded-xl border border-sky-400/25 bg-sky-400/8 px-3 py-2.5" role="status">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-sky-100/85">
+            Recent History Only
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-foreground/80">
+            Only recent mission transcript history is currently retained in this live session.
+          </p>
+          {retainedHistory && retainedHistory.trimmedConversationUnitCount > 0 ? (
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground/85">
+              {retainedHistory.trimmedConversationUnitCount} earlier transcript turns are hidden until
+              transcript ownership resets.
+            </p>
+          ) : null}
+        </div>
+      ) : null,
+    [isRetainedHistoryActive, retainedHistory],
   );
   const abortSettlementCallout = isAbortSettling ? (
     <div
@@ -1307,6 +1334,7 @@ export const ChatArea = ({
           historyEmptyCallout={historyEmptyCallout}
           historyErrorCallout={historyErrorCallout}
           historyLoadingCallout={historyLoadingCallout}
+          historyRetentionCallout={historyRetentionCallout}
           isConversationUnitExpanded={inspectability.isConversationUnitExpanded}
           isStreaming={isStreaming}
           onToggleConversationUnit={inspectability.toggleConversationUnit}

--- a/web/app/routes/_layout.noctis-team/components/continue-mission-session.ts
+++ b/web/app/routes/_layout.noctis-team/components/continue-mission-session.ts
@@ -1,0 +1,67 @@
+import type { AgentId } from "@/lib/types/mission";
+
+export interface ContinueMissionAgentSessionResult {
+  agentId: AgentId;
+  missionId: string;
+  sessionId: string;
+}
+
+type ContinueMissionAgentSessionPayload = Partial<ContinueMissionAgentSessionResult> & {
+  error?: unknown;
+  ok?: unknown;
+};
+
+const AGENT_LABELS: Record<AgentId, string> = {
+  noctis: "Noctis",
+  lunafreya: "Lunafreya",
+  ignis: "Ignis",
+  gladiolus: "Gladiolus",
+  prompto: "Prompto",
+};
+
+export async function continueMissionAgentSession(input: {
+  missionId: string;
+  agentId: AgentId;
+  fetchImpl?: typeof fetch;
+}): Promise<ContinueMissionAgentSessionResult> {
+  const response = await (input.fetchImpl ?? fetch)(
+    `/api/missions/${input.missionId}/agents/${input.agentId}/continue`,
+    {
+      method: "POST",
+    }
+  );
+
+  const payload = (await response
+    .json()
+    .catch(() => null)) as ContinueMissionAgentSessionPayload | null;
+
+  if (!response.ok) {
+    const errorMessage =
+      payload && typeof payload.error === "string"
+        ? payload.error
+        : "Unable to send raw continue";
+    throw new Error(errorMessage);
+  }
+
+  if (
+    !payload ||
+    payload.ok !== true ||
+    payload.agentId !== input.agentId ||
+    payload.missionId !== input.missionId ||
+    typeof payload.sessionId !== "string"
+  ) {
+    throw new Error("Continue route returned an invalid payload");
+  }
+
+  return {
+    agentId: payload.agentId,
+    missionId: payload.missionId,
+    sessionId: payload.sessionId,
+  };
+}
+
+export function formatContinueMissionAgentSessionSuccessMessage(
+  result: ContinueMissionAgentSessionResult
+): string {
+  return `Sent raw continue to ${AGENT_LABELS[result.agentId]}.`;
+}

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   chatStoreStateMock,
+  continueMissionAgentSessionMock,
   contextMenuItemPropsSpy,
+  formatContinueMissionAgentSessionSuccessMessageMock,
   formatSwitchMissionAgentPaneSessionSuccessMessageMock,
   pickerPropsSpy,
   setAgentModelMock,
@@ -13,7 +15,9 @@ const {
   toastSuccessMock,
 } = vi.hoisted(() => ({
   chatStoreStateMock: vi.fn(),
+  continueMissionAgentSessionMock: vi.fn(),
   contextMenuItemPropsSpy: vi.fn(),
+  formatContinueMissionAgentSessionSuccessMessageMock: vi.fn(),
   formatSwitchMissionAgentPaneSessionSuccessMessageMock: vi.fn(),
   pickerPropsSpy: vi.fn(),
   setAgentModelMock: vi.fn(),
@@ -134,6 +138,12 @@ vi.mock("./switch-pane-session", () => ({
   switchMissionAgentPaneSession: switchMissionAgentPaneSessionMock,
 }));
 
+vi.mock("./continue-mission-session", () => ({
+  continueMissionAgentSession: continueMissionAgentSessionMock,
+  formatContinueMissionAgentSessionSuccessMessage:
+    formatContinueMissionAgentSessionSuccessMessageMock,
+}));
+
 vi.mock("./character-card", () => ({
   CharacterCard: ({ detail, metaAccessory }: { detail?: string; metaAccessory?: ReactNode }) => (
     <div>
@@ -151,7 +161,9 @@ import {
 
 describe("LunafreyaStatusPanel", () => {
   beforeEach(() => {
+    continueMissionAgentSessionMock.mockReset();
     contextMenuItemPropsSpy.mockReset();
+    formatContinueMissionAgentSessionSuccessMessageMock.mockReset();
     formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReset();
     pickerPropsSpy.mockReset();
     setAgentModelMock.mockReset();
@@ -367,6 +379,28 @@ describe("LunafreyaStatusPanel", () => {
     expect(markup).toContain("Switch To Current Mission Session");
   });
 
+  it("shows a raw Continue action when a Lunafreya mission session exists", () => {
+    const markup = renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Send raw continue to Lunafreya mission session"/
+    );
+    expect(markup).toContain("Continue");
+  });
+
   it("shows the Lunafreya context menu header instead of a generic action group label", () => {
     const markup = renderToStaticMarkup(
       <LunafreyaStatusPanel
@@ -464,6 +498,58 @@ describe("LunafreyaStatusPanel", () => {
     expect(toastSuccessMock).toHaveBeenCalledWith(
       "Switched Lunafreya to the current mission session."
     );
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes raw continue delivery for Lunafreya when the current mission session exists", async () => {
+    formatContinueMissionAgentSessionSuccessMessageMock.mockReturnValue(
+      "Sent raw continue to Lunafreya."
+    );
+    continueMissionAgentSessionMock.mockResolvedValue({
+      agentId: "lunafreya",
+      missionId: "mission-luna",
+      sessionId: "session-luna",
+    });
+
+    renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Send raw continue to Lunafreya mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(continueMissionAgentSessionMock).toHaveBeenCalledWith({
+      agentId: "lunafreya",
+      missionId: "mission-luna",
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Sent raw continue to Lunafreya.");
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
@@ -2,10 +2,31 @@ import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { chatStoreStateMock, pickerPropsSpy, setAgentModelMock } = vi.hoisted(() => ({
+const {
+  chatStoreStateMock,
+  contextMenuItemPropsSpy,
+  formatSwitchMissionAgentPaneSessionSuccessMessageMock,
+  pickerPropsSpy,
+  setAgentModelMock,
+  switchMissionAgentPaneSessionMock,
+  toastErrorMock,
+  toastSuccessMock,
+} = vi.hoisted(() => ({
   chatStoreStateMock: vi.fn(),
+  contextMenuItemPropsSpy: vi.fn(),
+  formatSwitchMissionAgentPaneSessionSuccessMessageMock: vi.fn(),
   pickerPropsSpy: vi.fn(),
   setAgentModelMock: vi.fn(),
+  switchMissionAgentPaneSessionMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
 }));
 
 vi.mock("@/components/compact-model-variant-picker", () => ({
@@ -25,7 +46,9 @@ vi.mock("@/components/compact-model-variant-picker", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: { children?: ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/badge", () => ({
@@ -33,7 +56,8 @@ vi.mock("@/components/ui/badge", () => ({
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) => (open ? <div>{children}</div> : null),
+  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+    open ? <div>{children}</div> : null,
   DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
   DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -62,6 +86,37 @@ vi.mock("@/components/ui/select", () => ({
   SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
 }));
 
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...props
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onSelect?: (event: { preventDefault: () => void }) => void;
+  }) => {
+    contextMenuItemPropsSpy({ children, disabled, onSelect, ...props });
+
+    return (
+      <button
+        data-disabled={disabled ? "true" : "false"}
+        disabled={disabled}
+        onClick={() => onSelect?.({ preventDefault: () => undefined })}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+  ContextMenuLabel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ContextMenuSeparator: () => <hr />,
+}));
+
 vi.mock("@/stores/chat-store", () => ({
   useChatStore: (
     selector: (state: {
@@ -71,6 +126,12 @@ vi.mock("@/stores/chat-store", () => ({
       setAgentModel: typeof setAgentModelMock;
     }) => unknown
   ) => selector(chatStoreStateMock()),
+}));
+
+vi.mock("./switch-pane-session", () => ({
+  formatSwitchMissionAgentPaneSessionSuccessMessage:
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock,
+  switchMissionAgentPaneSession: switchMissionAgentPaneSessionMock,
 }));
 
 vi.mock("./character-card", () => ({
@@ -90,8 +151,13 @@ import {
 
 describe("LunafreyaStatusPanel", () => {
   beforeEach(() => {
+    contextMenuItemPropsSpy.mockReset();
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReset();
     pickerPropsSpy.mockReset();
     setAgentModelMock.mockReset();
+    switchMissionAgentPaneSessionMock.mockReset();
+    toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
 
     chatStoreStateMock.mockReturnValue({
       agentModels: {
@@ -127,7 +193,7 @@ describe("LunafreyaStatusPanel", () => {
         selectedSkillIds: ["hydraean"],
         query: "hyd",
         selectedOnly: true,
-      }).map((option) => option.id),
+      }).map((option) => option.id)
     ).toEqual(["hydraean"]);
   });
 
@@ -164,12 +230,12 @@ describe("LunafreyaStatusPanel", () => {
     expect(markup).toContain("1 selected");
     expect(markup).toContain("Skills help");
     expect(markup).toContain(
-      "Skill changes are stored immediately and apply on Lunafreya&#x27;s next User turn.",
+      "Skill changes are stored immediately and apply on Lunafreya&#x27;s next User turn."
     );
     expect(markup).toContain("Open skills selector");
     expect(markup).not.toContain("Archive Index");
     expect(markup).not.toContain(
-      "Model and overlay edits are stored immediately and will be applied when User sends the next prompt.",
+      "Model and overlay edits are stored immediately and will be applied when User sends the next prompt."
     );
   });
 
@@ -192,7 +258,7 @@ describe("LunafreyaStatusPanel", () => {
         selectedJobId={null}
         selectedSkillIds={[]}
         status="idle"
-      />,
+      />
     );
 
     expect(markup).toContain("Job");
@@ -256,7 +322,7 @@ describe("LunafreyaStatusPanel", () => {
     expect(markup).toContain("model-picker:github-copilot/gpt-5.4:balanced");
     expect(markup).toContain("Model and facet changes apply on the next User turn.");
     expect(markup).not.toContain(
-      "Model and overlay edits are stored immediately and will be applied when User sends the next prompt.",
+      "Model and overlay edits are stored immediately and will be applied when User sends the next prompt."
     );
 
     const pickerProps = pickerPropsSpy.mock.calls[0]?.[0] as {
@@ -277,5 +343,107 @@ describe("LunafreyaStatusPanel", () => {
       modelID: "claude-sonnet-4",
       variant: "high",
     });
+  });
+
+  it("shows a current-mission pane session switch action when a Lunafreya mission session exists", () => {
+    const markup = renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Switch Lunafreya pane to current mission session"/
+    );
+    expect(markup).toContain("Switch To Current Mission Session");
+  });
+
+  it("keeps the current-mission pane session switch action enabled while Lunafreya is working", () => {
+    const markup = renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="working"
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Switch Lunafreya pane to current mission session"/
+    );
+  });
+
+  it("invokes pane session switching for Lunafreya when the current mission session exists", async () => {
+    const switchResult = {
+      agentId: "lunafreya",
+      missionId: "mission-luna",
+      sessionId: "session-luna",
+      sessionTitle: "mission:mission-luna:lunafreya",
+    };
+    switchMissionAgentPaneSessionMock.mockResolvedValue(switchResult);
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReturnValue(
+      "Switched Lunafreya to the current mission session."
+    );
+
+    renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Switch Lunafreya pane to current mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(switchMissionAgentPaneSessionMock).toHaveBeenCalledWith({
+      agentId: "lunafreya",
+      missionId: "mission-luna",
+    });
+    expect(formatSwitchMissionAgentPaneSessionSuccessMessageMock).toHaveBeenCalledWith(
+      switchResult
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Switched Lunafreya to the current mission session."
+    );
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
@@ -401,6 +401,27 @@ describe("LunafreyaStatusPanel", () => {
     expect(markup).toContain("Continue");
   });
 
+  it("keeps raw Continue enabled even when the Lunafreya session is not yet known locally", () => {
+    const markup = renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession={false}
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Send raw continue to Lunafreya mission session"/
+    );
+  });
+
   it("shows the Lunafreya context menu header instead of a generic action group label", () => {
     const markup = renderToStaticMarkup(
       <LunafreyaStatusPanel
@@ -551,5 +572,49 @@ describe("LunafreyaStatusPanel", () => {
     });
     expect(toastSuccessMock).toHaveBeenCalledWith("Sent raw continue to Lunafreya.");
     expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the route error when raw continue is attempted before the Lunafreya session is known locally", async () => {
+    continueMissionAgentSessionMock.mockRejectedValue(new Error("Mission session not found"));
+
+    renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession={false}
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Send raw continue to Lunafreya mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(continueMissionAgentSessionMock).toHaveBeenCalledWith({
+      agentId: "lunafreya",
+      missionId: "mission-luna",
+    });
+    expect(toastErrorMock).toHaveBeenCalledWith("Mission session not found");
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.test.tsx
@@ -367,6 +367,26 @@ describe("LunafreyaStatusPanel", () => {
     expect(markup).toContain("Switch To Current Mission Session");
   });
 
+  it("shows the Lunafreya context menu header instead of a generic action group label", () => {
+    const markup = renderToStaticMarkup(
+      <LunafreyaStatusPanel
+        hasMissionSession
+        jobOptions={[]}
+        missionId="mission-luna"
+        skillOptions={[]}
+        onClearSkillIds={() => undefined}
+        onSelectedJobIdChange={() => undefined}
+        onToggleSkillId={() => undefined}
+        selectedJobId={null}
+        selectedSkillIds={[]}
+        status="idle"
+      />
+    );
+
+    expect(markup).toContain("Lunafreya");
+    expect(markup).not.toContain("Agent Actions");
+  });
+
   it("keeps the current-mission pane session switch action enabled while Lunafreya is working", () => {
     const markup = renderToStaticMarkup(
       <LunafreyaStatusPanel

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
@@ -42,6 +42,10 @@ import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
 import { CharacterCard } from "./character-card";
 import {
+  continueMissionAgentSession,
+  formatContinueMissionAgentSessionSuccessMessage,
+} from "./continue-mission-session";
+import {
   formatSwitchMissionAgentPaneSessionSuccessMessage,
   switchMissionAgentPaneSession,
 } from "./switch-pane-session";
@@ -280,6 +284,7 @@ export function LunafreyaStatusPanel({
   const [providers, setProviders] = useState<OpencodeProvider[]>([]);
   const [variantsByModel, setVariantsByModel] = useState<Record<string, string[]>>({});
   const [isSkillSelectorOpen, setIsSkillSelectorOpen] = useState(false);
+  const [isSendingContinue, setIsSendingContinue] = useState(false);
   const [isSwitchingSession, setIsSwitchingSession] = useState(false);
   const [skillQuery, setSkillQuery] = useState("");
   const [selectedOnly, setSelectedOnly] = useState(false);
@@ -333,6 +338,7 @@ export function LunafreyaStatusPanel({
   const switchActionLabel = !hasMissionSession
     ? "Mission Session Unavailable"
     : "Switch To Current Mission Session";
+  const continueActionDisabled = !missionId || !hasMissionSession || isSendingContinue;
 
   const handleSwitchMissionPaneSession = async () => {
     if (!missionId || !hasMissionSession || isSwitchingSession) {
@@ -350,6 +356,25 @@ export function LunafreyaStatusPanel({
       toast.error(error instanceof Error ? error.message : "Unable to switch pane session");
     } finally {
       setIsSwitchingSession(false);
+    }
+  };
+
+  const handleContinueMissionSession = async () => {
+    if (!missionId || !hasMissionSession || isSendingContinue) {
+      return;
+    }
+
+    setIsSendingContinue(true);
+    try {
+      const result = await continueMissionAgentSession({
+        missionId,
+        agentId: "lunafreya",
+      });
+      toast.success(formatContinueMissionAgentSessionSuccessMessage(result));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to send raw continue");
+    } finally {
+      setIsSendingContinue(false);
     }
   };
 
@@ -409,6 +434,16 @@ export function LunafreyaStatusPanel({
             }}
           >
             {switchActionLabel}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            aria-label="Send raw continue to Lunafreya mission session"
+            disabled={continueActionDisabled}
+            onSelect={() => {
+              void handleContinueMissionSession();
+            }}
+          >
+            Continue
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
@@ -1,8 +1,17 @@
 import { BrainCircuit, Cpu, Info, Layers3, Search, SlidersHorizontal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { CompactModelVariantPicker } from "@/components/compact-model-variant-picker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   Dialog,
   DialogContent,
@@ -32,6 +41,10 @@ import type { AgentContextUsage } from "@/lib/types/mission";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
 import { CharacterCard } from "./character-card";
+import {
+  formatSwitchMissionAgentPaneSessionSuccessMessage,
+  switchMissionAgentPaneSession,
+} from "./switch-pane-session";
 
 export type LunafreyaFacetOption = {
   id: string;
@@ -43,6 +56,8 @@ export type LunafreyaFacetOption = {
 
 type LunafreyaStatusPanelProps = {
   contextUsage?: AgentContextUsage | null;
+  missionId?: string | null;
+  hasMissionSession?: boolean;
   status: AgentStatus;
   isSpeaking?: boolean;
   selectedJobId: string | null;
@@ -63,7 +78,7 @@ const LUNAFREYA_CARD_COPY = {
 
 export function getSelectedSkillOptions(
   skillOptions: LunafreyaFacetOption[],
-  selectedSkillIds: string[],
+  selectedSkillIds: string[]
 ): LunafreyaFacetOption[] {
   const optionsById = new Map(skillOptions.map((option) => [option.id, option]));
 
@@ -127,7 +142,7 @@ export function LunafreyaSkillSelectorDialog({
         query,
         selectedOnly,
       }),
-    [query, selectedOnly, selectedSkillIds, skillOptions],
+    [query, selectedOnly, selectedSkillIds, skillOptions]
   );
 
   return (
@@ -138,10 +153,14 @@ export function LunafreyaSkillSelectorDialog({
             <div className="space-y-1">
               <DialogTitle>Manage Skills</DialogTitle>
               <DialogDescription>
-                Search available skills, review descriptions, and update Lunafreya&#39;s next-turn skill set.
+                Search available skills, review descriptions, and update Lunafreya&#39;s next-turn
+                skill set.
               </DialogDescription>
             </div>
-            <Badge className="rounded-full font-mono text-[10px] uppercase tracking-[0.16em]" variant="outline">
+            <Badge
+              className="rounded-full font-mono text-[10px] uppercase tracking-[0.16em]"
+              variant="outline"
+            >
               {`${selectedSkillIds.length} selected`}
             </Badge>
           </div>
@@ -207,14 +226,16 @@ export function LunafreyaSkillSelectorDialog({
                         "w-full rounded-lg border px-3 py-2 text-left transition-colors",
                         isSelected
                           ? "border-primary/40 bg-primary/10"
-                          : "border-border/50 bg-card/40 hover:bg-card/70",
+                          : "border-border/50 bg-card/40 hover:bg-card/70"
                       )}
                       onClick={() => onToggleSkillId(option.id)}
                       type="button"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
-                          <p className="truncate font-medium text-sm text-foreground/90">{option.label}</p>
+                          <p className="truncate font-medium text-sm text-foreground/90">
+                            {option.label}
+                          </p>
                           <p className="truncate font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/70">
                             {option.sourceLabel}
                           </p>
@@ -226,7 +247,9 @@ export function LunafreyaSkillSelectorDialog({
                         ) : null}
                       </div>
                       {option.description ? (
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground/80">{option.description}</p>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground/80">
+                          {option.description}
+                        </p>
                       ) : null}
                     </button>
                   );
@@ -242,6 +265,8 @@ export function LunafreyaSkillSelectorDialog({
 
 export function LunafreyaStatusPanel({
   contextUsage = null,
+  missionId = null,
+  hasMissionSession = false,
   status,
   isSpeaking = false,
   selectedJobId,
@@ -255,6 +280,7 @@ export function LunafreyaStatusPanel({
   const [providers, setProviders] = useState<OpencodeProvider[]>([]);
   const [variantsByModel, setVariantsByModel] = useState<Record<string, string[]>>({});
   const [isSkillSelectorOpen, setIsSkillSelectorOpen] = useState(false);
+  const [isSwitchingSession, setIsSwitchingSession] = useState(false);
   const [skillQuery, setSkillQuery] = useState("");
   const [selectedOnly, setSelectedOnly] = useState(false);
   const selectedModel = useChatStore((state) => state.agentModels.lunafreya ?? null);
@@ -285,10 +311,13 @@ export function LunafreyaStatusPanel({
     };
   }, []);
 
-  const modelItems = useMemo<ModelCatalogItem[]>(() => flattenProviderModels(providers), [providers]);
+  const modelItems = useMemo<ModelCatalogItem[]>(
+    () => flattenProviderModels(providers),
+    [providers]
+  );
   const selectedSkillOptions = useMemo(
     () => getSelectedSkillOptions(skillOptions, selectedSkillIds),
-    [selectedSkillIds, skillOptions],
+    [selectedSkillIds, skillOptions]
   );
 
   useEffect(() => {
@@ -300,6 +329,30 @@ export function LunafreyaStatusPanel({
     setSelectedOnly(false);
   }, [isSkillSelectorOpen]);
 
+  const switchActionDisabled = !missionId || !hasMissionSession || isSwitchingSession;
+  const switchActionLabel = !hasMissionSession
+    ? "Mission Session Unavailable"
+    : "Switch To Current Mission Session";
+
+  const handleSwitchMissionPaneSession = async () => {
+    if (!missionId || !hasMissionSession || isSwitchingSession) {
+      return;
+    }
+
+    setIsSwitchingSession(true);
+    try {
+      const result = await switchMissionAgentPaneSession({
+        missionId,
+        agentId: "lunafreya",
+      });
+      toast.success(formatSwitchMissionAgentPaneSessionSuccessMessage(result));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to switch pane session");
+    } finally {
+      setIsSwitchingSession(false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex shrink-0 items-center gap-2 border-border/50 border-b pb-2">
@@ -309,36 +362,56 @@ export function LunafreyaStatusPanel({
         </span>
       </div>
 
-      <CharacterCard
-        agentId="lunafreya"
-        contextUsage={contextUsage}
-        detail="Model and facet changes apply on the next User turn."
-        imageSrc="/images/lunafreya.png"
-        isInParty
-        isSpeaking={isSpeaking}
-        metaAccessory={
-          <CompactModelVariantPicker
-            ariaLabel="Select model for lunafreya"
-            contentAlign="end"
-            contentSide="bottom"
-            emptyLabel="model"
-            modelItems={modelItems}
-            onSelect={(model) => setAgentModel("lunafreya", model)}
-            selectedModel={selectedModel}
-            showProviderName={false}
-            triggerClassName={cn(
-              "h-6 w-full rounded-md border border-border/40 bg-background/20 px-2 font-mono text-[9px] uppercase tracking-[0.18em]",
-              selectedModel
-                ? "text-primary/80 hover:text-primary"
-                : "text-muted-foreground/50 hover:text-muted-foreground"
-            )}
-            triggerIcon={<Cpu className="h-2.5 w-2.5 shrink-0" />}
-            variantsByModel={variantsByModel}
-          />
-        }
-        {...LUNAFREYA_CARD_COPY}
-        status={status}
-      />
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div>
+            <CharacterCard
+              agentId="lunafreya"
+              contextUsage={contextUsage}
+              detail="Model and facet changes apply on the next User turn."
+              imageSrc="/images/lunafreya.png"
+              isInParty
+              isSpeaking={isSpeaking}
+              metaAccessory={
+                <CompactModelVariantPicker
+                  ariaLabel="Select model for lunafreya"
+                  contentAlign="end"
+                  contentSide="bottom"
+                  emptyLabel="model"
+                  modelItems={modelItems}
+                  onSelect={(model) => setAgentModel("lunafreya", model)}
+                  selectedModel={selectedModel}
+                  showProviderName={false}
+                  triggerClassName={cn(
+                    "h-6 w-full rounded-md border border-border/40 bg-background/20 px-2 font-mono text-[9px] uppercase tracking-[0.18em]",
+                    selectedModel
+                      ? "text-primary/80 hover:text-primary"
+                      : "text-muted-foreground/50 hover:text-muted-foreground"
+                  )}
+                  triggerIcon={<Cpu className="h-2.5 w-2.5 shrink-0" />}
+                  variantsByModel={variantsByModel}
+                />
+              }
+              {...LUNAFREYA_CARD_COPY}
+              status={status}
+            />
+          </div>
+        </ContextMenuTrigger>
+
+        <ContextMenuContent>
+          <ContextMenuLabel>Agent Actions</ContextMenuLabel>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            aria-label="Switch Lunafreya pane to current mission session"
+            disabled={switchActionDisabled}
+            onSelect={() => {
+              void handleSwitchMissionPaneSession();
+            }}
+          >
+            {switchActionLabel}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
 
       <div className="space-y-3 rounded-xl border border-border/50 bg-card/40 p-3">
         <div className="space-y-1">
@@ -432,7 +505,8 @@ export function LunafreyaStatusPanel({
               <div className="space-y-1">
                 <p className="text-sm text-foreground/85">No skills selected.</p>
                 <p className="text-xs text-muted-foreground/75">
-                  Use the selector to browse the catalog and activate the skills Lunafreya should use on the next User turn.
+                  Use the selector to browse the catalog and activate the skills Lunafreya should
+                  use on the next User turn.
                 </p>
               </div>
             )}

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
@@ -338,7 +338,7 @@ export function LunafreyaStatusPanel({
   const switchActionLabel = !hasMissionSession
     ? "Mission Session Unavailable"
     : "Switch To Current Mission Session";
-  const continueActionDisabled = !missionId || !hasMissionSession || isSendingContinue;
+  const continueActionDisabled = !missionId || isSendingContinue;
 
   const handleSwitchMissionPaneSession = async () => {
     if (!missionId || !hasMissionSession || isSwitchingSession) {
@@ -360,7 +360,7 @@ export function LunafreyaStatusPanel({
   };
 
   const handleContinueMissionSession = async () => {
-    if (!missionId || !hasMissionSession || isSendingContinue) {
+    if (!missionId || isSendingContinue) {
       return;
     }
 

--- a/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/lunafreya-status-panel.tsx
@@ -399,7 +399,7 @@ export function LunafreyaStatusPanel({
         </ContextMenuTrigger>
 
         <ContextMenuContent>
-          <ContextMenuLabel>Agent Actions</ContextMenuLabel>
+          <ContextMenuLabel>{LUNAFREYA_CARD_COPY.name}</ContextMenuLabel>
           <ContextMenuSeparator />
           <ContextMenuItem
             aria-label="Switch Lunafreya pane to current mission session"

--- a/web/app/routes/_layout.noctis-team/components/message-detail-sheet.presence.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/message-detail-sheet.presence.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import MessageDetailSheet from "./message-detail-sheet";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+vi.hoisted(() => {
+  const maybeWindow = globalThis as typeof globalThis & {
+    window?: typeof globalThis & { __vite_plugin_react_preamble_installed__?: boolean };
+    __vite_plugin_react_preamble_installed__?: boolean;
+    $RefreshReg$?: (type: unknown, id: string) => void;
+    $RefreshSig$?: () => <T>(type: T) => T;
+  };
+
+  if (maybeWindow.window) {
+    maybeWindow.window.__vite_plugin_react_preamble_installed__ = true;
+  }
+  maybeWindow.__vite_plugin_react_preamble_installed__ = true;
+  maybeWindow.$RefreshReg$ = () => undefined;
+  maybeWindow.$RefreshSig$ = () => (type) => type;
+});
+
+vi.mock("@/components/chat/session-message-detail-sheet", () => ({
+  SessionMessageDetailSheet: ({ open }: { open: boolean }) => (
+    <div data-message-detail-sheet={open ? "open" : "closed"} />
+  ),
+}));
+
+describe("message-detail-sheet presence", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+
+    container.remove();
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = undefined;
+  });
+
+  it("stays mounted after closing once opened so the sheet can run its exit animation", async () => {
+    await act(async () => {
+      root?.render(
+        <MessageDetailSheet
+          content="Sliding detail."
+          onOpenChange={() => undefined}
+          open={true}
+          sender="noctis"
+        />,
+      );
+    });
+
+    expect(container.innerHTML).toContain('data-message-detail-sheet="open"');
+
+    await act(async () => {
+      root?.render(
+        <MessageDetailSheet
+          content="Sliding detail."
+          onOpenChange={() => undefined}
+          open={false}
+          sender="noctis"
+        />,
+      );
+    });
+
+    expect(container.innerHTML).toContain('data-message-detail-sheet="closed"');
+  });
+});

--- a/web/app/routes/_layout.noctis-team/components/message-detail-sheet.tsx
+++ b/web/app/routes/_layout.noctis-team/components/message-detail-sheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { SessionMessageDetailSheet } from "@/components/chat/session-message-detail-sheet";
 import { type WorkflowMessagePresentation } from "@/lib/chat-workflow-presentation";
 import { type SessionMessageDisplay } from "@/lib/session-message-presentation";
@@ -32,6 +33,18 @@ const MessageDetailSheet = ({
   messageDisplay,
   workflowPresentation,
 }: Props) => {
+  const [hasOpened, setHasOpened] = useState(open);
+
+  useEffect(() => {
+    if (open) {
+      setHasOpened(true);
+    }
+  }, [open]);
+
+  if (!open && !hasOpened) {
+    return null;
+  }
+
   return (
     <SessionMessageDetailSheet
       content={content}

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.test.tsx
@@ -52,6 +52,16 @@ vi.mock("@/components/ui/button", () => ({
   Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
 }));
 
+vi.mock("@/components/workspace-launch-actions", () => ({
+  WorkspaceLaunchActions: ({
+    path,
+    vscodePreference,
+  }: {
+    path: string;
+    vscodePreference: string;
+  }) => <div>{`workspace-launch-actions:${path}:${vscodePreference}`}</div>,
+}));
+
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children }: { children?: ReactNode; open?: boolean }) => <div>{children}</div>,
   DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -105,6 +115,8 @@ vi.mock("./chat-area", () => ({
     composerDraftKey,
     showExecutionProjectSelector,
     selectedExecutionProjectId,
+    executionProjectLaunchPath,
+    executionProjectVSCodePreference,
     selectedExecutionTargetMode,
     executionProjectHint,
     executionProjectOptions,
@@ -128,6 +140,8 @@ vi.mock("./chat-area", () => ({
     composerDraftKey?: string | null;
     showExecutionProjectSelector?: boolean;
     selectedExecutionProjectId?: string | null;
+    executionProjectLaunchPath?: string | null;
+    executionProjectVSCodePreference?: string | null;
     selectedExecutionTargetMode?: string | null;
     executionProjectHint?: string | null;
     executionProjectOptions?: Array<{ value: string; label: string }>;
@@ -180,6 +194,9 @@ vi.mock("./chat-area", () => ({
       ) : null}
       {showExecutionProjectSelector ? (
         <div>{`execution-selector:${selectedExecutionProjectId ?? "none"}`}</div>
+      ) : null}
+      {executionProjectLaunchPath ? (
+        <div>{`execution-launch:${executionProjectLaunchPath}:${executionProjectVSCodePreference ?? "auto"}`}</div>
       ) : null}
       {showExecutionProjectSelector ? (
         <div>{`execution-mode:${selectedExecutionTargetMode ?? "none"}`}</div>
@@ -320,12 +337,21 @@ describe("noctis-team-screen", () => {
 
     expect(markup).toContain("composer-draft-key:mission-surface:noctis_team:new");
     expect(markup).toContain("execution-selector:core-repo");
+    expect(markup).toContain("execution-launch:/repos/core:auto");
     expect(markup).toContain("execution-mode:execution_project");
     expect(markup).toContain("execution-options:Core Repo,Reference Docs");
     expect(markup).toContain("Context projects start empty for new missions.");
     expect(markup).toContain("context:None");
     expect(markup).toContain("context-action:Mission Context");
     expect(markup).not.toContain("Mission Setup");
+  });
+
+  it("renders execution project launch actions in the new-mission context dialog", () => {
+    const markup = renderToStaticMarkup(
+      <NoctisTeamScreen activeMissionId={null} initialMissionData={null} language="other" />,
+    );
+
+    expect(markup).toContain("workspace-launch-actions:/repos/core:auto");
   });
 
   it("passes temporary mission streaming content through to the chat area", () => {

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -28,10 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  type MissionResumePayload,
-  useAgentSession,
-} from "@/hooks/use-agent-session";
+import { type MissionResumePayload, useAgentSession } from "@/hooks/use-agent-session";
 import { useProjectRegistry } from "@/hooks/use-project-registry";
 import { useSessionStatusFeed } from "@/hooks/use-session-status-feed";
 import { useVSCodePreferences } from "@/hooks/use-vscode-preferences";
@@ -63,10 +60,7 @@ import { ChatArea } from "./chat-area";
 import { LunafreyaStatusPanel, type LunafreyaFacetOption } from "./lunafreya-status-panel";
 import { MissionHistoryItem } from "./mission-history-item";
 import { MissionActivityLog } from "./mission-activity-log";
-import {
-  getMissionOutputKey,
-  MissionOutputBrowser,
-} from "./mission-output-browser";
+import { getMissionOutputKey, MissionOutputBrowser } from "./mission-output-browser";
 import {
   buildMissionOutputDetailKey,
   buildMissionOutputDetailPath,
@@ -106,7 +100,7 @@ export function NoctisTeamScreen({
 }: NoctisTeamScreenProps) {
   const surface = getMissionSurface(
     requestedSurfaceId ??
-      (initialMissionData?.surfaceId === "lunafreya" ? "lunafreya" : "noctis_team"),
+      (initialMissionData?.surfaceId === "lunafreya" ? "lunafreya" : "noctis_team")
   );
   const isLunafreyaSurface = surface.id === "lunafreya";
   const missionRouteBase = surface.routeBase;
@@ -117,7 +111,7 @@ export function NoctisTeamScreen({
   const navigate = useNavigate();
   const params = useParams();
   const outputDetailMatch = useMatch(
-    `${missionRouteBase}/mission/:id/output/:step/:taskId/:filename`,
+    `${missionRouteBase}/mission/:id/output/:step/:taskId/:filename`
   );
   const routeMissionId = params.id ?? null;
   const routeOutputStep = outputDetailMatch?.params.step ?? null;
@@ -126,11 +120,11 @@ export function NoctisTeamScreen({
   const effectiveMissionId = activeMissionId ?? routeMissionId;
   const outputDetailActive = resolveMissionOutputDetailActive(
     {
-    step: routeOutputStep,
-    taskId: routeOutputTaskId,
-    filename: routeOutputFilename,
+      step: routeOutputStep,
+      taskId: routeOutputTaskId,
+      filename: routeOutputFilename,
     },
-    visualOutputDetailActive,
+    visualOutputDetailActive
   );
 
   useEffect(() => {
@@ -156,25 +150,28 @@ export function NoctisTeamScreen({
   const [isBulkMissionActionPending, setIsBulkMissionActionPending] = useState(false);
   const [isRenamingMission, setIsRenamingMission] = useState(false);
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>(
-    surface.supportsBanter ? "banter" : "activity",
+    surface.supportsBanter ? "banter" : "activity"
   );
   const [missionOutputs, setMissionOutputs] = useState<MissionOutputSummary[]>([]);
   const [isLoadingMissionOutputs, setIsLoadingMissionOutputs] = useState(false);
   const [missionOutputsError, setMissionOutputsError] = useState<string | null>(null);
-  const [missionDetail, setMissionDetail] = useState<MissionResumePayload | null>(initialMissionData ?? null);
+  const [missionDetail, setMissionDetail] = useState<MissionResumePayload | null>(
+    initialMissionData ?? null
+  );
   const [draftExecutionProjectId, setDraftExecutionProjectId] = useState<string | null>(
-    initialMissionData?.executionProjectId ?? null,
+    initialMissionData?.executionProjectId ?? null
   );
-  const [draftExecutionTargetMode, setDraftExecutionTargetMode] = useState<MissionExecutionTargetMode>(
-    initialMissionData
-      ? (normalizeMissionExecutionTargetMode(
-          initialMissionData.executionTargetMode ?? undefined,
-          initialMissionData.executionProjectId ?? undefined,
-        ) ?? "mission_workspace")
-      : DEFAULT_NEW_MISSION_EXECUTION_TARGET_MODE,
-  );
+  const [draftExecutionTargetMode, setDraftExecutionTargetMode] =
+    useState<MissionExecutionTargetMode>(
+      initialMissionData
+        ? (normalizeMissionExecutionTargetMode(
+            initialMissionData.executionTargetMode ?? undefined,
+            initialMissionData.executionProjectId ?? undefined
+          ) ?? "mission_workspace")
+        : DEFAULT_NEW_MISSION_EXECUTION_TARGET_MODE
+    );
   const [draftContextProjectIds, setDraftContextProjectIds] = useState<string[]>(
-    initialMissionData?.contextProjectIds ?? [],
+    initialMissionData?.contextProjectIds ?? []
   );
   const [hasLoadedDraftState, setHasLoadedDraftState] = useState(false);
   const [isContextDialogOpen, setIsContextDialogOpen] = useState(false);
@@ -182,28 +179,27 @@ export function NoctisTeamScreen({
   const [isSavingContext, setIsSavingContext] = useState(false);
   const [isDeletingWorkspace, setIsDeletingWorkspace] = useState(false);
   const [replayingTransportItemId, setReplayingTransportItemId] = useState<string | null>(null);
-  const [dismissedFailedDeliveryItemId, setDismissedFailedDeliveryItemId] = useState<string | null>(null);
+  const [dismissedFailedDeliveryItemId, setDismissedFailedDeliveryItemId] = useState<string | null>(
+    null
+  );
   const [lunafreyaJobOptions, setLunafreyaJobOptions] = useState<LunafreyaFacetOption[]>([]);
   const [lunafreyaSkillOptions, setLunafreyaSkillOptions] = useState<LunafreyaFacetOption[]>([]);
   const [selectedLunafreyaJobId, setSelectedLunafreyaJobId] = useState<string | null>(
-    initialMissionData?.lunafreyaFacetSelection?.selectedJobId ?? null,
+    initialMissionData?.lunafreyaFacetSelection?.selectedJobId ?? null
   );
   const [selectedLunafreyaSkillIds, setSelectedLunafreyaSkillIds] = useState<string[]>(
-    initialMissionData?.lunafreyaFacetSelection?.selectedSkillIds ?? [],
+    initialMissionData?.lunafreyaFacetSelection?.selectedSkillIds ?? []
   );
   const activeMissionIdRef = useRef<string | null>(effectiveMissionId);
   const previousMissionSummariesRef = useRef<MissionSummary[]>([]);
-  const {
-    data: projectRegistryData,
-    error: projectRegistryError,
-  } = useProjectRegistry();
+  const { data: projectRegistryData, error: projectRegistryError } = useProjectRegistry();
   const { vscodePreferences, updateVSCodePreference } = useVSCodePreferences();
   const availableProjects = projectRegistryData?.projects ?? [];
   const defaultExecutionProjectId = availableProjects[0]?.id ?? null;
   const effectiveExecutionTargetMode =
     normalizeMissionExecutionTargetMode(
       missionDetail?.executionTargetMode ?? undefined,
-      missionDetail?.executionProjectId ?? undefined,
+      missionDetail?.executionProjectId ?? undefined
     ) ?? draftExecutionTargetMode;
   const effectiveExecutionProjectId =
     missionDetail?.executionProjectId ??
@@ -225,9 +221,10 @@ export function NoctisTeamScreen({
     () =>
       effectiveContextProjectIds.map((projectId) => ({
         id: projectId,
-        label: availableProjects.find((project) => project.id === projectId)?.displayName ?? projectId,
+        label:
+          availableProjects.find((project) => project.id === projectId)?.displayName ?? projectId,
       })),
-    [availableProjects, effectiveContextProjectIds],
+    [availableProjects, effectiveContextProjectIds]
   );
   const {
     sessionId,
@@ -273,50 +270,73 @@ export function NoctisTeamScreen({
   const currentOperationStep =
     activeOperationState?.currentStep ?? initialMissionData?.operationState?.currentStep ?? null;
   const effectiveWorkflowProgress =
-    workflowProgress ?? missionDetail?.workflowProgress ?? initialMissionData?.workflowProgress ?? null;
-  const selectedExecutionProject = availableProjects.find(
-    (project) => project.id === effectiveExecutionProjectId,
-  ) ?? null;
+    workflowProgress ??
+    missionDetail?.workflowProgress ??
+    initialMissionData?.workflowProgress ??
+    null;
+  const selectedExecutionProject =
+    availableProjects.find((project) => project.id === effectiveExecutionProjectId) ?? null;
   const missionExecutionTargetMode = normalizeMissionExecutionTargetMode(
     missionDetail?.executionTargetMode ?? undefined,
-    missionDetail?.executionProjectId ?? undefined,
+    missionDetail?.executionProjectId ?? undefined
   );
   const isDirectExecutionMission = missionExecutionTargetMode === "execution_project";
   const workspaceLaunchPreferenceKey =
-    missionDetail?.executionProjectId ?? effectiveExecutionProjectId ?? missionDetail?.workspacePath ?? null;
+    missionDetail?.executionProjectId ??
+    effectiveExecutionProjectId ??
+    missionDetail?.workspacePath ??
+    null;
   const workspaceVSCodePreference = workspaceLaunchPreferenceKey
     ? (vscodePreferences[workspaceLaunchPreferenceKey] ?? "auto")
     : "auto";
-  const newMissionContextHint =
-    "Context projects start empty for new missions.";
-  const resumeBlockedCode = effectiveMissionId ? missionDetail?.resumeBlockedCode ?? null : null;
-  const resumeBlockedReason = effectiveMissionId ? missionDetail?.resumeBlockedReason ?? null : null;
-  const isLegacyMissionBlocked =
-    resumeBlockedCode === "missing_execution_project";
+  const newMissionContextHint = "Context projects start empty for new missions.";
+  const resumeBlockedCode = effectiveMissionId ? (missionDetail?.resumeBlockedCode ?? null) : null;
+  const resumeBlockedReason = effectiveMissionId
+    ? (missionDetail?.resumeBlockedReason ?? null)
+    : null;
+  const hasMissionSessionByAgent = useMemo<Partial<Record<string, boolean>>>(() => {
+    if (!effectiveMissionId || !missionDetail) {
+      return {};
+    }
+
+    const primarySessionId =
+      missionDetail.primarySessionId ??
+      missionDetail.sessions.primary ??
+      missionDetail.sessions.noctis;
+    const resolvedPrimaryAgentId = missionDetail.primaryAgentId ?? primaryAgentId;
+
+    return {
+      ...(resolvedPrimaryAgentId ? { [resolvedPrimaryAgentId]: Boolean(primarySessionId) } : {}),
+      ignis: Boolean(missionDetail.sessions.ignis),
+      gladiolus: Boolean(missionDetail.sessions.gladiolus),
+      prompto: Boolean(missionDetail.sessions.prompto),
+    };
+  }, [effectiveMissionId, missionDetail, primaryAgentId]);
+  const isLegacyMissionBlocked = resumeBlockedCode === "missing_execution_project";
   const isUnsupportedMission = resumeBlockedCode === "unsupported_mission_runtime";
   const executionProjectBranchName = selectedExecutionProject?.branchName ?? null;
-  const missionWorkingBranch =
-    effectiveMissionId
-      ? isDirectExecutionMission
-        ? executionProjectBranchName
-        : missionDetail?.branch ?? null
-      : null;
+  const missionWorkingBranch = effectiveMissionId
+    ? isDirectExecutionMission
+      ? executionProjectBranchName
+      : (missionDetail?.branch ?? null)
+    : null;
   const executionProjectHeadBranch =
     effectiveMissionId && !isDirectExecutionMission ? executionProjectBranchName : null;
-  const workspaceStatusLabel =
-    isDirectExecutionMission
-      ? "Registered project"
-      : missionDetail?.workspaceStatus === "ready"
-        ? "Ready"
-        : missionDetail?.workspaceStatus === "deleted"
-          ? "Deleted"
-          : missionDetail?.workspaceStatus === "missing"
-            ? "Missing"
-            : "Not provisioned";
+  const workspaceStatusLabel = isDirectExecutionMission
+    ? "Registered project"
+    : missionDetail?.workspaceStatus === "ready"
+      ? "Ready"
+      : missionDetail?.workspaceStatus === "deleted"
+        ? "Deleted"
+        : missionDetail?.workspaceStatus === "missing"
+          ? "Missing"
+          : "Not provisioned";
   const displayedWorkspacePath = isDirectExecutionMission
-    ? selectedExecutionProject?.path ?? null
-    : missionDetail?.workspacePath ?? null;
-  const missionActionLabel = isLegacyMissionBlocked ? "Assign Execution Project" : "Mission Details";
+    ? (selectedExecutionProject?.path ?? null)
+    : (missionDetail?.workspacePath ?? null);
+  const missionActionLabel = isLegacyMissionBlocked
+    ? "Assign Execution Project"
+    : "Mission Details";
   const missionStatusAlert = isLegacyMissionBlocked
     ? {
         toneClassName: "border-amber-500/30 bg-amber-500/10 text-amber-100",
@@ -332,19 +352,20 @@ export function NoctisTeamScreen({
             "Mission uses an unsupported runtime format and can no longer be resumed.",
           actionLabel: "Mission Details",
         }
-    : !isDirectExecutionMission && missionDetail?.workspaceStatus === "deleted"
-      ? {
-          toneClassName: "border-border/60 bg-card/40 text-muted-foreground",
-          message: "Workspace deleted. Resume will recreate a fresh workspace and sessions.",
-          actionLabel: "Mission Details",
-        }
-      : !isDirectExecutionMission && missionDetail?.workspaceStatus === "missing"
+      : !isDirectExecutionMission && missionDetail?.workspaceStatus === "deleted"
         ? {
             toneClassName: "border-border/60 bg-card/40 text-muted-foreground",
-            message: "Workspace missing. Resume will recreate it from the persisted mission branch.",
+            message: "Workspace deleted. Resume will recreate a fresh workspace and sessions.",
             actionLabel: "Mission Details",
           }
-        : null;
+        : !isDirectExecutionMission && missionDetail?.workspaceStatus === "missing"
+          ? {
+              toneClassName: "border-border/60 bg-card/40 text-muted-foreground",
+              message:
+                "Workspace missing. Resume will recreate it from the persisted mission branch.",
+              actionLabel: "Mission Details",
+            }
+          : null;
   const latestRetryableFailedDelivery = useMemo(() => {
     if (!effectiveMissionId) {
       return null;
@@ -358,11 +379,16 @@ export function NoctisTeamScreen({
             entry.status === "failed" &&
             entry.payload.agent === primaryAgentId &&
             !entry.replay?.supersededByItemId &&
-            entry.id !== dismissedFailedDeliveryItemId,
+            entry.id !== dismissedFailedDeliveryItemId
         )
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0] ?? null
     );
-  }, [dismissedFailedDeliveryItemId, effectiveMissionId, missionDetail?.primaryAgentOutbox, primaryAgentId]);
+  }, [
+    dismissedFailedDeliveryItemId,
+    effectiveMissionId,
+    missionDetail?.primaryAgentOutbox,
+    primaryAgentId,
+  ]);
   const isWorkspaceDeleteDisabled =
     isDirectExecutionMission ||
     !effectiveMissionId ||
@@ -427,8 +453,8 @@ export function NoctisTeamScreen({
       setDraftExecutionTargetMode(
         normalizeMissionExecutionTargetMode(
           missionDetail.executionTargetMode ?? undefined,
-          missionDetail.executionProjectId,
-        ) ?? "mission_workspace",
+          missionDetail.executionProjectId
+        ) ?? "mission_workspace"
       );
       return;
     }
@@ -564,7 +590,7 @@ export function NoctisTeamScreen({
           previousMissions: previousMissionSummariesRef.current,
           nextMissions,
           activeMissionId: activeMissionIdRef.current,
-        }),
+        })
       );
       previousMissionSummariesRef.current = nextMissions;
       setMissions(nextMissions);
@@ -594,7 +620,7 @@ export function NoctisTeamScreen({
     }
 
     setFreshMissionIds((currentFreshMissionIds) =>
-      currentFreshMissionIds.filter((missionId) => missionId !== effectiveMissionId),
+      currentFreshMissionIds.filter((missionId) => missionId !== effectiveMissionId)
     );
   }, [effectiveMissionId]);
 
@@ -657,11 +683,14 @@ export function NoctisTeamScreen({
   const selectedOutput = useMemo(
     () =>
       missionOutputs.find((output) => getMissionOutputKey(output) === selectedOutputKey) ?? null,
-    [missionOutputs, selectedOutputKey],
+    [missionOutputs, selectedOutputKey]
   );
 
   const visibleMissions = useMemo(
-    () => missions.filter((mission) => (missionView === "archived" ? mission.status === "archived" : mission.status !== "archived")),
+    () =>
+      missions.filter((mission) =>
+        missionView === "archived" ? mission.status === "archived" : mission.status !== "archived"
+      ),
     [missionView, missions]
   );
 
@@ -673,10 +702,18 @@ export function NoctisTeamScreen({
         }
 
         const isDisabled =
-          effectiveMissionId === mission.missionId && (isSessionActive || isStreaming || isLoadingHistory);
+          effectiveMissionId === mission.missionId &&
+          (isSessionActive || isStreaming || isLoadingHistory);
         return !isDisabled;
       }),
-    [effectiveMissionId, isLoadingHistory, isSessionActive, isStreaming, missionView, visibleMissions]
+    [
+      effectiveMissionId,
+      isLoadingHistory,
+      isSessionActive,
+      isStreaming,
+      missionView,
+      visibleMissions,
+    ]
   );
 
   const skippedVisibleMissionCount = visibleMissions.length - actionableVisibleMissions.length;
@@ -689,45 +726,50 @@ export function NoctisTeamScreen({
     setEditingMissionId(null);
   }, []);
 
-  const submitRenameMission = useCallback(async (missionId: string, nextTitle: string) => {
-    const title = nextTitle.trim();
-    if (!title) {
-      toast.error("Mission title cannot be empty");
-      return;
-    }
-
-    setIsRenamingMission(true);
-    try {
-      const response = await fetch(`${missionApiBase}/${missionId}/rename`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title }),
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to rename mission");
+  const submitRenameMission = useCallback(
+    async (missionId: string, nextTitle: string) => {
+      const title = nextTitle.trim();
+      if (!title) {
+        toast.error("Mission title cannot be empty");
+        return;
       }
 
-      const data = (await response.json()) as {
-        mission?: { title?: string; updatedAt?: string };
-      };
-      const updatedTitle = data.mission?.title ?? title;
-      const updatedAt = data.mission?.updatedAt ?? new Date().toISOString();
+      setIsRenamingMission(true);
+      try {
+        const response = await fetch(`${missionApiBase}/${missionId}/rename`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title }),
+        });
 
-      setMissions((current) =>
-        current.map((mission) =>
-          mission.missionId === missionId ? { ...mission, title: updatedTitle, updatedAt } : mission
-        )
-      );
-      setEditingMissionId(null);
-    } catch {
-      toast.error("Unable to rename mission", {
-        description: "Mission metadata could not be updated.",
-      });
-    } finally {
-      setIsRenamingMission(false);
-    }
-  }, [missionApiBase]);
+        if (!response.ok) {
+          throw new Error("Failed to rename mission");
+        }
+
+        const data = (await response.json()) as {
+          mission?: { title?: string; updatedAt?: string };
+        };
+        const updatedTitle = data.mission?.title ?? title;
+        const updatedAt = data.mission?.updatedAt ?? new Date().toISOString();
+
+        setMissions((current) =>
+          current.map((mission) =>
+            mission.missionId === missionId
+              ? { ...mission, title: updatedTitle, updatedAt }
+              : mission
+          )
+        );
+        setEditingMissionId(null);
+      } catch {
+        toast.error("Unable to rename mission", {
+          description: "Mission metadata could not be updated.",
+        });
+      } finally {
+        setIsRenamingMission(false);
+      }
+    },
+    [missionApiBase]
+  );
 
   const submitMissionArchive = useCallback(
     async (
@@ -775,7 +817,7 @@ export function NoctisTeamScreen({
             : {
                 active: currentCounts.active + 1,
                 archived: Math.max(0, currentCounts.archived - 1),
-              },
+              }
         );
         setEditingMissionId(null);
 
@@ -809,9 +851,12 @@ export function NoctisTeamScreen({
         return true;
       } catch {
         if (!options?.silent) {
-          toast.error(action === "archive" ? "Unable to archive mission" : "Unable to restore mission", {
-            description: "Mission metadata could not be updated.",
-          });
+          toast.error(
+            action === "archive" ? "Unable to archive mission" : "Unable to restore mission",
+            {
+              description: "Mission metadata could not be updated.",
+            }
+          );
         }
         return false;
       } finally {
@@ -821,13 +866,16 @@ export function NoctisTeamScreen({
     [effectiveMissionId, missionApiBase, missionRouteBase, navigate, surface.lastMissionStorageKey]
   );
 
-  const openBulkMissionDialog = useCallback((action: BulkMissionAction) => {
-    setBulkMissionDialog({
-      action,
-      count: actionableVisibleMissions.length,
-      skipped: skippedVisibleMissionCount,
-    });
-  }, [actionableVisibleMissions.length, skippedVisibleMissionCount]);
+  const openBulkMissionDialog = useCallback(
+    (action: BulkMissionAction) => {
+      setBulkMissionDialog({
+        action,
+        count: actionableVisibleMissions.length,
+        skipped: skippedVisibleMissionCount,
+      });
+    },
+    [actionableVisibleMissions.length, skippedVisibleMissionCount]
+  );
 
   const confirmBulkMissionAction = useCallback(async () => {
     if (!bulkMissionDialog) {
@@ -880,7 +928,9 @@ export function NoctisTeamScreen({
       .join(" ");
 
     toast.success(
-      bulkMissionDialog.action === "archive" ? "Visible missions archived" : "Visible missions restored",
+      bulkMissionDialog.action === "archive"
+        ? "Visible missions archived"
+        : "Visible missions restored",
       {
         description: details,
       }
@@ -903,7 +953,7 @@ export function NoctisTeamScreen({
       if (isUnsupportedMission) {
         toast.error(
           missionDetail?.resumeBlockedReason ??
-            "Mission uses an unsupported runtime format and can no longer be resumed.",
+            "Mission uses an unsupported runtime format and can no longer be resumed."
         );
         return;
       }
@@ -935,7 +985,7 @@ export function NoctisTeamScreen({
     setSelectedLunafreyaSkillIds((current) =>
       current.includes(skillId)
         ? current.filter((entry) => entry !== skillId)
-        : [...current, skillId],
+        : [...current, skillId]
     );
   }, []);
 
@@ -962,7 +1012,7 @@ export function NoctisTeamScreen({
     setDraftContextProjectIds((current) =>
       current.includes(projectId)
         ? current.filter((entry) => entry !== projectId)
-        : [...current, projectId],
+        : [...current, projectId]
     );
   }, []);
 
@@ -975,7 +1025,7 @@ export function NoctisTeamScreen({
 
     const normalizedContextProjectIds = normalizeContextProjectIds(
       executionProjectId,
-      draftContextProjectIds,
+      draftContextProjectIds
     );
 
     if (!effectiveMissionId) {
@@ -1006,7 +1056,7 @@ export function NoctisTeamScreen({
       setIsContextDialogOpen(false);
       await Promise.all([loadMissionDetail(), loadMissions()]);
       toast.success(
-        missionDetail?.executionProjectId ? "Mission context updated" : "Execution project assigned",
+        missionDetail?.executionProjectId ? "Mission context updated" : "Execution project assigned"
       );
     } catch (error) {
       toast.error("Unable to save mission context", {
@@ -1084,17 +1134,20 @@ export function NoctisTeamScreen({
         setReplayingTransportItemId(null);
       }
     },
-    [effectiveMissionId, loadMissionDetail, missionApiBase],
+    [effectiveMissionId, loadMissionDetail, missionApiBase]
   );
 
-  const handleSelectOutput = useCallback((output: MissionOutputSummary) => {
-    if (!effectiveMissionId) {
-      return;
-    }
+  const handleSelectOutput = useCallback(
+    (output: MissionOutputSummary) => {
+      if (!effectiveMissionId) {
+        return;
+      }
 
-    setInspectorTab("outputs");
-    navigate(buildMissionOutputDetailPath(effectiveMissionId, output, missionRouteBase));
-  }, [effectiveMissionId, missionRouteBase, navigate]);
+      setInspectorTab("outputs");
+      navigate(buildMissionOutputDetailPath(effectiveMissionId, output, missionRouteBase));
+    },
+    [effectiveMissionId, missionRouteBase, navigate]
+  );
 
   const handleInspectorTabChange = useCallback(
     (value: string) => {
@@ -1108,7 +1161,7 @@ export function NoctisTeamScreen({
         navigate(buildMissionPath(effectiveMissionId, missionRouteBase));
       }
     },
-    [effectiveMissionId, missionRouteBase, navigate, outputDetailActive],
+    [effectiveMissionId, missionRouteBase, navigate, outputDetailActive]
   );
 
   const activeInspectorTab = resolveMissionInspectorTab(inspectorTab, outputDetailActive);
@@ -1138,18 +1191,22 @@ export function NoctisTeamScreen({
                       size="icon"
                       variant="ghost"
                       className="h-7 w-7"
-                      disabled={isBulkMissionActionPending || actionableVisibleMissions.length === 0}
+                      disabled={
+                        isBulkMissionActionPending || actionableVisibleMissions.length === 0
+                      }
                       title={
-                        missionView === "archived"
-                          ? "More restore actions"
-                          : "More archive actions"
+                        missionView === "archived" ? "More restore actions" : "More archive actions"
                       }
                     >
                       <Ellipsis className="h-4 w-4" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-56">
-                    <DropdownMenuItem onSelect={() => openBulkMissionDialog(missionView === "archived" ? "restore" : "archive") }>
+                    <DropdownMenuItem
+                      onSelect={() =>
+                        openBulkMissionDialog(missionView === "archived" ? "restore" : "archive")
+                      }
+                    >
                       {missionView === "archived"
                         ? `Restore all visible (${actionableVisibleMissions.length})`
                         : `Archive all visible (${actionableVisibleMissions.length})`}
@@ -1201,7 +1258,9 @@ export function NoctisTeamScreen({
                   </div>
                 ) : visibleMissions.length === 0 ? (
                   <div className="rounded-lg border border-border/50 bg-card/40 p-3 font-mono text-[11px] text-muted-foreground/70">
-                    {missionView === "archived" ? "No archived missions." : "No saved missions yet."}
+                    {missionView === "archived"
+                      ? "No archived missions."
+                      : "No saved missions yet."}
                   </div>
                 ) : (
                   visibleMissions.map((mission) => (
@@ -1214,7 +1273,9 @@ export function NoctisTeamScreen({
                       isActive={effectiveMissionId === mission.missionId}
                       isArchivedView={missionView === "archived"}
                       isEditing={editingMissionId === mission.missionId}
-                      isArchivePending={archiveMissionId === mission.missionId || isBulkMissionActionPending}
+                      isArchivePending={
+                        archiveMissionId === mission.missionId || isBulkMissionActionPending
+                      }
                       isArchiveDisabled={
                         isBulkMissionActionPending ||
                         (missionView === "active" &&
@@ -1262,13 +1323,17 @@ export function NoctisTeamScreen({
               selectedExecutionTargetMode={effectiveExecutionTargetMode}
               executionProjectHint={newMissionContextHint}
               executionProjectError={projectRegistryError}
-              onSelectedExecutionProjectChange={(projectId) => setDraftExecutionProjectId(projectId)}
+              onSelectedExecutionProjectChange={(projectId) =>
+                setDraftExecutionProjectId(projectId)
+              }
               onSelectedExecutionTargetModeChange={
                 !effectiveMissionId ? setDraftExecutionTargetMode : undefined
               }
               missionExecutionLabel={
                 effectiveMissionId
-                  ? selectedExecutionProject?.displayName ?? missionDetail?.executionProjectId ?? "Not assigned"
+                  ? (selectedExecutionProject?.displayName ??
+                    missionDetail?.executionProjectId ??
+                    "Not assigned")
                   : null
               }
               contextProjects={contextProjects}
@@ -1288,9 +1353,7 @@ export function NoctisTeamScreen({
                 isSessionActive && !isAbortSettling && !isLoadingHistory && !isMissionStartPending
               }
               showWorkflowSelector={surface.supportsWorkflowSelector}
-              headerTitle={
-                isLunafreyaSurface ? "Oracle Mission Surface" : "Regalia Command Center"
-              }
+              headerTitle={isLunafreyaSurface ? "Oracle Mission Surface" : "Regalia Command Center"}
               headerSubtitle={
                 isLunafreyaSurface
                   ? "Lunafreya Nox Fleuret - Direct Line"
@@ -1304,7 +1367,8 @@ export function NoctisTeamScreen({
                   ? {
                       itemId: latestRetryableFailedDelivery.id,
                       failedAt:
-                        latestRetryableFailedDelivery.failure?.failedAt ?? latestRetryableFailedDelivery.updatedAt,
+                        latestRetryableFailedDelivery.failure?.failedAt ??
+                        latestRetryableFailedDelivery.updatedAt,
                       reason:
                         latestRetryableFailedDelivery.failure?.reason ??
                         "Unable to deliver the tmux request.",
@@ -1326,7 +1390,9 @@ export function NoctisTeamScreen({
           <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
             <div className="shrink-0 border-border/50 border-b p-3">
               {missionStatusAlert ? (
-                <div className={cn("mb-3 rounded-lg border p-2.5", missionStatusAlert.toneClassName)}>
+                <div
+                  className={cn("mb-3 rounded-lg border p-2.5", missionStatusAlert.toneClassName)}
+                >
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <p className="text-xs">{missionStatusAlert.message}</p>
                     <Button type="button" variant="outline" size="sm" onClick={openContextDialog}>
@@ -1341,13 +1407,16 @@ export function NoctisTeamScreen({
                   members={partyMembers}
                   missionId={effectiveMissionId}
                   activeOperationState={activeOperationState}
+                  hasMissionSessionByAgent={hasMissionSessionByAgent}
                   speakingAgentId={speakingAgentId}
                 />
               ) : (
                 <LunafreyaStatusPanel
                   contextUsage={primaryContextUsage}
+                  hasMissionSession={Boolean(hasMissionSessionByAgent.lunafreya)}
                   isSpeaking={isStreaming || speakingAgentId === primaryAgentId}
                   jobOptions={lunafreyaJobOptions}
+                  missionId={effectiveMissionId}
                   skillOptions={lunafreyaSkillOptions}
                   onClearSkillIds={clearLunafreyaSkillIds}
                   onSelectedJobIdChange={setSelectedLunafreyaJobId}
@@ -1411,7 +1480,10 @@ export function NoctisTeamScreen({
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
-      <Dialog open={bulkMissionDialog !== null} onOpenChange={(open) => (!open ? setBulkMissionDialog(null) : undefined)}>
+      <Dialog
+        open={bulkMissionDialog !== null}
+        onOpenChange={(open) => (!open ? setBulkMissionDialog(null) : undefined)}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
@@ -1520,13 +1592,16 @@ export function NoctisTeamScreen({
                 </p>
                 {isDirectExecutionMission ? (
                   <p className="text-xs text-muted-foreground/75">
-                    This mission is using the execution project directly without a dedicated workspace.
+                    This mission is using the execution project directly without a dedicated
+                    workspace.
                   </p>
                 ) : null}
                 {displayedWorkspacePath ? (
                   <WorkspaceLaunchActions
                     className="pt-1"
-                    disabled={!isDirectExecutionMission && missionDetail?.workspaceStatus !== "ready"}
+                    disabled={
+                      !isDirectExecutionMission && missionDetail?.workspaceStatus !== "ready"
+                    }
                     path={displayedWorkspacePath}
                     vscodePreference={workspaceVSCodePreference}
                     onVSCodePreferenceChange={(preference) => {
@@ -1545,7 +1620,10 @@ export function NoctisTeamScreen({
               <p className="font-medium text-sm">Context projects</p>
               <div className="flex flex-wrap gap-2.5">
                 {availableProjects
-                  .filter((project) => project.id !== (missionDetail?.executionProjectId ?? draftExecutionProjectId))
+                  .filter(
+                    (project) =>
+                      project.id !== (missionDetail?.executionProjectId ?? draftExecutionProjectId)
+                  )
                   .map((project) => {
                     const selected = draftContextProjectIds.includes(project.id);
                     return (
@@ -1557,7 +1635,7 @@ export function NoctisTeamScreen({
                           "rounded-full px-4",
                           selected
                             ? "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
-                            : "bg-background/70 text-muted-foreground hover:bg-accent/70 hover:text-foreground",
+                            : "bg-background/70 text-muted-foreground hover:bg-accent/70 hover:text-foreground"
                         )}
                         variant="outline"
                         size="sm"
@@ -1588,7 +1666,11 @@ export function NoctisTeamScreen({
             <Button type="button" variant="outline" onClick={() => setIsContextDialogOpen(false)}>
               Cancel
             </Button>
-            <Button type="button" onClick={() => void saveMissionContext()} disabled={isSavingContext}>
+            <Button
+              type="button"
+              onClick={() => void saveMissionContext()}
+              disabled={isSavingContext}
+            >
               Save
             </Button>
           </DialogFooter>

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -276,6 +276,12 @@ export function NoctisTeamScreen({
     null;
   const selectedExecutionProject =
     availableProjects.find((project) => project.id === effectiveExecutionProjectId) ?? null;
+  const newMissionExecutionProjectLaunchPreferenceKey = !effectiveMissionId
+    ? (selectedExecutionProject?.id ?? null)
+    : null;
+  const newMissionExecutionProjectVSCodePreference = newMissionExecutionProjectLaunchPreferenceKey
+    ? (vscodePreferences[newMissionExecutionProjectLaunchPreferenceKey] ?? "auto")
+    : "auto";
   const missionExecutionTargetMode = normalizeMissionExecutionTargetMode(
     missionDetail?.executionTargetMode ?? undefined,
     missionDetail?.executionProjectId ?? undefined
@@ -1320,12 +1326,21 @@ export function NoctisTeamScreen({
                 label: project.displayName,
               }))}
               selectedExecutionProjectId={effectiveExecutionProjectId}
+              executionProjectLaunchPath={!effectiveMissionId ? (selectedExecutionProject?.path ?? null) : null}
+              executionProjectVSCodePreference={newMissionExecutionProjectVSCodePreference}
               selectedExecutionTargetMode={effectiveExecutionTargetMode}
               executionProjectHint={newMissionContextHint}
               executionProjectError={projectRegistryError}
               onSelectedExecutionProjectChange={(projectId) =>
                 setDraftExecutionProjectId(projectId)
               }
+              onExecutionProjectVSCodePreferenceChange={(preference) => {
+                if (!newMissionExecutionProjectLaunchPreferenceKey) {
+                  return;
+                }
+
+                updateVSCodePreference(newMissionExecutionProjectLaunchPreferenceKey, preference);
+              }}
               onSelectedExecutionTargetModeChange={
                 !effectiveMissionId ? setDraftExecutionTargetMode : undefined
               }
@@ -1531,21 +1546,42 @@ export function NoctisTeamScreen({
             {!missionDetail?.executionProjectId ? (
               <div className="space-y-2">
                 <p className="font-medium text-sm">Execution project</p>
-                <Select
-                  value={draftExecutionProjectId ?? undefined}
-                  onValueChange={(value) => setDraftExecutionProjectId(value || null)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Choose a project" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableProjects.map((project) => (
-                      <SelectItem key={project.id} value={project.id}>
-                        {project.displayName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="min-w-0 flex-1">
+                    <Select
+                      value={draftExecutionProjectId ?? undefined}
+                      onValueChange={(value) => setDraftExecutionProjectId(value || null)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choose a project" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableProjects.map((project) => (
+                          <SelectItem key={project.id} value={project.id}>
+                            {project.displayName}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {!effectiveMissionId && selectedExecutionProject?.path ? (
+                    <WorkspaceLaunchActions
+                      path={selectedExecutionProject.path}
+                      vscodePreference={newMissionExecutionProjectVSCodePreference}
+                      onVSCodePreferenceChange={(preference) => {
+                        if (!newMissionExecutionProjectLaunchPreferenceKey) {
+                          return;
+                        }
+
+                        updateVSCodePreference(
+                          newMissionExecutionProjectLaunchPreferenceKey,
+                          preference,
+                        );
+                      }}
+                    />
+                  ) : null}
+                </div>
               </div>
             ) : (
               <div className="space-y-1">

--- a/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
+++ b/web/app/routes/_layout.noctis-team/components/noctis-team-screen.tsx
@@ -229,6 +229,7 @@ export function NoctisTeamScreen({
   const {
     sessionId,
     messages,
+    retainedHistory,
     liveDraft,
     streamingMessageId,
     streamingContent,
@@ -1320,6 +1321,7 @@ export function NoctisTeamScreen({
               isSessionActive={isSessionActive}
               isStreaming={isStreaming}
               messages={messages}
+              retainedHistory={retainedHistory}
               showExecutionProjectSelector={!effectiveMissionId}
               executionProjectOptions={availableProjects.map((project) => ({
                 value: project.id,

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -116,15 +116,17 @@ vi.mock("./continue-mission-session", () => ({
 
 vi.mock("./character-card", () => ({
   CharacterCard: ({
+    isStepOwner,
     name,
     statusAccessory,
     metaAccessory,
   }: {
+    isStepOwner?: boolean;
     name: string;
     statusAccessory?: ReactNode;
     metaAccessory?: ReactNode;
   }) => (
-    <section>
+    <section data-step-owner={isStepOwner ? "true" : undefined}>
       <h2>{name}</h2>
       {statusAccessory}
       {metaAccessory}
@@ -234,6 +236,22 @@ describe("PartyStatusPanel", () => {
     expect(markup).toMatch(
       /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/
     );
+  });
+
+  it("marks the primary agent card as the active step owner when Noctis owns the step", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+      />
+    );
+
+    expect(markup).toMatch(/<section data-step-owner="true"><h2>Noctis<\/h2>/);
+    expect(markup).not.toMatch(/<section data-step-owner="true"><h2>Ignis<\/h2>/);
+    expect(markup).not.toMatch(/<section data-step-owner="true"><h2>Gladiolus<\/h2>/);
+    expect(markup).not.toMatch(/<section data-step-owner="true"><h2>Prompto<\/h2>/);
   });
 
   it("shows current-mission pane session switching only when the agent card is switchable", () => {

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -252,6 +252,26 @@ describe("PartyStatusPanel", () => {
     expect(markup).toContain("Mission Session Unavailable");
   });
 
+  it("shows the member name as the context menu header instead of generic action group labels", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("gladiolus")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          ignis: true,
+        }}
+      />
+    );
+
+    expect(markup).toMatch(
+      /<div>Ignis<\/div><hr\/><button[^>]*aria-label="Switch Ignis pane to current mission session"[^>]*>Switch To Current Mission Session<\/button><hr\/><button[^>]*aria-label="Resume active worker step for Ignis"[^>]*>Resume Active Step<\/button>/
+    );
+    expect(markup).not.toContain("Agent Actions");
+    expect(markup).not.toContain("Worker Actions");
+  });
+
   it("keeps the current-mission switch action enabled for the runtime Gladio member id", () => {
     const markup = renderToStaticMarkup(
       <PartyStatusPanel

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -7,14 +7,18 @@ import type { PartyMember } from "@/lib/noctis-team-ui-types";
 
 const {
   chatStoreStateMock,
+  continueMissionAgentSessionMock,
   contextMenuItemPropsSpy,
+  formatContinueMissionAgentSessionSuccessMessageMock,
   formatSwitchMissionAgentPaneSessionSuccessMessageMock,
   switchMissionAgentPaneSessionMock,
   toastErrorMock,
   toastSuccessMock,
 } = vi.hoisted(() => ({
   chatStoreStateMock: vi.fn(),
+  continueMissionAgentSessionMock: vi.fn(),
   contextMenuItemPropsSpy: vi.fn(),
+  formatContinueMissionAgentSessionSuccessMessageMock: vi.fn(),
   formatSwitchMissionAgentPaneSessionSuccessMessageMock: vi.fn(),
   switchMissionAgentPaneSessionMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -104,6 +108,12 @@ vi.mock("./switch-pane-session", () => ({
   switchMissionAgentPaneSession: switchMissionAgentPaneSessionMock,
 }));
 
+vi.mock("./continue-mission-session", () => ({
+  continueMissionAgentSession: continueMissionAgentSessionMock,
+  formatContinueMissionAgentSessionSuccessMessage:
+    formatContinueMissionAgentSessionSuccessMessageMock,
+}));
+
 vi.mock("./character-card", () => ({
   CharacterCard: ({
     name,
@@ -159,7 +169,9 @@ function createActiveOperationState(agent: "noctis" | "ignis" | "gladiolus" | "p
 
 describe("PartyStatusPanel", () => {
   beforeEach(() => {
+    continueMissionAgentSessionMock.mockReset();
     contextMenuItemPropsSpy.mockReset();
+    formatContinueMissionAgentSessionSuccessMessageMock.mockReset();
     formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReset();
     chatStoreStateMock.mockReturnValue({
       agentModels: {
@@ -252,6 +264,25 @@ describe("PartyStatusPanel", () => {
     expect(markup).toContain("Mission Session Unavailable");
   });
 
+  it("shows a raw Continue action for party members with a managed mission session", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          ignis: true,
+        }}
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Send raw continue to Ignis mission session"/
+    );
+    expect(markup).toContain("Continue");
+  });
+
   it("shows the member name as the context menu header instead of generic action group labels", () => {
     const markup = renderToStaticMarkup(
       <PartyStatusPanel
@@ -266,7 +297,7 @@ describe("PartyStatusPanel", () => {
     );
 
     expect(markup).toMatch(
-      /<div>Ignis<\/div><hr\/><button[^>]*aria-label="Switch Ignis pane to current mission session"[^>]*>Switch To Current Mission Session<\/button><hr\/><button[^>]*aria-label="Resume active worker step for Ignis"[^>]*>Resume Active Step<\/button>/
+      /<div>Ignis<\/div><hr\/><button[^>]*aria-label="Switch Ignis pane to current mission session"[^>]*>Switch To Current Mission Session<\/button><hr\/><button[^>]*aria-label="Send raw continue to Ignis mission session"[^>]*>Continue<\/button><hr\/><button[^>]*aria-label="Resume active worker step for Ignis"[^>]*>Resume Active Step<\/button>/
     );
     expect(markup).not.toContain("Agent Actions");
     expect(markup).not.toContain("Worker Actions");
@@ -349,6 +380,55 @@ describe("PartyStatusPanel", () => {
       switchResult
     );
     expect(toastSuccessMock).toHaveBeenCalledWith("Switched Ignis to the current mission session.");
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes raw continue delivery for an enabled party member action", async () => {
+    formatContinueMissionAgentSessionSuccessMessageMock.mockReturnValue(
+      "Sent raw continue to Ignis."
+    );
+    continueMissionAgentSessionMock.mockResolvedValue({
+      agentId: "ignis",
+      missionId: "mission-123",
+      sessionId: "session-ignis",
+    });
+
+    renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          ignis: true,
+        }}
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Send raw continue to Ignis mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(continueMissionAgentSessionMock).toHaveBeenCalledWith({
+      agentId: "ignis",
+      missionId: "mission-123",
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Sent raw continue to Ignis.");
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -252,6 +252,32 @@ describe("PartyStatusPanel", () => {
     expect(markup).toContain("Mission Session Unavailable");
   });
 
+  it("keeps the current-mission switch action enabled for the runtime Gladio member id", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={[
+          {
+            id: "gladio",
+            name: "Gladio",
+            role: "Executor",
+            status: "idle",
+            imageSrc: "/gladiolus.png",
+          },
+        ]}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          gladiolus: true,
+        }}
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Switch Gladio pane to current mission session"/
+    );
+  });
+
   it("invokes pane session switching for an enabled party member action", async () => {
     const switchResult = {
       agentId: "ignis",

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -283,6 +283,22 @@ describe("PartyStatusPanel", () => {
     expect(markup).toContain("Continue");
   });
 
+  it("keeps raw Continue enabled even when the party member session is not yet known locally", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{}}
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Send raw continue to Ignis mission session"/
+    );
+  });
+
   it("shows the member name as the context menu header instead of generic action group labels", () => {
     const markup = renderToStaticMarkup(
       <PartyStatusPanel
@@ -430,5 +446,44 @@ describe("PartyStatusPanel", () => {
     });
     expect(toastSuccessMock).toHaveBeenCalledWith("Sent raw continue to Ignis.");
     expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the route error when raw continue is attempted before the party member session is known locally", async () => {
+    continueMissionAgentSessionMock.mockRejectedValue(new Error("Mission session not found"));
+
+    renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{}}
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Send raw continue to Ignis mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(continueMissionAgentSessionMock).toHaveBeenCalledWith({
+      agentId: "ignis",
+      missionId: "mission-123",
+    });
+    expect(toastErrorMock).toHaveBeenCalledWith("Mission session not found");
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.test.tsx
@@ -5,8 +5,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createOperationState } from "@/lib/operation-runtime/state";
 import type { PartyMember } from "@/lib/noctis-team-ui-types";
 
-const { chatStoreStateMock } = vi.hoisted(() => ({
+const {
+  chatStoreStateMock,
+  contextMenuItemPropsSpy,
+  formatSwitchMissionAgentPaneSessionSuccessMessageMock,
+  switchMissionAgentPaneSessionMock,
+  toastErrorMock,
+  toastSuccessMock,
+} = vi.hoisted(() => ({
   chatStoreStateMock: vi.fn(),
+  contextMenuItemPropsSpy: vi.fn(),
+  formatSwitchMissionAgentPaneSessionSuccessMessageMock: vi.fn(),
+  switchMissionAgentPaneSessionMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
 }));
 
 vi.mock("@/components/compact-model-variant-picker", () => ({
@@ -14,7 +33,9 @@ vi.mock("@/components/compact-model-variant-picker", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: { children?: ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/command", () => ({
@@ -22,7 +43,9 @@ vi.mock("@/components/ui/command", () => ({
   CommandEmpty: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   CommandGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   CommandInput: (props: Record<string, unknown>) => <input {...props} />,
-  CommandItem: ({ children, ...props }: { children?: ReactNode }) => <div {...props}>{children}</div>,
+  CommandItem: ({ children, ...props }: { children?: ReactNode }) => (
+    <div {...props}>{children}</div>
+  ),
   CommandList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 
@@ -45,16 +68,20 @@ vi.mock("@/components/ui/context-menu", () => ({
     children?: ReactNode;
     disabled?: boolean;
     onSelect?: (event: { preventDefault: () => void }) => void;
-  }) => (
-    <button
-      data-disabled={disabled ? "true" : "false"}
-      disabled={disabled}
-      onClick={() => onSelect?.({ preventDefault: () => undefined })}
-      {...props}
-    >
-      {children}
-    </button>
-  ),
+  }) => {
+    contextMenuItemPropsSpy({ children, disabled, onSelect, ...props });
+
+    return (
+      <button
+        data-disabled={disabled ? "true" : "false"}
+        disabled={disabled}
+        onClick={() => onSelect?.({ preventDefault: () => undefined })}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
   ContextMenuLabel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   ContextMenuSeparator: () => <hr />,
 }));
@@ -67,8 +94,14 @@ vi.mock("@/stores/chat-store", () => ({
       setAgentModel: (agentId: string, model: unknown) => void;
       setAgentModels: (models: Record<string, unknown>) => void;
       setWorkingPartyMember: (agentId: string, included: boolean) => void;
-    }) => unknown,
+    }) => unknown
   ) => selector(chatStoreStateMock()),
+}));
+
+vi.mock("./switch-pane-session", () => ({
+  formatSwitchMissionAgentPaneSessionSuccessMessage:
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock,
+  switchMissionAgentPaneSession: switchMissionAgentPaneSessionMock,
 }));
 
 vi.mock("./character-card", () => ({
@@ -105,7 +138,11 @@ const partyMembers: PartyMember[] = [
 ];
 
 function createActiveOperationState(agent: "noctis" | "ignis" | "gladiolus" | "prompto") {
-  const state = createOperationState("review-cycle-test", "implement", "builtin:ja:review-cycle-test.yaml");
+  const state = createOperationState(
+    "review-cycle-test",
+    "implement",
+    "builtin:ja:review-cycle-test.yaml"
+  );
   state.currentStep = "implement";
   state.status = "waiting_for_report";
   state.stepHistory = [
@@ -122,6 +159,8 @@ function createActiveOperationState(agent: "noctis" | "ignis" | "gladiolus" | "p
 
 describe("PartyStatusPanel", () => {
   beforeEach(() => {
+    contextMenuItemPropsSpy.mockReset();
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReset();
     chatStoreStateMock.mockReturnValue({
       agentModels: {
         noctis: null,
@@ -138,6 +177,9 @@ describe("PartyStatusPanel", () => {
       setAgentModels: () => undefined,
       setWorkingPartyMember: () => undefined,
     });
+    switchMissionAgentPaneSessionMock.mockReset();
+    toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
   });
 
   it("enables resume only on the worker card that owns the active step", () => {
@@ -147,17 +189,17 @@ describe("PartyStatusPanel", () => {
         missionId="mission-123"
         activeOperationState={createActiveOperationState("gladiolus")}
         speakingAgentId={null}
-      />,
+      />
     );
 
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/,
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/
     );
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="false"[^>]*aria-label="Resume active worker step for Gladiolus"/,
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Resume active worker step for Gladiolus"/
     );
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/,
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/
     );
   });
 
@@ -168,17 +210,99 @@ describe("PartyStatusPanel", () => {
         missionId="mission-123"
         activeOperationState={createActiveOperationState("noctis")}
         speakingAgentId={null}
-      />,
+      />
     );
 
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/,
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Ignis"/
     );
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Gladiolus"/,
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Gladiolus"/
     );
     expect(markup).toMatch(
-      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/,
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Resume active worker step for Prompto"/
     );
+  });
+
+  it("shows current-mission pane session switching only when the agent card is switchable", () => {
+    const markup = renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          noctis: true,
+          ignis: true,
+          gladiolus: true,
+          prompto: false,
+        }}
+      />
+    );
+
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Switch Ignis pane to current mission session"/
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="false"[^>]*aria-label="Switch Gladiolus pane to current mission session"/
+    );
+    expect(markup).toMatch(
+      /<button[^>]*data-disabled="true"[^>]*aria-label="Switch Prompto pane to current mission session"/
+    );
+    expect(markup).toContain("Mission Session Unavailable");
+  });
+
+  it("invokes pane session switching for an enabled party member action", async () => {
+    const switchResult = {
+      agentId: "ignis",
+      missionId: "mission-123",
+      sessionId: "session-ignis",
+      sessionTitle: "mission:mission-123:ignis",
+    };
+    switchMissionAgentPaneSessionMock.mockResolvedValue(switchResult);
+    formatSwitchMissionAgentPaneSessionSuccessMessageMock.mockReturnValue(
+      "Switched Ignis to the current mission session."
+    );
+
+    renderToStaticMarkup(
+      <PartyStatusPanel
+        members={partyMembers}
+        missionId="mission-123"
+        activeOperationState={createActiveOperationState("noctis")}
+        speakingAgentId={null}
+        hasMissionSessionByAgent={{
+          ignis: true,
+        }}
+      />
+    );
+
+    const actionProps = contextMenuItemPropsSpy.mock.calls
+      .map(([props]) => props)
+      .find(
+        (props) =>
+          typeof props === "object" &&
+          props !== null &&
+          (props as { "aria-label"?: string })["aria-label"] ===
+            "Switch Ignis pane to current mission session"
+      ) as
+      | {
+          onSelect?: (event: { preventDefault: () => void }) => void;
+        }
+      | undefined;
+
+    expect(actionProps).toBeTruthy();
+    actionProps?.onSelect?.({ preventDefault: () => undefined });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(switchMissionAgentPaneSessionMock).toHaveBeenCalledWith({
+      agentId: "ignis",
+      missionId: "mission-123",
+    });
+    expect(formatSwitchMissionAgentPaneSessionSuccessMessageMock).toHaveBeenCalledWith(
+      switchResult
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith("Switched Ignis to the current mission session.");
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -41,6 +41,10 @@ import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chat-store";
 import { CharacterCard } from "./character-card";
 import {
+  continueMissionAgentSession,
+  formatContinueMissionAgentSessionSuccessMessage,
+} from "./continue-mission-session";
+import {
   formatResumeActiveWorkerStepSuccessMessage,
   resumeActiveWorkerStep,
 } from "./resume-active-worker-step";
@@ -208,6 +212,7 @@ export const PartyStatusPanel = ({
 }: PartyStatusPanelProps) => {
   const [providers, setProviders] = useState<OpencodeProvider[]>([]);
   const [presets, setPresets] = useState<ModelPreset[]>([]);
+  const [continuingAgentId, setContinuingAgentId] = useState<PresetAgentId | null>(null);
   const [resumingAgentId, setResumingAgentId] = useState<PresetAgentId | null>(null);
   const [switchingAgentId, setSwitchingAgentId] = useState<PresetAgentId | null>(null);
   const [variantsByModel, setVariantsByModel] = useState<Record<string, string[]>>({});
@@ -313,6 +318,25 @@ export const PartyStatusPanel = ({
     }
   };
 
+  const handleContinueMissionSession = async (agentId: PresetAgentId) => {
+    if (!missionId || !hasMissionSessionByAgent[agentId] || continuingAgentId !== null) {
+      return;
+    }
+
+    setContinuingAgentId(agentId);
+    try {
+      const result = await continueMissionAgentSession({
+        missionId,
+        agentId,
+      });
+      toast.success(formatContinueMissionAgentSessionSuccessMessage(result));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to send raw continue");
+    } finally {
+      setContinuingAgentId((current) => (current === agentId ? null : current));
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex shrink-0 items-center gap-2 border-border/50 border-b pb-2">
@@ -361,6 +385,8 @@ export const PartyStatusPanel = ({
           const switchActionLabel = !hasMissionSession
             ? "Mission Session Unavailable"
             : "Switch To Current Mission Session";
+          const continueActionDisabled =
+            !missionId || !normalizedAgentId || !hasMissionSession || continuingAgentId !== null;
 
           const segmentBaseClass =
             "h-6 rounded-full border px-0 font-mono text-[8px] font-semibold uppercase tracking-[0.16em] transition-all";
@@ -471,6 +497,20 @@ export const PartyStatusPanel = ({
                       }}
                     >
                       {switchActionLabel}
+                    </ContextMenuItem>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem
+                      aria-label={`Send raw continue to ${member.name} mission session`}
+                      disabled={continueActionDisabled}
+                      onSelect={() => {
+                        if (!normalizedAgentId) {
+                          return;
+                        }
+
+                        void handleContinueMissionSession(normalizedAgentId);
+                      }}
+                    >
+                      Continue
                     </ContextMenuItem>
                     {isWorker ? <ContextMenuSeparator /> : null}
                     <ContextMenuItem

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -461,7 +461,7 @@ export const PartyStatusPanel = ({
 
                 {normalizedAgentId ? (
                   <ContextMenuContent>
-                    <ContextMenuLabel>Agent Actions</ContextMenuLabel>
+                    <ContextMenuLabel>{member.name}</ContextMenuLabel>
                     <ContextMenuSeparator />
                     <ContextMenuItem
                       aria-label={`Switch ${member.name} pane to current mission session`}
@@ -472,8 +472,6 @@ export const PartyStatusPanel = ({
                     >
                       {switchActionLabel}
                     </ContextMenuItem>
-                    {isWorker ? <ContextMenuSeparator /> : null}
-                    {isWorker ? <ContextMenuLabel>Worker Actions</ContextMenuLabel> : null}
                     {isWorker ? <ContextMenuSeparator /> : null}
                     <ContextMenuItem
                       aria-label={`Resume active worker step for ${member.name}`}

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -44,6 +44,10 @@ import {
   formatResumeActiveWorkerStepSuccessMessage,
   resumeActiveWorkerStep,
 } from "./resume-active-worker-step";
+import {
+  formatSwitchMissionAgentPaneSessionSuccessMessage,
+  switchMissionAgentPaneSession,
+} from "./switch-pane-session";
 
 const PRESET_AGENT_IDS = ["noctis", "ignis", "gladiolus", "prompto"] as const;
 
@@ -192,6 +196,7 @@ interface PartyStatusPanelProps {
   missionId?: string | null;
   activeOperationState?: OperationState | null;
   speakingAgentId?: string | null;
+  hasMissionSessionByAgent?: Partial<Record<string, boolean>>;
 }
 
 export const PartyStatusPanel = ({
@@ -199,10 +204,12 @@ export const PartyStatusPanel = ({
   missionId = null,
   activeOperationState = null,
   speakingAgentId = null,
+  hasMissionSessionByAgent = {},
 }: PartyStatusPanelProps) => {
   const [providers, setProviders] = useState<OpencodeProvider[]>([]);
   const [presets, setPresets] = useState<ModelPreset[]>([]);
   const [resumingAgentId, setResumingAgentId] = useState<PresetAgentId | null>(null);
+  const [switchingAgentId, setSwitchingAgentId] = useState<PresetAgentId | null>(null);
   const [variantsByModel, setVariantsByModel] = useState<Record<string, string[]>>({});
   const agentModels = useChatStore((state) => state.agentModels);
   const workingParty = useChatStore((state) => state.workingParty);
@@ -257,7 +264,11 @@ export const PartyStatusPanel = ({
     }
 
     const activeStepRecord = getActiveStepRecord(activeOperationState);
-    if (!activeStepRecord || activeStepRecord.agent === "noctis" || activeStepRecord.agent === "lunafreya") {
+    if (
+      !activeStepRecord ||
+      activeStepRecord.agent === "noctis" ||
+      activeStepRecord.agent === "lunafreya"
+    ) {
       return null;
     }
 
@@ -280,6 +291,25 @@ export const PartyStatusPanel = ({
       toast.error(error instanceof Error ? error.message : "Unable to resume active worker step");
     } finally {
       setResumingAgentId((current) => (current === agentId ? null : current));
+    }
+  };
+
+  const handleSwitchMissionPaneSession = async (agentId: PresetAgentId) => {
+    if (!missionId || !hasMissionSessionByAgent[agentId] || switchingAgentId !== null) {
+      return;
+    }
+
+    setSwitchingAgentId(agentId);
+    try {
+      const result = await switchMissionAgentPaneSession({
+        missionId,
+        agentId,
+      });
+      toast.success(formatSwitchMissionAgentPaneSessionSuccessMessage(result));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to switch pane session");
+    } finally {
+      setSwitchingAgentId((current) => (current === agentId ? null : current));
     }
   };
 
@@ -318,11 +348,17 @@ export const PartyStatusPanel = ({
             ? isWorkingPartyMemberId(workingPartyAgentId)
             : false;
           const isNoctis = normalizedAgentId === "noctis";
+          const hasMissionSession = Boolean(hasMissionSessionByAgent[member.id]);
           const isInParty = isNoctis
             ? true
             : workingPartyAgentId
               ? workingParty[workingPartyAgentId]
               : false;
+          const switchActionDisabled =
+            !missionId || !normalizedAgentId || !hasMissionSession || switchingAgentId !== null;
+          const switchActionLabel = !hasMissionSession
+            ? "Mission Session Unavailable"
+            : "Switch To Current Mission Session";
 
           const segmentBaseClass =
             "h-6 rounded-full border px-0 font-mono text-[8px] font-semibold uppercase tracking-[0.16em] transition-all";
@@ -421,10 +457,22 @@ export const PartyStatusPanel = ({
                   </div>
                 </ContextMenuTrigger>
 
-                {isWorker ? (
+                {normalizedAgentId ? (
                   <ContextMenuContent>
-                    <ContextMenuLabel>Worker Actions</ContextMenuLabel>
+                    <ContextMenuLabel>Agent Actions</ContextMenuLabel>
                     <ContextMenuSeparator />
+                    <ContextMenuItem
+                      aria-label={`Switch ${member.name} pane to current mission session`}
+                      disabled={switchActionDisabled}
+                      onSelect={() => {
+                        void handleSwitchMissionPaneSession(normalizedAgentId);
+                      }}
+                    >
+                      {switchActionLabel}
+                    </ContextMenuItem>
+                    {isWorker ? <ContextMenuSeparator /> : null}
+                    {isWorker ? <ContextMenuLabel>Worker Actions</ContextMenuLabel> : null}
+                    {isWorker ? <ContextMenuSeparator /> : null}
                     <ContextMenuItem
                       aria-label={`Resume active worker step for ${member.name}`}
                       disabled={

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -319,7 +319,7 @@ export const PartyStatusPanel = ({
   };
 
   const handleContinueMissionSession = async (agentId: PresetAgentId) => {
-    if (!missionId || !hasMissionSessionByAgent[agentId] || continuingAgentId !== null) {
+    if (!missionId || continuingAgentId !== null) {
       return;
     }
 
@@ -386,7 +386,7 @@ export const PartyStatusPanel = ({
             ? "Mission Session Unavailable"
             : "Switch To Current Mission Session";
           const continueActionDisabled =
-            !missionId || !normalizedAgentId || !hasMissionSession || continuingAgentId !== null;
+            !missionId || !normalizedAgentId || continuingAgentId !== null;
 
           const segmentBaseClass =
             "h-6 rounded-full border px-0 font-mono text-[8px] font-semibold uppercase tracking-[0.16em] transition-all";

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -263,22 +263,26 @@ export const PartyStatusPanel = ({
     () => getCompactWorkingPartySummary(allowedWorkers),
     [allowedWorkers]
   );
-  const activeWorkerStepAgentId = useMemo(() => {
+  const activeStepOwnerAgentId = useMemo(() => {
     if (!missionId || !activeOperationState) {
       return null;
     }
 
     const activeStepRecord = getActiveStepRecord(activeOperationState);
-    if (
-      !activeStepRecord ||
-      activeStepRecord.agent === "noctis" ||
-      activeStepRecord.agent === "lunafreya"
-    ) {
+    if (!activeStepRecord) {
       return null;
     }
 
     return normalizePartyAgentId(activeStepRecord.agent);
   }, [activeOperationState, missionId]);
+
+  const activeWorkerStepAgentId = useMemo(() => {
+    if (!activeStepOwnerAgentId || activeStepOwnerAgentId === "noctis") {
+      return null;
+    }
+
+    return activeStepOwnerAgentId;
+  }, [activeStepOwnerAgentId]);
 
   const handleResumeActiveWorkerStep = async (agentId: PresetAgentId) => {
     if (!missionId || !isWorkingPartyMemberId(agentId) || agentId !== activeWorkerStepAgentId) {
@@ -463,6 +467,7 @@ export const PartyStatusPanel = ({
                       agentId={normalizedAgentId ?? member.id}
                       isInParty={isWorker ? isInParty : true}
                       isSpeaking={normalizedAgentId === speakingAgentId}
+                      isStepOwner={normalizedAgentId === activeStepOwnerAgentId}
                       statusAccessory={partyControl}
                       metaAccessory={
                         <AgentModelPicker

--- a/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
+++ b/web/app/routes/_layout.noctis-team/components/party-status-panel.tsx
@@ -348,7 +348,9 @@ export const PartyStatusPanel = ({
             ? isWorkingPartyMemberId(workingPartyAgentId)
             : false;
           const isNoctis = normalizedAgentId === "noctis";
-          const hasMissionSession = Boolean(hasMissionSessionByAgent[member.id]);
+          const hasMissionSession = normalizedAgentId
+            ? Boolean(hasMissionSessionByAgent[normalizedAgentId])
+            : false;
           const isInParty = isNoctis
             ? true
             : workingPartyAgentId

--- a/web/app/routes/_layout.noctis-team/components/switch-pane-session.ts
+++ b/web/app/routes/_layout.noctis-team/components/switch-pane-session.ts
@@ -1,0 +1,70 @@
+import type { AgentId } from "@/lib/types/mission";
+
+export interface SwitchMissionAgentPaneSessionResult {
+  agentId: AgentId;
+  missionId: string;
+  sessionId: string;
+  sessionTitle: string;
+}
+
+type SwitchMissionAgentPaneSessionPayload = Partial<SwitchMissionAgentPaneSessionResult> & {
+  error?: unknown;
+  ok?: unknown;
+};
+
+const AGENT_LABELS: Record<AgentId, string> = {
+  noctis: "Noctis",
+  lunafreya: "Lunafreya",
+  ignis: "Ignis",
+  gladiolus: "Gladiolus",
+  prompto: "Prompto",
+};
+
+export async function switchMissionAgentPaneSession(input: {
+  missionId: string;
+  agentId: AgentId;
+  fetchImpl?: typeof fetch;
+}): Promise<SwitchMissionAgentPaneSessionResult> {
+  const response = await (input.fetchImpl ?? fetch)(
+    `/api/missions/${input.missionId}/agents/${input.agentId}/switch-pane-session`,
+    {
+      method: "POST",
+    }
+  );
+
+  const payload = (await response
+    .json()
+    .catch(() => null)) as SwitchMissionAgentPaneSessionPayload | null;
+
+  if (!response.ok) {
+    const errorMessage =
+      payload && typeof payload.error === "string"
+        ? payload.error
+        : "Unable to switch pane session";
+    throw new Error(errorMessage);
+  }
+
+  if (
+    !payload ||
+    payload.ok !== true ||
+    payload.agentId !== input.agentId ||
+    payload.missionId !== input.missionId ||
+    typeof payload.sessionId !== "string" ||
+    typeof payload.sessionTitle !== "string"
+  ) {
+    throw new Error("Switch pane session route returned an invalid payload");
+  }
+
+  return {
+    agentId: payload.agentId,
+    missionId: payload.missionId,
+    sessionId: payload.sessionId,
+    sessionTitle: payload.sessionTitle,
+  };
+}
+
+export function formatSwitchMissionAgentPaneSessionSuccessMessage(
+  result: SwitchMissionAgentPaneSessionResult
+): string {
+  return `Switched ${AGENT_LABELS[result.agentId]} to the current mission session.`;
+}

--- a/web/app/routes/api.missions.$missionId.agents.$agentId.continue/route.test.ts
+++ b/web/app/routes/api.missions.$missionId.agents.$agentId.continue/route.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMission, deleteMission, setWorkerSession } from "@/lib/mission-store";
+
+const {
+  promptAsyncMock,
+  queueTmuxAgentDispatchMock,
+  resolveManagedSessionActivationTitleMock,
+  resolveOwnerEndpointTargetMock,
+} = vi.hoisted(() => ({
+  promptAsyncMock: vi.fn(),
+  queueTmuxAgentDispatchMock: vi.fn(),
+  resolveManagedSessionActivationTitleMock: vi.fn(),
+  resolveOwnerEndpointTargetMock: vi.fn(),
+}));
+
+vi.mock("@/lib/opencode-client", () => ({
+  getOpencodeClient: () => ({
+    session: {
+      promptAsync: promptAsyncMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/session-owner-routing.server", () => ({
+  resolveOwnerEndpointTarget: resolveOwnerEndpointTargetMock,
+}));
+
+vi.mock("@/lib/managed-session-activation.server", () => ({
+  resolveManagedSessionActivationTitle: resolveManagedSessionActivationTitleMock,
+}));
+
+vi.mock("@/lib/primary-agent-outbox-dispatch.server", () => ({
+  queueTmuxAgentDispatch: queueTmuxAgentDispatchMock,
+}));
+
+import { action } from "./route";
+
+const missionIds: string[] = [];
+
+afterEach(() => {
+  while (missionIds.length > 0) {
+    const missionId = missionIds.pop();
+    if (missionId) {
+      deleteMission(missionId);
+    }
+  }
+});
+
+describe("api.missions.$missionId.agents.$agentId.continue", () => {
+  beforeEach(() => {
+    promptAsyncMock.mockReset();
+    queueTmuxAgentDispatchMock.mockReset();
+    resolveManagedSessionActivationTitleMock.mockReset();
+    resolveOwnerEndpointTargetMock.mockReset();
+  });
+
+  it("sends a raw continue prompt to an existing direct worker mission session", async () => {
+    const missionId = `mission-continue-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    const mission = createMission(missionId, `session-${missionId}`, {
+      title: "Continue Worker Session",
+      objective: "Nudge a stopped worker session",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+    mission.transportMode = "app-owned";
+    setWorkerSession(missionId, "ignis", "session-ignis");
+    promptAsyncMock.mockResolvedValue({ data: { id: "prompt-continue" } });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/continue`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      missionId,
+      agentId: "ignis",
+      sessionId: "session-ignis",
+    });
+    expect(promptAsyncMock).toHaveBeenCalledWith({
+      sessionID: "session-ignis",
+      parts: [{ type: "text", text: "continue" }],
+      agent: "ignis",
+    });
+    expect(resolveOwnerEndpointTargetMock).not.toHaveBeenCalled();
+  });
+
+  it("queues a raw continue prompt for an existing tmux-resident worker mission session", async () => {
+    const missionId = `mission-continue-tmux-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    const mission = createMission(missionId, `session-${missionId}`, {
+      title: "Continue Worker Session In Tmux",
+      objective: "Queue a stopped worker session nudge",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+    mission.transportMode = "tmux-resident";
+    setWorkerSession(missionId, "ignis", "session-ignis-tmux");
+    resolveManagedSessionActivationTitleMock.mockResolvedValue(`mission:${missionId}:ignis`);
+    resolveOwnerEndpointTargetMock.mockReturnValue({
+      client: {
+        session: {
+          list: vi.fn(),
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4401",
+      managedSession: null,
+      mode: "managed",
+      ownedSession: null,
+      ownerAgent: "ignis",
+    });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/continue`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      missionId,
+      agentId: "ignis",
+      sessionId: "session-ignis-tmux",
+    });
+    expect(queueTmuxAgentDispatchMock).toHaveBeenCalledWith({
+      activityBody: "Queued raw continue delivery.",
+      agent: "ignis",
+      missionId,
+      parts: [{ type: "text", text: "continue" }],
+      sessionId: "session-ignis-tmux",
+      sessionTitle: `mission:${missionId}:ignis`,
+    });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects raw continue when the mission has no session for the requested agent", async () => {
+    const missionId = `mission-continue-missing-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    const mission = createMission(missionId, `session-${missionId}`, {
+      title: "Missing Continue Session",
+      objective: "Reject a missing session continue request",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+    mission.transportMode = "app-owned";
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/continue`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Mission session not found" });
+    expect(promptAsyncMock).not.toHaveBeenCalled();
+    expect(queueTmuxAgentDispatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/routes/api.missions.$missionId.agents.$agentId.continue/route.ts
+++ b/web/app/routes/api.missions.$missionId.agents.$agentId.continue/route.ts
@@ -1,0 +1,109 @@
+import {
+  getMission,
+  getMissionPrimaryAgentId,
+  getMissionPrimarySessionId,
+} from "@/lib/mission-store";
+import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
+import { splitModelSelection } from "@/lib/model-variant-selection";
+import { getOpencodeClient } from "@/lib/opencode-client";
+import { queueTmuxAgentDispatch } from "@/lib/primary-agent-outbox-dispatch.server";
+import { resolveOwnerEndpointTarget } from "@/lib/session-owner-routing.server";
+import type { AgentId, Mission } from "@/lib/types/mission";
+import type { Route } from "./+types/route";
+
+const MISSION_AGENT_IDS: ReadonlySet<string> = new Set<AgentId>([
+  "noctis",
+  "lunafreya",
+  "ignis",
+  "gladiolus",
+  "prompto",
+]);
+
+function isMissionAgentId(value: unknown): value is AgentId {
+  return typeof value === "string" && MISSION_AGENT_IDS.has(value);
+}
+
+function resolveMissionAgentSessionId(mission: Mission, agentId: AgentId): string | null {
+  if (agentId === "ignis" || agentId === "gladiolus" || agentId === "prompto") {
+    return mission.workerSessions[agentId] ?? null;
+  }
+
+  return getMissionPrimaryAgentId(mission) === agentId ? getMissionPrimarySessionId(mission) : null;
+}
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const missionId = params.missionId;
+  const agentId = params.agentId;
+
+  if (!missionId) {
+    return Response.json({ error: "Missing missionId" }, { status: 400 });
+  }
+
+  if (!isMissionAgentId(agentId)) {
+    return Response.json({ error: "Invalid agentId" }, { status: 400 });
+  }
+
+  const mission = getMission(missionId);
+  if (!mission) {
+    return Response.json({ error: "Mission not found" }, { status: 404 });
+  }
+
+  const sessionId = resolveMissionAgentSessionId(mission, agentId);
+  if (!sessionId) {
+    return Response.json({ error: "Mission session not found" }, { status: 409 });
+  }
+
+  const promptParts = [{ type: "text" as const, text: "continue" }];
+  const { model, variant } = splitModelSelection(mission.agentModels[agentId]);
+
+  if (mission.transportMode === "tmux-resident") {
+    const ownerTarget = resolveOwnerEndpointTarget(agentId, `raw continue ${missionId}`);
+    const sessionTitle = await resolveManagedSessionActivationTitle({
+      client: ownerTarget.client,
+      missionId,
+      agentId,
+      sessionId,
+    });
+
+    queueTmuxAgentDispatch({
+      activityBody: "Queued raw continue delivery.",
+      agent: agentId,
+      missionId,
+      ...(model ? { model } : {}),
+      parts: promptParts,
+      sessionId,
+      sessionTitle,
+      ...(variant ? { variant } : {}),
+    });
+
+    return Response.json({
+      ok: true,
+      missionId,
+      agentId,
+      sessionId,
+    });
+  }
+
+  const result = await getOpencodeClient().session.promptAsync({
+    sessionID: sessionId,
+    parts: promptParts,
+    agent: agentId,
+    ...(model ? { model } : {}),
+    ...(variant ? { variant } : {}),
+  });
+
+  if (result.error) {
+    return Response.json({ error: result.error }, { status: 502 });
+  }
+
+  return Response.json({
+    ok: true,
+    missionId,
+    agentId,
+    sessionId,
+  });
+};

--- a/web/app/routes/api.missions.$missionId.agents.$agentId.switch-pane-session/route.test.ts
+++ b/web/app/routes/api.missions.$missionId.agents.$agentId.switch-pane-session/route.test.ts
@@ -1,0 +1,304 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMission, deleteMission, setWorkerSession } from "@/lib/mission-store";
+import { readTmuxActiveMission, writeTmuxActiveMission } from "@/lib/tmux-active-mission.server";
+
+const { resolveOwnerEndpointTargetMock, sessionListMock, sessionStatusMock } = vi.hoisted(() => ({
+  resolveOwnerEndpointTargetMock: vi.fn(),
+  sessionListMock: vi.fn(),
+  sessionStatusMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session-owner-routing.server", () => ({
+  resolveOwnerEndpointTarget: resolveOwnerEndpointTargetMock,
+}));
+
+import { action } from "./route";
+
+const originalRootEnv = process.env.MULTI_AGENT_FF15_ROOT;
+const originalPath = process.env.PATH ?? "";
+const tempRoots: string[] = [];
+const missionIds: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "multi-agent-ff15-switch-pane-session-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "runtime"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  mkdirSync(join(root, "bin"), { recursive: true });
+  writeFileSync(join(root, "opencode.json"), "{}\n", "utf-8");
+  return root;
+}
+
+function installFakeTmux(root: string): string {
+  const logPath = join(root, "tmux.log");
+  writeFileSync(
+    join(root, "bin", "tmux"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${logPath}"
+`,
+    { encoding: "utf-8", mode: 0o755 }
+  );
+  writeFileSync(
+    join(root, "bin", "sleep"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+`,
+    { encoding: "utf-8", mode: 0o755 },
+  );
+  process.env.PATH = `${join(root, "bin")}:${originalPath}`;
+  return logPath;
+}
+
+afterEach(() => {
+  sessionListMock.mockReset();
+  sessionStatusMock.mockReset();
+  resolveOwnerEndpointTargetMock.mockReset();
+
+  for (const missionId of missionIds.splice(0)) {
+    deleteMission(missionId);
+  }
+
+  if (originalRootEnv === undefined) {
+    delete process.env.MULTI_AGENT_FF15_ROOT;
+  } else {
+    process.env.MULTI_AGENT_FF15_ROOT = originalRootEnv;
+  }
+  process.env.PATH = originalPath;
+
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("api.missions.$missionId.agents.$agentId.switch-pane-session", () => {
+  beforeEach(() => {
+    resolveOwnerEndpointTargetMock.mockReturnValue({
+      client: {
+        session: {
+          list: sessionListMock,
+          status: sessionStatusMock,
+        },
+      },
+      endpointUrl: "http://127.0.0.1:4401",
+      managedSession: null,
+      mode: "managed",
+      ownedSession: null,
+      ownerAgent: "ignis",
+    });
+  });
+
+  it("switches the worker pane to the current mission session without changing tmux write focus", async () => {
+    const root = createTempRoot();
+    const tmuxLog = installFakeTmux(root);
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-switch-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, `session-${missionId}`, {
+      title: "Switch Pane Session",
+      objective: "Inspect worker mission session",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+    setWorkerSession(missionId, "ignis", "session-ignis");
+
+    writeTmuxActiveMission(root, {
+      missionId: "other-mission",
+      updatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-ignis": "idle",
+      },
+    });
+    sessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-ignis",
+          title: `mission:${missionId}:ignis`,
+        },
+      ],
+    });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/switch-pane-session`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      missionId,
+      agentId: "ignis",
+      sessionId: "session-ignis",
+      sessionTitle: `mission:${missionId}:ignis`,
+    });
+
+    expect(readFileSync(tmuxLog, "utf-8").trim().split("\n")).toEqual([
+      "send-keys -t ff15:main.1 C-p",
+      "send-keys -t ff15:main.1 -l Switch session",
+      "send-keys -t ff15:main.1 Enter",
+      `send-keys -t ff15:main.1 -l mission:${missionId}:ignis`,
+      "send-keys -t ff15:main.1 Enter",
+    ]);
+    expect(readTmuxActiveMission(root)).toEqual({
+      missionId: "other-mission",
+      updatedAt: "2026-05-08T00:00:00.000Z",
+    });
+  });
+
+  it("switches the pane even when the target mission session is busy", async () => {
+    const root = createTempRoot();
+    const tmuxLog = installFakeTmux(root);
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-busy-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, `session-${missionId}`, {
+      title: "Busy Pane Session",
+      objective: "Protect active agent pane",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+    setWorkerSession(missionId, "ignis", "session-ignis-busy");
+
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-ignis-busy": "busy",
+      },
+    });
+    sessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-ignis-busy",
+          title: `mission:${missionId}:ignis`,
+        },
+      ],
+    });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/switch-pane-session`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      missionId,
+      agentId: "ignis",
+      sessionId: "session-ignis-busy",
+      sessionTitle: `mission:${missionId}:ignis`,
+    });
+    expect(readFileSync(tmuxLog, "utf-8").trim().split("\n")).toEqual([
+      "send-keys -t ff15:main.1 C-p",
+      "send-keys -t ff15:main.1 -l Switch session",
+      "send-keys -t ff15:main.1 Enter",
+      `send-keys -t ff15:main.1 -l mission:${missionId}:ignis`,
+      "send-keys -t ff15:main.1 Enter",
+    ]);
+  });
+
+  it("rejects the switch when the mission has no session for the requested agent", async () => {
+    const missionId = `mission-missing-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, `session-${missionId}`, {
+      title: "Missing Session",
+      objective: "Reject absent worker mission session",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/ignis/switch-pane-session`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "ignis",
+      },
+    } as never);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Mission session not found" });
+    expect(resolveOwnerEndpointTargetMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the stored legacy title when switching a primary-agent pane session", async () => {
+    const root = createTempRoot();
+    const tmuxLog = installFakeTmux(root);
+    process.env.MULTI_AGENT_FF15_ROOT = root;
+
+    const missionId = `mission-primary-${crypto.randomUUID()}`;
+    missionIds.push(missionId);
+    createMission(missionId, "session-noctis-legacy", {
+      title: "Primary Session Legacy",
+      objective: "Support legacy primary session titles",
+      allowedWorkers: ["ignis", "gladiolus", "prompto"],
+    });
+
+    sessionStatusMock.mockResolvedValue({
+      data: {
+        "session-noctis-legacy": "idle",
+      },
+    });
+    sessionListMock.mockResolvedValue({
+      data: [
+        {
+          id: "session-noctis-legacy",
+          title: `mission:${missionId}`,
+        },
+      ],
+    });
+
+    const response = await action({
+      request: new Request(
+        `http://localhost/api/missions/${missionId}/agents/noctis/switch-pane-session`,
+        {
+          method: "POST",
+        }
+      ),
+      params: {
+        missionId,
+        agentId: "noctis",
+      },
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      missionId,
+      agentId: "noctis",
+      sessionId: "session-noctis-legacy",
+      sessionTitle: `mission:${missionId}`,
+    });
+    expect(readFileSync(tmuxLog, "utf-8")).toContain(
+      `send-keys -t ff15:main.0 -l mission:${missionId}`
+    );
+  });
+});

--- a/web/app/routes/api.missions.$missionId.agents.$agentId.switch-pane-session/route.ts
+++ b/web/app/routes/api.missions.$missionId.agents.$agentId.switch-pane-session/route.ts
@@ -1,0 +1,88 @@
+import {
+  getMission,
+  getMissionPrimaryAgentId,
+  getMissionPrimarySessionId,
+} from "@/lib/mission-store";
+import { resolveManagedSessionActivationTitle } from "@/lib/managed-session-activation.server";
+import { resolveOwnerEndpointTarget } from "@/lib/session-owner-routing.server";
+import { switchTmuxPaneSession } from "@/lib/tmux-pane-session-switch.server";
+import type { AgentId, Mission } from "@/lib/types/mission";
+import type { Route } from "./+types/route";
+
+const MISSION_AGENT_IDS: ReadonlySet<string> = new Set<AgentId>([
+  "noctis",
+  "lunafreya",
+  "ignis",
+  "gladiolus",
+  "prompto",
+]);
+
+function isMissionAgentId(value: unknown): value is AgentId {
+  return typeof value === "string" && MISSION_AGENT_IDS.has(value);
+}
+
+function resolveMissionAgentSessionId(mission: Mission, agentId: AgentId): string | null {
+  if (agentId === "ignis" || agentId === "gladiolus" || agentId === "prompto") {
+    return mission.workerSessions[agentId] ?? null;
+  }
+
+  return getMissionPrimaryAgentId(mission) === agentId ? getMissionPrimarySessionId(mission) : null;
+}
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const missionId = params.missionId;
+  const agentId = params.agentId;
+
+  if (!missionId) {
+    return Response.json({ error: "Missing missionId" }, { status: 400 });
+  }
+
+  if (!isMissionAgentId(agentId)) {
+    return Response.json({ error: "Invalid agentId" }, { status: 400 });
+  }
+
+  const mission = getMission(missionId);
+  if (!mission) {
+    return Response.json({ error: "Mission not found" }, { status: 404 });
+  }
+
+  const sessionId = resolveMissionAgentSessionId(mission, agentId);
+  if (!sessionId) {
+    return Response.json({ error: "Mission session not found" }, { status: 409 });
+  }
+
+  const ownerTarget = resolveOwnerEndpointTarget(agentId, `switch pane session ${missionId}`);
+
+  try {
+    const sessionTitle = await resolveManagedSessionActivationTitle({
+      client: ownerTarget.client,
+      missionId,
+      agentId,
+      sessionId,
+    });
+
+    switchTmuxPaneSession({
+      agentId,
+      sessionTitle,
+    });
+
+    return Response.json({
+      ok: true,
+      missionId,
+      agentId,
+      sessionId,
+      sessionTitle,
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to switch pane session",
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/web/app/routes/api.noctis-team.model-presets.test.ts
+++ b/web/app/routes/api.noctis-team.model-presets.test.ts
@@ -56,11 +56,11 @@ describe("api.noctis-team.model-presets", () => {
   it("parses optional variant entries from config/models.yaml", async () => {
     process.env.MULTI_AGENT_FF15_ROOT = createTempRoot([
       "modes:",
-      "  balanced:",
-      '    _description: "Balanced"',
+      "  gpt5.4-medium:",
+      '    _description: "All agents use GPT-5.4 Medium"',
       "    noctis:",
       '      model: "github-copilot/gpt-5.4"',
-      '      variant: "high"',
+      '      variant: "medium"',
       "    ignis:",
       '      model: "github-copilot/gpt-5.4"',
       "    gladiolus:",
@@ -92,7 +92,7 @@ describe("api.noctis-team.model-presets", () => {
         opencodeVersion: "1.2.27",
         sourceCommand: "opencode models --verbose",
         variantsByModel: {
-          "github-copilot/gpt-5.4": ["high"],
+          "github-copilot/gpt-5.4": ["medium"],
         },
       },
       stale: false,
@@ -102,16 +102,74 @@ describe("api.noctis-team.model-presets", () => {
     const data = (await response.json()) as {
       presets: Array<{
         available: boolean;
+        label: string;
         agentModels: Record<string, { modelID: string; providerID: string; variant?: string }>;
       }>;
     };
 
     expect(data.presets[0]?.available).toBe(true);
+    expect(data.presets[0]?.label).toBe("GPT-5.4 Medium");
     expect(data.presets[0]?.agentModels.noctis).toEqual({
       providerID: "github-copilot",
       modelID: "gpt-5.4",
-      variant: "high",
+      variant: "medium",
     });
+  });
+
+  it("humanizes gpt5mini preset identifiers", async () => {
+    process.env.MULTI_AGENT_FF15_ROOT = createTempRoot([
+      "modes:",
+      "  gpt5mini-low:",
+      '    _description: "All agents use GPT-5 Mini Low"',
+      "    noctis:",
+      '      model: "github-copilot/gpt-5-mini"',
+      '      variant: "low"',
+      "    ignis:",
+      '      model: "github-copilot/gpt-5-mini"',
+      '      variant: "low"',
+      "    gladiolus:",
+      '      model: "github-copilot/gpt-5-mini"',
+      '      variant: "low"',
+      "    prompto:",
+      '      model: "github-copilot/gpt-5-mini"',
+      '      variant: "low"',
+      "",
+    ].join("\n"));
+
+    providersMock.mockResolvedValue({
+      data: {
+        default: {},
+        providers: [
+          {
+            id: "github-copilot",
+            models: {
+              "gpt-5-mini": { id: "gpt-5-mini" },
+            },
+          },
+        ],
+      },
+    });
+    readOpencodeModelCatalogMock.mockResolvedValue({
+      lastError: null,
+      refreshState: "ready",
+      snapshot: {
+        generatedAt: "2026-04-06T00:00:00.000Z",
+        models: ["github-copilot/gpt-5-mini"],
+        opencodeVersion: "1.2.27",
+        sourceCommand: "opencode models --verbose",
+        variantsByModel: {
+          "github-copilot/gpt-5-mini": ["low"],
+        },
+      },
+      stale: false,
+    });
+
+    const response = await loader();
+    const data = (await response.json()) as {
+      presets: Array<{ label: string }>;
+    };
+
+    expect(data.presets[0]?.label).toBe("GPT-5 Mini Low");
   });
 
   it("marks presets unavailable when the configured variant is stale", async () => {

--- a/web/app/routes/api.noctis-team.model-presets.ts
+++ b/web/app/routes/api.noctis-team.model-presets.ts
@@ -20,7 +20,32 @@ type ModeConfig = {
   _description?: string;
 } & Partial<Record<PresetAgentId, { model?: string; variant?: string }>>;
 
+function humanizeVariant(variant: string): string {
+  switch (variant) {
+    case "low":
+      return "Low";
+    case "medium":
+      return "Medium";
+    case "high":
+      return "High";
+    case "xhigh":
+      return "XHigh";
+    default:
+      return variant.charAt(0).toUpperCase() + variant.slice(1);
+  }
+}
+
 function humanizeModeName(modeId: string): string {
+  const gpt5MiniMatch = modeId.match(/^gpt5mini-(low|medium|high|xhigh)$/);
+  if (gpt5MiniMatch) {
+    return `GPT-5 Mini ${humanizeVariant(gpt5MiniMatch[1])}`;
+  }
+
+  const gpt54Match = modeId.match(/^gpt5\.4-(low|medium|high|xhigh)$/);
+  if (gpt54Match) {
+    return `GPT-5.4 ${humanizeVariant(gpt54Match[1])}`;
+  }
+
   if (modeId === "fullpower") {
     return "Full Power";
   }


### PR DESCRIPTION
## 📝 Summary

- Add session continuation and pane-switch controls for Noctis team missions
- Surface message detail sheets, transcript retention, launch actions, and step-owner state in the team UI
- Update model preset handling and supporting transport/config wiring for the new mission flows
- Expand hook, route, server, and component coverage for the new session and UI behaviors

## 🎯 Motivation

These changes make it easier to recover and control running missions from the dashboard, especially when a session needs to be continued or a pane session needs to be switched. They also expose more mission state in the UI so operators can inspect recent activity without leaving the Noctis team surface.

## 🔧 Changes Overview

- Add API routes and server helpers for continuing agent sessions and switching tmux pane sessions.
- Update the Noctis team screen, party and Lunafreya panels, chat area, character cards, and message detail sheet behavior to surface the new mission controls and state.
- Allow raw continue when a session is not known locally and simplify dispatch text construction around the new flows.
- Refresh model configuration data and tmux transport dispatcher wiring that support the new UI paths.
- Add and extend tests across hooks, routes, server helpers, and UI components for the affected behaviors.

## ✅ Testing

- Ran `.opencode/skills/pr-assistant/scripts/quality_checks.sh main`
- Quality checks passed: no uncommitted changes, no merge conflicts, branch ahead of `main`, no TODO/FIXME comments, no large files, tests updated with code changes, and no dependency changes.

## 📸 Screenshots

Not included in this PR draft.

## 🔗 Related Issues

None

## 📋 Checklist

- [x] Self-reviewed the diff and generated PR content
- [x] Automated tests added or updated as appropriate
- [x] Config and transport impact reviewed
- [ ] Manual browser verification completed
- [ ] Screenshots added for UI changes

## 📌 Notes

- Diff scope: 32 files changed, 3702 insertions, 429 deletions.
- Manual browser verification was not run as part of PR preparation.
